### PR TITLE
Better update of `securerandom.source` in java.security

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -19,7 +19,7 @@ RUN apt-get update -qqy \
     unzip \
     wget \
   && rm -rf /var/lib/apt/lists/* \
-  && sed -i 's/\/dev\/urandom/\/dev\/.\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
+  && sed -i 's/securerandom\.source=file:\/dev\/random/securerandom\.source=file:\/dev\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
 
 #==========
 # Selenium


### PR DESCRIPTION
Better update of `securerandom.source` to use `file:/dev/urandom` instead of `file:/dev/random

Better granularity, only one line is updated.

**Before**

```diff
87c87
< # special device files such as file:/dev/random.
---
> # special device files such as file:/dev/urandom.
89c89
< # On Windows systems, specifying the URLs "file:/dev/random" or
---
> # On Windows systems, specifying the URLs "file:/dev/urandom" or
101c101
< #         a default value of /dev/random will be used.  If neither
---
> #         a default value of /dev/urandom will be used.  If neither
108c108
< #   % java -Djava.security.egd=file:/dev/random MainClass
---
> #   % java -Djava.security.egd=file:/dev/urandom MainClass
113c113
< # In addition, if "file:/dev/random" or "file:/dev/urandom" is
---
> # In addition, if "file:/dev/urandom" or "file:/dev/urandom" is
117c117
< securerandom.source=file:/dev/random
---
> securerandom.source=file:/dev/urandom
```

**After**

```diff
117c117
< securerandom.source=file:/dev/random
---
> securerandom.source=file:/dev/urandom
```