### PR TITLE
Replace x11vnc with tightvnc.

### DIFF
--- a/NodeChromeDebug/Dockerfile
+++ b/NodeChromeDebug/Dockerfile
@@ -8,10 +8,10 @@ USER root
 #=====
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-    x11vnc \
+    tightvncserver \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p ~/.vnc \
-  && x11vnc -storepasswd secret ~/.vnc/passwd
+  && echo secret | vncpasswd -f >~/.vnc/passwd
 
 #=================
 # Locale settings
@@ -43,7 +43,7 @@ RUN apt-get update -qqy \
 #=========
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-    fluxbox \
+    fluxbox xterm \
   && rm -rf /var/lib/apt/lists/*
 
 #==============================
@@ -51,5 +51,7 @@ RUN apt-get update -qqy \
 #==============================
 COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
+RUN chmod go-rwx /root/.vnc/passwd
+ENV DISPLAY :99
 
 EXPOSE 5900

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -11,8 +11,9 @@ if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
 fi
 
 function shutdown {
-  kill -s SIGTERM $NODE_PID
-  wait $NODE_PID
+  kill -s SIGTERM $JAVA_PID
+  wait $JAVA_PID
+  kill -s SIGTERM $VNC_PID
 }
 
 REMOTE_HOST_PARAM=""
@@ -25,21 +26,21 @@ fi
 
 # startup tightvnc server
 export FONTROOT=/usr/share/fonts/X11
-export USER=root
+export USER=seluser
 export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT"
 
 Xtightvnc $DISPLAY \
-    -desktop X \
-    -auth /root/.Xauthority \
-    -geometry $GEOMETRY \
-    -depth $SCREEN_DEPTH \
-    -rfbwait 120000 \
-    -rfbauth /root/.vnc/passwd \
-    -rfbport 5900 \
-    -fp $FONTROOT/misc/,$FONTROOT/Type1/,$FONTROOT/75dpi/,$FONTROOT/100dpi/ \
-    -co /etc/X11/rgb &
+  -desktop X \
+  -auth /root/.Xauthority \
+  -geometry $GEOMETRY \
+  -depth $SCREEN_DEPTH \
+  -rfbwait 120000 \
+  -rfbauth /root/.vnc/passwd \
+  -rfbport 5900 \
+  -fp $FONTROOT/misc/,$FONTROOT/Type1/,$FONTROOT/75dpi/,$FONTROOT/100dpi/ \
+  -co /etc/X11/rgb &
 
-NODE_PID=$!
+VNC_PID=$!
 
 sleep 1
 
@@ -49,9 +50,11 @@ java -jar /opt/selenium/selenium-server-standalone.jar \
     ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
 
+JAVA_PID=$!
+
 fluxbox -display $DISPLAY &
 
 trap shutdown SIGTERM SIGINT
-sleep 0.5
-wait $NODE_PID
+sleep 1
+wait $VNC_PID $JAVA_PID
 

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
 
 if [ ! -e /opt/selenium/config.json ]; then
   echo No Selenium Node configuration file, the node-base image is not intended to be run directly. 1>&2
@@ -24,29 +23,35 @@ fi
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
-sudo -E -i -u seluser \
-  DISPLAY=$DISPLAY \
-  xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar \
+# startup tightvnc server
+export FONTROOT=/usr/share/fonts/X11
+export USER=root
+export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT"
+
+Xtightvnc $DISPLAY \
+    -desktop X \
+    -auth /root/.Xauthority \
+    -geometry $GEOMETRY \
+    -depth $SCREEN_DEPTH \
+    -rfbwait 120000 \
+    -rfbauth /root/.vnc/passwd \
+    -rfbport 5900 \
+    -fp $FONTROOT/misc/,$FONTROOT/Type1/,$FONTROOT/75dpi/,$FONTROOT/100dpi/ \
+    -co /etc/X11/rgb &
+
+NODE_PID=$!
+
+sleep 1
+
+java -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
-NODE_PID=$!
-
-trap shutdown SIGTERM SIGINT
-for i in $(seq 1 10)
-do
-  xdpyinfo -display $DISPLAY >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    break
-  fi
-  echo Waiting xvfb...
-  sleep 0.5
-done
 
 fluxbox -display $DISPLAY &
 
-x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
-
+trap shutdown SIGTERM SIGINT
+sleep 0.5
 wait $NODE_PID
+

--- a/NodeFirefoxDebug/Dockerfile
+++ b/NodeFirefoxDebug/Dockerfile
@@ -8,10 +8,10 @@ USER root
 #=====
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-    x11vnc \
+    tightvncserver \
   && rm -rf /var/lib/apt/lists/* \
   && mkdir -p ~/.vnc \
-  && x11vnc -storepasswd secret ~/.vnc/passwd
+  && echo secret | vncpasswd -f >~/.vnc/passwd
 
 #=================
 # Locale settings
@@ -43,7 +43,7 @@ RUN apt-get update -qqy \
 #=========
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-    fluxbox \
+    fluxbox xterm \
   && rm -rf /var/lib/apt/lists/*
 
 #==============================
@@ -51,5 +51,7 @@ RUN apt-get update -qqy \
 #==============================
 COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
+RUN chmod go-rwx /root/.vnc/passwd
+ENV DISPLAY :99
 
 EXPOSE 5900

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -1,5 +1,4 @@
 #!/bin/bash
-export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
 
 if [ ! -e /opt/selenium/config.json ]; then
   echo No Selenium Node configuration file, the node-base image is not intended to be run directly. 1>&2
@@ -24,29 +23,35 @@ fi
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
-sudo -E -i -u seluser \
-  DISPLAY=$DISPLAY \
-  xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar \
+# startup tightvnc server
+export FONTROOT=/usr/share/fonts/X11
+export USER=root
+export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT"
+
+Xtightvnc $DISPLAY \
+    -desktop X \
+    -auth /root/.Xauthority \
+    -geometry $GEOMETRY \
+    -depth $SCREEN_DEPTH \
+    -rfbwait 120000 \
+    -rfbauth /root/.vnc/passwd \
+    -rfbport 5900 \
+    -fp $FONTROOT/misc/,$FONTROOT/Type1/,$FONTROOT/75dpi/,$FONTROOT/100dpi/ \
+    -co /etc/X11/rgb &
+
+NODE_PID=$!
+
+sleep 1
+
+java -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
-NODE_PID=$!
-
-trap shutdown SIGTERM SIGINT
-for i in $(seq 1 10)
-do
-  xdpyinfo -display $DISPLAY >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    break
-  fi
-  echo Waiting xvfb...
-  sleep 0.5
-done
 
 fluxbox -display $DISPLAY &
 
-x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
-
+trap shutdown SIGTERM SIGINT
+sleep 0.5
 wait $NODE_PID
+

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -11,8 +11,9 @@ if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
 fi
 
 function shutdown {
-  kill -s SIGTERM $NODE_PID
-  wait $NODE_PID
+  kill -s SIGINT $JAVA_PID
+  wait $JAVA_PID
+  kill -s SIGINT $VNC_PID
 }
 
 REMOTE_HOST_PARAM=""
@@ -25,21 +26,21 @@ fi
 
 # startup tightvnc server
 export FONTROOT=/usr/share/fonts/X11
-export USER=root
+export USER=seluser
 export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT"
 
 Xtightvnc $DISPLAY \
-    -desktop X \
-    -auth /root/.Xauthority \
-    -geometry $GEOMETRY \
-    -depth $SCREEN_DEPTH \
-    -rfbwait 120000 \
-    -rfbauth /root/.vnc/passwd \
-    -rfbport 5900 \
-    -fp $FONTROOT/misc/,$FONTROOT/Type1/,$FONTROOT/75dpi/,$FONTROOT/100dpi/ \
-    -co /etc/X11/rgb &
+  -desktop X \
+  -auth /root/.Xauthority \
+  -geometry $GEOMETRY \
+  -depth $SCREEN_DEPTH \
+  -rfbwait 120000 \
+  -rfbauth /root/.vnc/passwd \
+  -rfbport 5900 \
+  -fp $FONTROOT/misc/,$FONTROOT/Type1/,$FONTROOT/75dpi/,$FONTROOT/100dpi/ \
+  -co /etc/X11/rgb &
 
-NODE_PID=$!
+VNC_PID=$!
 
 sleep 1
 
@@ -49,9 +50,11 @@ java -jar /opt/selenium/selenium-server-standalone.jar \
     ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
 
+JAVA_PID=$!
+
 fluxbox -display $DISPLAY &
 
 trap shutdown SIGTERM SIGINT
-sleep 0.5
-wait $NODE_PID
+sleep 1
+wait $VNC_PID $JAVA_PID
 


### PR DESCRIPTION
I'm running my docker-selenium nodes using tightvnc to record video of browser sessions over the network. I've found it to be more responsive than x11vnc.  If there is interest in keeping x11vnc the entry point could be modularized so that either x11vnc or tightvnc could be started, e.g. `VNCSERVER=[x11vnc | tightvnc]`
