### PR TITLE
Add HUB_HOST environment variable for Docker networking clarity

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -6,6 +6,11 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
+if [ ! -z "$HUB_HOST" ]; then
+  echo "Connecting to the selenium hub using the host string ${HUB_HOST}"
+  HUB_PORT_4444_TCP_ADDR=$HUB_HOST
+fi
+
 if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
   echo Not linked with a running Hub container 1>&2
   exit 1

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -6,6 +6,11 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
+if [ ! -z "$HUB_HOST" ]; then
+  echo "Connecting to the selenium hub using the host string ${HUB_HOST}"
+  HUB_PORT_4444_TCP_ADDR=$HUB_HOST
+fi
+
 if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
   echo Not linked with a running Hub container 1>&2
   exit 1

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -6,6 +6,11 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
+if [ ! -z "$HUB_HOST" ]; then
+  echo "Connecting to the selenium hub using the host string ${HUB_HOST}"
+  HUB_PORT_4444_TCP_ADDR=$HUB_HOST
+fi
+
 if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
   echo Not linked with a running Hub container 1>&2
   exit 1

--- a/README.md
+++ b/README.md
@@ -56,6 +56,14 @@ $ docker run -d --link selenium-hub:hub selenium/node-chrome:2.48.2
 $ docker run -d --link selenium-hub:hub selenium/node-firefox:2.48.2
 ```
 
+### Hub and Nodes Using Docker Networking
+``` bash
+docker network create selenium-network
+docker run -d -p 4444:4444 --net=selenium-network --name selenium-hub selenium/hub:2.48.2
+docker run -d --net=selenium-network -e HUB_HOST=selenium-hub selenium/node-chrome:2.48.2
+docker run -d --net=selenium-network -e HUB_HOST=selenium-hub selenium/node-firefox:2.48.2
+```
+
 ### JAVA_OPTS Java Environment Options
 
 You can pass `JAVA_OPTS` environment variable to java process.

--- a/README.md
+++ b/README.md
@@ -63,6 +63,12 @@ docker run -d -p 4444:4444 --net=selenium-network --name selenium-hub selenium/h
 docker run -d --net=selenium-network -e HUB_HOST=selenium-hub selenium/node-chrome:2.48.2
 docker run -d --net=selenium-network -e HUB_HOST=selenium-hub selenium/node-firefox:2.48.2
 ```
+You can also pass in an IP address, if your selenium hub is location on a different physical machine:
+``` bash
+docker run -d -e HUB_HOST=10.0.0.1:4444 selenium/node-chrome:2.48.2
+docker run -d -e HUB_HOST=10.0.0.1:4444 selenium/node-firefox:2.48.2
+```
+
 
 ### JAVA_OPTS Java Environment Options
 


### PR DESCRIPTION
Helps resolve #133 by increasing clarity on how to use the new (Docker v1.7) networking feature.
