### PR TITLE
Upgrade Selenium version to 2.53.0.

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -qqy \
 # Selenium
 #==========
 RUN  mkdir -p /opt/selenium \
-  && wget --no-verbose http://selenium-release.storage.googleapis.com/2.52/selenium-server-standalone-2.52.0.jar -O /opt/selenium/selenium-server-standalone.jar
+  && wget --no-verbose http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar -O /opt/selenium/selenium-server-standalone.jar
 
 #========================================
 # Add normal user with passwordless sudo

--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -25,7 +25,7 @@ RUN apt-get update -qqy \
 # Selenium
 #==========
 RUN  mkdir -p /opt/selenium \
-  && wget --no-verbose http://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar -O /opt/selenium/selenium-server-standalone.jar
+  && wget --no-verbose https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar -O /opt/selenium/selenium-server-standalone.jar
 
 #========================================
 # Add normal user with passwordless sudo

--- a/Hub/Dockerfile
+++ b/Hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/base:2.52.0
+FROM selenium/base:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 #========================

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := selenium
-VERSION := $(or $(VERSION),$(VERSION),'2.52.0')
+VERSION := $(or $(VERSION),$(VERSION),'2.53.0')
 PLATFORM := $(shell uname -s)
 BUILD_ARGS := $(BUILD_ARGS)
 

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/base:2.52.0
+FROM selenium/base:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -17,7 +17,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ENV CHROME_DRIVER_VERSION 2.20
+ENV CHROME_DRIVER_VERSION 2.21
 RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-base:2.52.0
+FROM selenium/node-base:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -18,7 +18,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 # Chrome webdriver
 #==================
 ENV CHROME_DRIVER_VERSION 2.21
-RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
   && rm /tmp/chromedriver_linux64.zip \

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -17,7 +17,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 # Chrome webdriver
 #==================
 ENV CHROME_DRIVER_VERSION 2.21
-RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
+RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \
   && rm /tmp/chromedriver_linux64.zip \

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -16,7 +16,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ENV CHROME_DRIVER_VERSION 2.20
+ENV CHROME_DRIVER_VERSION 2.21
 RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip http://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \

