### PR TITLE
Propagate JAVA OPTIONS

### DIFF
--- a/Hub/entry_point.sh
+++ b/Hub/entry_point.sh
@@ -14,7 +14,10 @@ function shutdown {
     echo "shutdown complete"
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 java -jar /opt/selenium/selenium-server-standalone.jar \
+  $* \
   -role hub \
   -hubConfig $CONF &
 NODE_PID=$!

--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -18,8 +18,11 @@ function shutdown {
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java -jar /opt/selenium/selenium-server-standalone.jar \
+    $* \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     -nodeConfig /opt/selenium/config.json &

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -18,10 +18,13 @@ function shutdown {
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 sudo -E -i -u seluser \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java -jar /opt/selenium/selenium-server-standalone.jar \
+    $* \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     -nodeConfig /opt/selenium/config.json &

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -18,10 +18,13 @@ function shutdown {
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 sudo -E -i -u seluser \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java -jar /opt/selenium/selenium-server-standalone.jar \
+    $* \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     -nodeConfig /opt/selenium/config.json &

--- a/README.md
+++ b/README.md
@@ -48,6 +48,15 @@ $ docker run -d --link selenium-hub:hub selenium/node-chrome:2.45.0
 $ docker run -d --link selenium-hub:hub selenium/node-firefox:2.45.0
 ```
 
+### Additional parameters
+
+If you need to pass additional configuration flags to the selenium servers (hub or node), you just need to add them at the end of the docker command line you are using to start the containers: 
+
+``` bash
+JAVA_OPTS=-Dhttp.proxyHost=webproxy.domain.com -Dhttp.proxyPort=3128
+docker run -d -p 4444:4444 --name selenium-hub selenium/hub ${JAVA_OPTS}
+```
+
 ## Building the images
 
 Ensure you have the `ubuntu:14.04` base image downloaded, this step is _optional_ since docker takes care of downloading the parent base image automatically.

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ docker run -d --link selenium-hub:hub selenium/node-firefox:2.45.0
 
 ### Additional parameters
 
-If you need to pass additional configuration flags to the selenium servers (hub or node), you just need to add them at the end of the docker command line you are using to start the containers: 
+If you need to pass additional configuration flags to the selenium servers (hub or node), you just need to add them at the end of the docker command line you use to start the containers. This example below shows you how to configure the http proxy inside the container. 
 
 ``` bash
 JAVA_OPTS=-Dhttp.proxyHost=webproxy.domain.com -Dhttp.proxyPort=3128

--- a/Standalone/entry_point.sh
+++ b/Standalone/entry_point.sh
@@ -6,8 +6,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar &
+  java -jar /opt/selenium/selenium-server-standalone.jar $* &
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT

--- a/StandaloneChrome/entry_point.sh
+++ b/StandaloneChrome/entry_point.sh
@@ -6,8 +6,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar &
+  java -jar /opt/selenium/selenium-server-standalone.jar $* &
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT

--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -6,10 +6,12 @@ function shutdown {
   wait $NODE_PID
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 sudo -E -i -u seluser \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar &
+  java -jar /opt/selenium/selenium-server-standalone.jar $* &
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT

--- a/StandaloneDebugChrome/entry_point.sh
+++ b/StandaloneDebugChrome/entry_point.sh
@@ -6,10 +6,12 @@ function shutdown {
   wait $NODE_PID
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 sudo -E -i -u seluser \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar &
+  java -jar /opt/selenium/selenium-server-standalone.jar $* &
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT

--- a/StandaloneDebugFirefox/entry_point.sh
+++ b/StandaloneDebugFirefox/entry_point.sh
@@ -6,10 +6,12 @@ function shutdown {
   wait $NODE_PID
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 sudo -E -i -u seluser \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar &
+  java -jar /opt/selenium/selenium-server-standalone.jar $* &
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT

--- a/StandaloneFirefox/entry_point.sh
+++ b/StandaloneFirefox/entry_point.sh
@@ -6,8 +6,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+[ $# -ne 0 ] && echo "Running with JAVA_OPTS = $* " ]
+
 xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
-  java -jar /opt/selenium/selenium-server-standalone.jar &
+  java -jar /opt/selenium/selenium-server-standalone.jar $* &
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT


### PR DESCRIPTION
I have updated the entry point to propagate additional parameters as JAVA OPTS for the JVM inside the container.

This is definitely needed to set the http proxy at runtime

I have added a small section in the readme and updated all the entry points to keep it consistent.