### PR TITLE
move the creation of the config.json file into a RUN directive

### DIFF
--- a/Hub/Dockerfile
+++ b/Hub/Dockerfile
@@ -18,6 +18,7 @@ ENV GRID_UNREGISTER_IF_STILL_DOWN_AFTER 30000
 
 COPY generate_config /opt/selenium/generate_config
 COPY entry_point.sh /opt/bin/entry_point.sh
+RUN /opt/selenium/generate_config > /opt/selenium/config.json
 RUN chown -R seluser /opt/selenium
 
 USER seluser

--- a/Hub/entry_point.sh
+++ b/Hub/entry_point.sh
@@ -3,7 +3,6 @@
 ROOT=/opt/selenium
 CONF=$ROOT/config.json
 
-$ROOT/generate_config >$CONF
 echo "starting selenium hub with configuration:"
 cat $CONF
 


### PR DESCRIPTION
You would *think* that this is a no-op, but it's not.  This was actually creating an issue when running Docker containers in succession with Kubernetes and OpenShift.

This change won't affect other users using this without Kubernetes and OpenShift.  Due to the nature that some Docker containers won't be safe - OpenShift enforces a policy of an [arbitrary user ID](https://docs.openshift.com/enterprise/3.0/creating_images/guidelines.html) that has sudo'ers rather than running as root.