### PR TITLE
manullay transmit env variables to selenium user in *debug*

### DIFF
--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -28,7 +28,10 @@ fi
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
-sudo -E -i -u seluser \
+env | cut -f 1 -d "=" | sort > asroot
+  sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
+  sudo -E -i -u seluser \
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \

--- a/NodeDebug/generate.sh
+++ b/NodeDebug/generate.sh
@@ -11,7 +11,10 @@ echo FROM selenium/$BASE:$VERSION > $FOLDER/Dockerfile
 cat ./Dockerfile.txt >> $FOLDER/Dockerfile
 
 cat ../NodeBase/entry_point.sh \
-  | sed 's/^xvfb-run/sudo -E -i -u seluser \\\
+  | sed 's/^xvfb-run/env | cut -f 1 -d "=" | sort > asroot\
+  sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser\
+  sudo -E -i -u seluser \\\
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \\\$$E); done) \\\
   DISPLAY=$DISPLAY \\\
   xvfb-run/' \
   | sed 's/^wait \$NODE_PID/for i in $(seq 1 10)\

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -28,7 +28,10 @@ fi
 
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
-sudo -E -i -u seluser \
+env | cut -f 1 -d "=" | sort > asroot
+  sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
+  sudo -E -i -u seluser \
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \

--- a/StandaloneChromeDebug/entry_point.sh
+++ b/StandaloneChromeDebug/entry_point.sh
@@ -10,7 +10,10 @@ if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi
 
+env | cut -f 1 -d "=" | sort > asroot
+sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
 sudo -E -i -u seluser \
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \

--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -10,7 +10,10 @@ if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi
 
+env | cut -f 1 -d "=" | sort > asroot
+sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
 sudo -E -i -u seluser \
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \

--- a/StandaloneFirefoxDebug/entry_point.sh
+++ b/StandaloneFirefoxDebug/entry_point.sh
@@ -10,7 +10,10 @@ if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi
 
+env | cut -f 1 -d "=" | sort > asroot
+sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
 sudo -E -i -u seluser \
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run --server-args="$DISPLAY -screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \


### PR DESCRIPTION
the debug images are using the `sudo -E -i -u seluser` to start the selenium stuffs and browser with the appropriated seluser.

Unfortunatly, as described in the sudoers documentation: 

> As a special case, if sudo's -i option (initial login) is specified, sudoers will initialize the environment regardless of the value of env_reset. 

That means the env variables from the docker client won't be transmitted to the browser with `-i`

As the `-i` is mandatory to initiate the browser stuffs and `-E` is useless, I have added a trick to extract env variables from the root users and pass them to the seluser.

This is definitly needed to make the debug images working