### PR TITLE
Pin the Firefox version to 45

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -14,6 +14,7 @@ RUN  echo "deb http://archive.ubuntu.com/ubuntu xenial main universe\n" > /etc/a
 #========================
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
+    bzip2 \
     ca-certificates \
     openjdk-8-jre-headless \
     sudo \

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -6,10 +6,17 @@ USER root
 #=========
 # Firefox
 #=========
+ENV FIREFOX_VERSION 45.0.1
 RUN apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install \
-    firefox \
-  && rm -rf /var/lib/apt/lists/*
+  && apt-get -qqy --no-install-recommends install firefox \
+  && rm -rf /var/lib/apt/lists/* \
+  && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
+  && apt-get -y purge firefox \
+  && rm -rf /opt/firefox \
+  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
+  && rm /tmp/firefox.tar.bz2 \
+  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
+  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
 #========================
 # Selenium Configuration


### PR DESCRIPTION
When Firefox 46 is released, the current FirefoxDriver will stop working. Currently, the latest stable version of Firefox at the time the image was build is installed. This means if it's rebuilt, the version might update beyond Firefox 45, but it also means if it's not rebuilt an old and unsupported version of Firefox may be used.

This patch explicitly installs Firefox 45.0.1, and allows more purposeful updates of the browser. It will also allow us to manage Firefox 46 and adding support for Marionette.

Something I'm not clear on is the tags. I've changed them to 'latest' for the affected images because they require the upstream changes, but I'm not sure how this should affect users of the tags. Should updating Firefox mean also updating the tags? Perhaps tags could be the Selenium version plus a point release for each image, such as `2.52.0.1` and include a changelog to indicate what's new?