### PR TITLE
allow marathon mesos to set REMOTE_HOST

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -16,6 +16,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+if [ ! -z "$MESOS_TASK_ID" ]; then
+  REMOTE_HOST="http://${HOST}:${PORT_5555}"
+fi
+
 REMOTE_HOST_PARAM=""
 if [ ! -z "$REMOTE_HOST" ]; then
   echo "REMOTE_HOST variable is set, appending -remoteHost"


### PR DESCRIPTION
We spin docker nodes for the hub in Marathon Mesos. 

At the time of starting the docker container Marathon sets MESOS_TASK_ID and we have access to HOST and PORT_5555 env variables from which REMOTE_HOST can be constructed. 

This is an experimental way of spinning nodes. 

Does anyone use Mesos Marathon for their Selenium Grid? How do you deal with this? 
