### PR TITLE
Adds support for -remoteHost parameter for nodes. This is required when ...

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -16,12 +16,19 @@ function shutdown {
   wait $NODE_PID
 }
 
+REMOTE_HOST_PARAM=""
+if [ ! -z "$REMOTE_HOST" ]; then
+  echo "REMOTE_HOST variable is set, appending -remoteHost"
+  REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
+fi
+
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
 xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
+    ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
 NODE_PID=$!
 

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -16,6 +16,12 @@ function shutdown {
   wait $NODE_PID
 }
 
+REMOTE_HOST_PARAM=""
+if [ ! -z "$REMOTE_HOST" ]; then
+  echo "REMOTE_HOST variable is set, appending -remoteHost"
+  REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
+fi
+
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
 sudo -E -i -u seluser \
@@ -24,6 +30,7 @@ sudo -E -i -u seluser \
   java -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
+    ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
 NODE_PID=$!
 

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -16,6 +16,12 @@ function shutdown {
   wait $NODE_PID
 }
 
+REMOTE_HOST_PARAM=""
+if [ ! -z "$REMOTE_HOST" ]; then
+  echo "REMOTE_HOST variable is set, appending -remoteHost"
+  REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
+fi
+
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
 sudo -E -i -u seluser \
@@ -24,6 +30,7 @@ sudo -E -i -u seluser \
   java -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
+    ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json &
 NODE_PID=$!
 


### PR DESCRIPTION
...node is running on separate host from hub, and also has multiple network interfaces. This is because selenium by default sets -remoteHost to first available network interface, which may not be the one that you want to use. In my use case, we have two network interfaces, and it's the 2nd one listed that we use for our remoteHost ip. More info about this parameter available here: http://automatictester.co.uk/2012/10/27/selenium-grid-2-0-and-remotehost-parameter/. 

To enable, add -e REMOTE_HOST="http://1.2.3.4:5555" to docker run command for node, replacing 1.2.3.4 with the accesible IP of your node.