### PR TITLE
Upgrade OS to bridge gap until next LTS release.

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:15.04
+FROM ubuntu:15.10
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 #================================================


### PR DESCRIPTION
We've switched to Ubuntu 15.04 to use an OS supported package of
Java 8. That version of Ubuntu hits it's EOL date *before* the next
LTS version (Ubuntu 16.04) hits the road. Therefore we upgrade to
15.10 to bridge that gap.