### PR TITLE
fix entry should be in Dockerfile template

### DIFF
--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -16,7 +16,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ENV CHROME_DRIVER_VERSION 2.18
+ENV CHROME_DRIVER_VERSION 2.19
 RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \


### PR DESCRIPTION
Dockerfile.txt is a template for final Dockerfile. 
We should enter entires in template and use the make generate target to output final Dockerfile.

I missed this detail in the pull request #100 
No functionality affected