### PR TITLE
Update Dockerfile to use wily apt repo

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Selenium <selenium-developers@googlegroups.com>
 #================================================
 # Customize sources for apt-get
 #================================================
-RUN  echo "deb http://archive.ubuntu.com/ubuntu vivid main universe\n" > /etc/apt/sources.list \
-  && echo "deb http://archive.ubuntu.com/ubuntu vivid-updates main universe\n" >> /etc/apt/sources.list
+RUN  echo "deb http://archive.ubuntu.com/ubuntu wily main universe\n" > /etc/apt/sources.list \
+  && echo "deb http://archive.ubuntu.com/ubuntu wily-updates main universe\n" >> /etc/apt/sources.list
 
 #========================
 # Miscellaneous packages


### PR DESCRIPTION
Not sure if this was an oversight or an intentional workaround for something, but 15.10 is wily, not vivid. When trying to extend the standalone base docker image I got some failures due to unexpected versions.

Vivid is also past EOL, so there might be security issues from using the old packages (e.g. the glibc getaddrinfo bug was more recent than vivid EOL).