### PR TITLE
fix random issue by modifying java.security file

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get update -qqy \
     wget \
   && rm -rf /var/lib/apt/lists/*
 
+# fix random issue
+RUN sed -i 's/\/dev\/urandom/\/dev\/.\/urandom/' ./usr/lib/jvm/java-7-openjdk-amd64/jre/lib/security/java.security
+
 #==========
 # Selenium
 #==========

--- a/Hub/README.md
+++ b/Hub/README.md
@@ -26,23 +26,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/NodeBase/README.md
+++ b/NodeBase/README.md
@@ -27,23 +27,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/NodeChrome/README.md
+++ b/NodeChrome/README.md
@@ -27,23 +27,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/NodeChromeDebug/README.md
+++ b/NodeChromeDebug/README.md
@@ -50,23 +50,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/NodeDebug/README.template.md
+++ b/NodeDebug/README.template.md
@@ -50,23 +50,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/NodeFirefox/README.md
+++ b/NodeFirefox/README.md
@@ -27,23 +27,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/NodeFirefoxDebug/README.md
+++ b/NodeFirefoxDebug/README.md
@@ -50,23 +50,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/README.md
+++ b/README.md
@@ -114,23 +114,6 @@ When you are prompted for the password it is __secret__. If you wish to change t
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that nodes will not immediately connect with the hub. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random --link selenium-hub:hub selenium/node-firefox
-```
-
 ##### Look around
 
 ``` bash

--- a/Standalone/README.template.md
+++ b/Standalone/README.template.md
@@ -28,22 +28,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that Selenium containers are not immediately responsive. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random selenium/standalone-##BROWSER_LC##
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/StandaloneChrome/README.md
+++ b/StandaloneChrome/README.md
@@ -28,22 +28,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that Selenium containers are not immediately responsive. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random selenium/standalone-chrome
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/StandaloneFirefox/README.md
+++ b/StandaloneFirefox/README.md
@@ -28,22 +28,6 @@ Selenium has the support of some of the largest browser vendors who have taken (
 
 See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
 
-## Known Issues
-
-### Problems with `/dev/random`
-
-You may occasionally see that Selenium containers are not immediately responsive. In some cases the delay has been as high as 40 minutes. This is due to a known problem with linux containers where there is a lack of entropy within the running container. [James Bayer](http://blog.pivotal.io/cloud-foundry-pivotal/features/challenges-with-randomness-in-multi-tenant-linux-container-platforms) wrote a great article explaining the core of the problem.
-
-You can either install an entropy gathering daemon (EGD), such as [HAVEGED](http://www.issihosts.com/haveged/index.html), on you docker host.
-
--- or --
-
-Run your container with the `-v /dev/urandom:/dev/random` option. ie:
-
-```
-$ docker run -d -v /dev/urandom:/dev/random selenium/standalone-firefox
-```
-
 ## License
 
 View [license information](https://code.google.com/p/selenium/source/browse/COPYING) for the software contained in this image.

--- a/sa-test.sh
+++ b/sa-test.sh
@@ -7,7 +7,7 @@ function test_standalone {
   BROWSER=$1
   echo Starting $BROWSER standalone container
 
-  SA=$(docker run -d -v /dev/urandom:/dev/random selenium/standalone-$BROWSER:2.44.0)
+  SA=$(docker run -d selenium/standalone-$BROWSER:2.44.0)
   SA_NAME=$(docker inspect -f '{{ .Name  }}' $SA | sed s:/::)
   TEST_CMD="node smoke-$BROWSER.js"
 

--- a/test.sh
+++ b/test.sh
@@ -13,8 +13,8 @@ HUB=$(docker run -d selenium/hub:2.44.0)
 HUB_NAME=$(docker inspect -f '{{ .Name  }}' $HUB | sed s:/::)
 sleep 2
 
-NODE_CHROME=$(docker run -d --link $HUB_NAME:hub -v /dev/urandom:/dev/random selenium/node-chrome$DEBUG:2.44.0)
-NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub -v /dev/urandom:/dev/random selenium/node-firefox$DEBUG:2.44.0)
+NODE_CHROME=$(docker run -d --link $HUB_NAME:hub  selenium/node-chrome$DEBUG:2.44.0)
+NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub selenium/node-firefox$DEBUG:2.44.0)
 
 docker logs -f $HUB &
 docker logs -f $NODE_CHROME &


### PR DESCRIPTION
This fixes the issue with blocking random calls by modifying java.security with the workaround described in [JDK-6202721](http://bugs.java.com/view_bug.do;jsessionid=ff625daf459fdffffffffcd54f1c775299e0?bug_id=6202721).  This is essentially the same fix that @zxqfox mentioned in comments for #14, but taken one layer deeper by modifying java.security instead of specifying the parameter on the command line with -D.
