### PR TITLE
Document how to access host URL's from within the container

### DIFF
--- a/README.md
+++ b/README.md
@@ -72,6 +72,9 @@ You can pass `SE_OPTS` variable with additional commandline parameters for start
 $ docker run -d -p 4444:4444 -e SE_OPTS=-debug --name selenium-hub selenium/hub:2.52.0
 ```
 
+### Connect to host network from container
+When developing with a web server running locally on the host, the browser within the docker container needs to access the URL that's available only on the host (typically `http://localhost` or maybe `http://myproject.dev`). Add the `--net=host` option to the `docker run` commands to accomplish this.
+
 ## Building the images
 
 Ensure you have the `ubuntu:15.04` base image downloaded, this step is _optional_ since Docker takes care of downloading the parent base image automatically.


### PR DESCRIPTION
When developing with a web server running on the host, the browser within the container needs to access the URL that's available only within the host. Adding `--net=host` to the `docker run` command accomplishes this.

See https://docs.docker.com/v1.8/articles/networking/#container-networking for more details, including a warning that "You should use this option with caution." Should a warning like that be included here? When used in a gitlab test runner, for example, the option shouldn't be a problem, but let me know if this PR should be modified to mention that.
