### PR TITLE
[work-in-progress] Add support for Marionette

### DIFF
--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -18,6 +18,17 @@ RUN apt-get update -qqy \
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
+#=======
+# Wires
+#=======
+ENV WIRES_VERSION 0.6.2
+RUN wget --no-verbose -O /tmp/wires.gz https://github.com/jgraham/wires/releases/download/v$WIRES_VERSION/wires-$WIRES_VERSION-linux64.gz \
+  && rm -rf /opt/wires \
+  && gunzip -c /tmp/wires.gz > /opt/wires-$WIRES_VERSION \
+  && rm /tmp/wires.gz \
+  && chmod 755 /opt/wires-$WIRES_VERSION \
+  && ln -fs /opt/wires-$WIRES_VERSION /usr/bin/wires
+
 #========================
 # Selenium Configuration
 #========================


### PR DESCRIPTION
This builds on #188 and adds the new Firefox driver 'wires' to support Firefox 46+ with Marionette. It should also work with Firefox 45 to allow users to start experimenting with using Marionette by setting a 'marionette' capability. I've had issues connecting to the wires service though - it appears to start, but the connection is refused:

```
Driver info: driver.version: MarionetteDriver
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:91)
	at org.openqa.selenium.remote.RemoteWebDriver.execute(RemoteWebDriver.java:644)
	... 19 more
Caused by: org.apache.http.conn.HttpHostConnectException: Connect to localhost:6600 [localhost/127.0.0.1, localhost/0:0:0:0:0:0:0:1] failed: Connection refused
	at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:151)
	at org.apache.http.impl.conn.PoolingHttpClientConnectionManager.connect(PoolingHttpClientConnectionManager.java:353)
	at org.apache.http.impl.execchain.MainClientExec.establishRoute(MainClientExec.java:380)
	at org.apache.http.impl.execchain.MainClientExec.execute(MainClientExec.java:236)
	at org.apache.http.impl.execchain.ProtocolExec.execute(ProtocolExec.java:184)
	at org.apache.http.impl.execchain.RetryExec.execute(RetryExec.java:88)
	at org.apache.http.impl.execchain.RedirectExec.execute(RedirectExec.java:110)
	at org.apache.http.impl.client.InternalHttpClient.doExecute(InternalHttpClient.java:184)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:71)
	at org.apache.http.impl.client.CloseableHttpClient.execute(CloseableHttpClient.java:55)
	at org.openqa.selenium.remote.internal.ApacheHttpClient.fallBackExecute(ApacheHttpClient.java:144)
	at org.openqa.selenium.remote.internal.ApacheHttpClient.execute(ApacheHttpClient.java:90)
	at org.openqa.selenium.remote.HttpCommandExecutor.execute(HttpCommandExecutor.java:142)
	at org.openqa.selenium.remote.service.DriverCommandExecutor.execute(DriverCommandExecutor.java:82)
	... 20 more
Caused by: java.net.ConnectException: Connection refused
	at java.net.PlainSocketImpl.socketConnect(Native Method)
	at java.net.AbstractPlainSocketImpl.doConnect(AbstractPlainSocketImpl.java:350)
	at java.net.AbstractPlainSocketImpl.connectToAddress(AbstractPlainSocketImpl.java:206)
	at java.net.AbstractPlainSocketImpl.connect(AbstractPlainSocketImpl.java:188)
	at java.net.SocksSocketImpl.connect(SocksSocketImpl.java:392)
	at java.net.Socket.connect(Socket.java:589)
	at org.apache.http.conn.socket.PlainConnectionSocketFactory.connectSocket(PlainConnectionSocketFactory.java:74)
	at org.apache.http.impl.conn.DefaultHttpClientConnectionOperator.connect(DefaultHttpClientConnectionOperator.java:134)
	... 33 more
01:22:06.345 WARN - Exception: Connection refused
```