### PR TITLE
Reduce sleep times back to prev. values.

### DIFF
--- a/test.sh
+++ b/test.sh
@@ -13,7 +13,7 @@ HUB=$(docker run -d selenium/hub:2.47.1)
 HUB_NAME=$(docker inspect -f '{{ .Name  }}' $HUB | sed s:/::)
 echo 'Waiting for Hub to come online...'
 docker logs -f $HUB &
-sleep 4
+sleep 2
 
 echo 'Starting Selenium Chrome node...'
 NODE_CHROME=$(docker run -d --link $HUB_NAME:hub  selenium/node-chrome$DEBUG:2.47.1)
@@ -22,7 +22,7 @@ NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub selenium/node-firefox$DEBUG:2.
 docker logs -f $NODE_CHROME &
 docker logs -f $NODE_FIREFOX &
 echo 'Waiting for nodes to register and come online...'
-sleep 10
+sleep 2
 
 function test_node {
   BROWSER=$1


### PR DESCRIPTION
There have been problems during the tests with CircleCI, which I think
were related to the sleep values being too low. I raised them, but
increasing hard-coded sleeps is not something you want to do in your
tests.

Change sleep times back to their previous values and see if the CI
environment is happy with that change.