### PR TITLE
Fix x11vnc sometimes fails

### DIFF
--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -28,7 +28,15 @@ sudo -E -i -u seluser \
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT
-sleep 0.5
+for i in $(seq 1 10)
+do
+  xdpyinfo -display $DISPLAY >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  echo Waiting xvfb...
+  sleep 0.5
+done
 
 fluxbox -display $DISPLAY &
 

--- a/NodeDebug/debug-script.sh
+++ b/NodeDebug/debug-script.sh
@@ -1,5 +1,13 @@
   | tee "/tmp/sel-node.log" &
-sleep 0.5
+for i in $(seq 1 10)
+do
+  xdpyinfo -display $DISPLAY >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  echo Waiting xvfb...
+  sleep 0.5
+done
 
 fluxbox -display $DISPLAY &
 

--- a/NodeDebug/generate.sh
+++ b/NodeDebug/generate.sh
@@ -14,7 +14,15 @@ cat ../NodeBase/entry_point.sh \
   | sed 's/^xvfb-run/sudo -E -i -u seluser \\\
   DISPLAY=$DISPLAY \\\
   xvfb-run/' \
-  | sed 's/^wait \$NODE_PID/sleep 0.5\
+  | sed 's/^wait \$NODE_PID/for i in $(seq 1 10)\
+do\
+  xdpyinfo -display $DISPLAY >\/dev\/null 2>\&1\
+  if [ $? -eq 0 ]; then\
+    break\
+  fi\
+  echo Waiting xvfb...\
+  sleep 0.5\
+done\
 \
 fluxbox -display $DISPLAY \&\
 \

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -28,7 +28,15 @@ sudo -E -i -u seluser \
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT
-sleep 0.5
+for i in $(seq 1 10)
+do
+  xdpyinfo -display $DISPLAY >/dev/null 2>&1
+  if [ $? -eq 0 ]; then
+    break
+  fi
+  echo Waiting xvfb...
+  sleep 0.5
+done
 
 fluxbox -display $DISPLAY &
 


### PR DESCRIPTION
In my environment, x11vnc sometimes fails with the following logs. It seems that an X server is not running. After changing the sleep time from 0.5 seconds to 2 seconds, it becomes stable.

```
22/12/2014 12:45:04 x11vnc version: 0.9.13 lastmod: 2011-08-10  pid: 10
22/12/2014 12:45:04 XOpenDisplay(":99.0") failed.
22/12/2014 12:45:04 Trying again with XAUTHLOCALHOSTNAME=localhost ...

22/12/2014 12:45:04 ***************************************
22/12/2014 12:45:04 *** XOpenDisplay failed (:99.0)

*** x11vnc was unable to open the X DISPLAY: ":99.0", it cannot continue.
*** There may be "Xlib:" error messages above with details about the failure.

Some tips and guidelines:

** An X server (the one you wish to view) must be running before x11vnc is
   started: x11vnc does not start the X server.  (however, see the -create
   option if that is what you really want).

** You must use -display <disp>, -OR- set and export your $DISPLAY
   environment variable to refer to the display of the desired X server.
 - Usually the display is simply ":0" (in fact x11vnc uses this if you forget
   to specify it), but in some multi-user situations it could be ":1", ":2",
   or even ":137".  Ask your administrator or a guru if you are having
   difficulty determining what your X DISPLAY is.

** Next, you need to have sufficient permissions (Xauthority) 
   to connect to the X DISPLAY.   Here are some Tips:

 - Often, you just need to run x11vnc as the user logged into the X session.
   So make sure to be that user when you type x11vnc.
 - Being root is usually not enough because the incorrect MIT-MAGIC-COOKIE
   file may be accessed.  The cookie file contains the secret key that
   allows x11vnc to connect to the desired X DISPLAY.
 - You can explicitly indicate which MIT-MAGIC-COOKIE file should be used
   by the -auth option, e.g.:
       x11vnc -auth /home/someuser/.Xauthority -display :0
       x11vnc -auth /tmp/.gdmzndVlR -display :0
   you must have read permission for the auth file.
   See also '-auth guess' and '-findauth' discussed below.

** If NO ONE is logged into an X session yet, but there is a greeter login
   program like "gdm", "kdm", "xdm", or "dtlogin" running, you will need
   to find and use the raw display manager MIT-MAGIC-COOKIE file.
   Some examples for various display managers:

     gdm:     -auth /var/gdm/:0.Xauth
              -auth /var/lib/gdm/:0.Xauth
     kdm:     -auth /var/lib/kdm/A:0-crWk72
              -auth /var/run/xauth/A:0-crWk72
     xdm:     -auth /var/lib/xdm/authdir/authfiles/A:0-XQvaJk
     dtlogin: -auth /var/dt/A:0-UgaaXa

   Sometimes the command "ps wwwwaux | grep auth" can reveal the file location.

   Starting with x11vnc 0.9.9 you can have it try to guess by using:

              -auth guess

   (see also the x11vnc -findauth option.)

   Only root will have read permission for the file, and so x11vnc must be run
   as root (or copy it).  The random characters in the filenames will of course
   change and the directory the cookie file resides in is system dependent.
```