--- a/NodeChromeDebug/Dockerfile
+++ b/NodeChromeDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome:2.52.0
+FROM selenium/node-chrome:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeChromeDebug/README.md
+++ b/NodeChromeDebug/README.md
@@ -38,7 +38,7 @@ If you are running Boot2Docker on Mac then you already have a [VNC client](http:
 When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
 
 ``` dockerfile
-FROM selenium/node-chrome-debug:2.52.0
+FROM selenium/node-chrome-debug:2.53.0
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```

--- a/NodeDebug/README.template.md
+++ b/NodeDebug/README.template.md
@@ -38,7 +38,7 @@ If you are running Boot2Docker on Mac then you already have a [VNC client](http:
 When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
 
 ``` dockerfile
-FROM selenium/##BASE##-debug:2.52.0
+FROM selenium/##BASE##-debug:2.53.0
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-base:2.52.0
+FROM selenium/node-base:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeFirefoxDebug/Dockerfile
+++ b/NodeFirefoxDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-firefox:2.52.0
+FROM selenium/node-firefox:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeFirefoxDebug/README.md
+++ b/NodeFirefoxDebug/README.md
@@ -38,7 +38,7 @@ If you are running Boot2Docker on Mac then you already have a [VNC client](http:
 When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
 
 ``` dockerfile
-FROM selenium/node-firefox-debug:2.52.0
+FROM selenium/node-firefox-debug:2.53.0
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Images included:
 When executing docker run for an image with chrome browser please add volume mount `-v /dev/shm:/dev/shm` to use the host's shared memory.
 
 ``` bash
-$ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.52.0
+$ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.53.0
 ```
 
 This is a workaround to node-chrome crash in docker container issue: https://code.google.com/p/chromium/issues/detail?id=519952 
@@ -34,9 +34,9 @@ This is a workaround to node-chrome crash in docker container issue: https://cod
 ### Standalone Chrome and Firefox
 
 ``` bash
-$ docker run -d -p 4444:4444 selenium/standalone-chrome:2.52.0
+$ docker run -d -p 4444:4444 selenium/standalone-chrome:2.53.0
 # OR
-$ docker run -d -p 4444:4444 selenium/standalone-firefox:2.52.0
+$ docker run -d -p 4444:4444 selenium/standalone-firefox:2.53.0
 ```
 
 _Note: Only one standalone image can run on port_ `4444` _at a time._
@@ -46,14 +46,14 @@ To inspect visually what the browser is doing use the `standalone-chrome-debug` 
 ### Selenium Grid Hub
 
 ``` bash
-$ docker run -d -p 4444:4444 --name selenium-hub selenium/hub:2.52.0
+$ docker run -d -p 4444:4444 --name selenium-hub selenium/hub:2.53.0
 ```
 
 ### Chrome and Firefox Grid Nodes
 
 ``` bash
-$ docker run -d --link selenium-hub:hub selenium/node-chrome:2.52.0
-$ docker run -d --link selenium-hub:hub selenium/node-firefox:2.52.0
+$ docker run -d --link selenium-hub:hub selenium/node-chrome:2.53.0
+$ docker run -d --link selenium-hub:hub selenium/node-firefox:2.53.0
 ```
 
 ### JAVA_OPTS Java Environment Options
@@ -61,7 +61,7 @@ $ docker run -d --link selenium-hub:hub selenium/node-firefox:2.52.0
 You can pass `JAVA_OPTS` environment variable to java process.
 
 ``` bash
-$ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/hub:2.52.0
+$ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/hub:2.53.0
 ```
 
 ### SE_OPTS Selenium Configuration Options
@@ -69,7 +69,7 @@ $ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/
 You can pass `SE_OPTS` variable with additional commandline parameters for starting a hub or a node.
 
 ``` bash
-$ docker run -d -p 4444:4444 -e SE_OPTS=-debug --name selenium-hub selenium/hub:2.52.0
+$ docker run -d -p 4444:4444 -e SE_OPTS=-debug --name selenium-hub selenium/hub:2.53.0
 ```
 
 ## Building the images
@@ -99,10 +99,10 @@ _Note: Omitting_ `VERSION=local` _will build the images with the current version
 ##### Example: Spawn a container for testing in Chrome:
 
 ``` bash
-$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.52.0
+$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.53.0
 $ CH=$(docker run --rm --name=ch \
     --link selenium-hub:hub -v /e2e/uploads:/e2e/uploads \
-    selenium/node-chrome:2.52.0)
+    selenium/node-chrome:2.53.0)
 ```
 
 _Note:_ `-v /e2e/uploads:/e2e/uploads` _is optional in case you are testing browser uploads on your web app you will probably need to share a directory for this._
@@ -112,10 +112,10 @@ _Note:_ `-v /e2e/uploads:/e2e/uploads` _is optional in case you are testing brow
 This command line is the same as for Chrome. Remember that the Selenium running container is able to launch either Chrome or Firefox, the idea around having 2 separate containers, one for each browser is for convenience plus avoiding certain `:focus` issues your web app may encounter during end-to-end test automation.
 
 ``` bash
-$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.52.0
+$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.53.0
 $ FF=$(docker run --rm --name=fx \
     --link selenium-hub:hub -v /e2e/uploads:/e2e/uploads \
-    selenium/node-firefox:2.52.0)
+    selenium/node-firefox:2.53.0)
 ```
 
 _Note: Since a Docker container is not meant to preserve state and spawning a new one takes less than 3 seconds you will likely want to remove containers after each end-to-end test with_ `--rm` _command. You need to think of your Docker containers as single processes, not as running virtual machines, in case you are familiar with [Vagrant](https://www.vagrantup.com/)._
@@ -124,8 +124,8 @@ _Note: Since a Docker container is not meant to preserve state and spawning a ne
 
 In the event you wish to visually see what the browser is doing you will want to run the `debug` variant of node or standalone images (substitute a free port that you wish to connect to on VNC for <port4VNC>; 5900 is fine if it is free, but of course you can only run one node on that port):
 ``` bash
-$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-chrome-debug:2.52.0
-$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-firefox-debug:2.52.0
+$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-chrome-debug:2.53.0
+$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-firefox-debug:2.53.0
 ```
 e.g.:
 ``` bash
@@ -137,15 +137,15 @@ to connect to the Chrome node on 5900 and the Firefox node on 5901 (assuming tho
 
 And for standalone: 
 ``` bash
-$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-chrome-debug:2.52.0
+$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-chrome-debug:2.53.0
 # OR
-$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-firefox-debug:2.52.0
+$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-firefox-debug:2.53.0
 ```
 or
 ``` bash
-$ docker run -d -p 4444:4444 -p 5900:5900 selenium/standalone-chrome-debug:2.52.0
+$ docker run -d -p 4444:4444 -p 5900:5900 selenium/standalone-chrome-debug:2.53.0
 # OR
-$ docker run -d -p 4444:4444 -p 5901:5900 selenium/standalone-firefox-debug:2.52.0
+$ docker run -d -p 4444:4444 -p 5901:5900 selenium/standalone-firefox-debug:2.53.0
 ```
 
 You can acquire the port that the VNC server is exposed to by running:
@@ -163,8 +163,8 @@ If you are running [Boot2Docker](https://docs.docker.com/installation/mac/) on O
 
 When you are prompted for the password it is `secret`. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a Docker image that derives from the posted ones which reconfigures it:
 ``` dockerfile
-#FROM selenium/node-chrome-debug:2.52.0
-#FROM selenium/node-firefox-debug:2.52.0
+#FROM selenium/node-chrome-debug:2.53.0
+#FROM selenium/node-firefox-debug:2.53.0
 #Choose the FROM statement that works for you.
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
@@ -176,11 +176,11 @@ RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 $ docker images
 #=>
 REPOSITORY                      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-selenium/node-firefox           2.52.0              69f762d0d79e        29 minutes ago      552.1 MB
-selenium/node-chrome            2.52.0              9dd73160660b        30 minutes ago      723.6 MB
-selenium/node-base              2.52.0              1b7a0b7024b1        32 minutes ago      426.1 MB
-selenium/hub                    2.52.0              2570bbb98229        33 minutes ago      394.4 MB
-selenium/base                   2.52.0              33478d455dab        33 minutes ago      362.6 MB
+selenium/node-firefox           2.53.0              69f762d0d79e        29 minutes ago      552.1 MB
+selenium/node-chrome            2.53.0              9dd73160660b        30 minutes ago      723.6 MB
+selenium/node-base              2.53.0              1b7a0b7024b1        32 minutes ago      426.1 MB
+selenium/hub                    2.53.0              2570bbb98229        33 minutes ago      394.4 MB
+selenium/base                   2.53.0              33478d455dab        33 minutes ago      362.6 MB
 ubuntu                          15.04               013f3d01d247        6 days ago          131.4 MB
 ```
 

--- a/StandaloneChrome/Dockerfile
+++ b/StandaloneChrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome:2.52.0
+FROM selenium/node-chrome:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneChromeDebug/Dockerfile
+++ b/StandaloneChromeDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:2.52.0
+FROM selenium/standalone-chrome:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneFirefox/Dockerfile
+++ b/StandaloneFirefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-firefox:2.52.0
+FROM selenium/node-firefox:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneFirefoxDebug/Dockerfile
+++ b/StandaloneFirefoxDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-firefox:2.52.0
+FROM selenium/standalone-firefox:2.53.0
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/sa-test.sh
+++ b/sa-test.sh
@@ -13,7 +13,7 @@ function test_standalone {
   BROWSER=$1
   echo Starting Selenium standalone-$BROWSER$DEBUG container
 
-  SA=$(docker run -d selenium/standalone-$BROWSER$DEBUG:2.52.0)
+  SA=$(docker run -d selenium/standalone-$BROWSER$DEBUG:2.53.0)
   SA_NAME=$(docker inspect -f '{{ .Name  }}' $SA | sed s:/::)
   TEST_CMD="node smoke-$BROWSER.js"
 

--- a/test.sh
+++ b/test.sh
@@ -9,16 +9,16 @@ echo Building test container image
 docker build -t selenium/test:local ./Test
 
 echo 'Starting Selenium Hub Container...'
-HUB=$(docker run -d selenium/hub:2.52.0)
+HUB=$(docker run -d selenium/hub:2.53.0)
 HUB_NAME=$(docker inspect -f '{{ .Name  }}' $HUB | sed s:/::)
 echo 'Waiting for Hub to come online...'
 docker logs -f $HUB &
 sleep 2
 
 echo 'Starting Selenium Chrome node...'
-NODE_CHROME=$(docker run -d --link $HUB_NAME:hub  selenium/node-chrome$DEBUG:2.52.0)
+NODE_CHROME=$(docker run -d --link $HUB_NAME:hub  selenium/node-chrome$DEBUG:2.53.0)
 echo 'Starting Selenium Firefox node...'
-NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub selenium/node-firefox$DEBUG:2.52.0)
+NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub selenium/node-firefox$DEBUG:2.53.0)
 docker logs -f $NODE_CHROME &
 docker logs -f $NODE_FIREFOX &
 echo 'Waiting for nodes to register and come online...'


### PR DESCRIPTION
Supersedes https://github.com/SeleniumHQ/docker-selenium/pull/192. Despite passing on CircleCI building locally fails on some linux machines without using https for 'storage.googleapis.com'. 