### PR TITLE
IncreasingMaxInstancesValueForNodes

### DIFF
--- a/NodeChrome/config.json
+++ b/NodeChrome/config.json
@@ -2,18 +2,18 @@
   "capabilities": [
     {
       "browserName": "*googlechrome",
-      "maxInstances": 1,
+      "maxInstances": 5,
       "seleniumProtocol": "Selenium"
     },
     {
       "browserName": "chrome",
-      "maxInstances": 1,
+      "maxInstances": 5,
       "seleniumProtocol": "WebDriver"
     }
   ],
   "configuration": {
     "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
-    "maxSession": 1,
+    "maxSession": 5,
     "port": 5555,
     "register": true,
     "registerCycle": 5000

--- a/NodeFirefox/config.json
+++ b/NodeFirefox/config.json
@@ -2,18 +2,18 @@
   "capabilities": [
     {
       "browserName": "*firefox",
-      "maxInstances": 1,
+      "maxInstances": 5,
       "seleniumProtocol": "Selenium"
     },
     {
       "browserName": "firefox",
-      "maxInstances": 1,
+      "maxInstances": 5,
       "seleniumProtocol": "WebDriver"
     }
   ],
   "configuration": {
     "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
-    "maxSession": 1,
+    "maxSession": 5,
     "port": 5555,
     "register": true,
     "registerCycle": 5000


### PR DESCRIPTION
Increasing maxInstances and maxSessions values in the config.json files for the Chrome and Firefox nodes.  

Idea here is to take better advantage of the GRID_MAX_SESSION value (5) configured in the Hub, so that as many as 5 browser sessions can run at the same time (either from a single node or distributed across multiple nodes).