### PR TITLE
Updated the apt sources to use "wily" (15.10) instead of "vivid" (15.04).

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -4,8 +4,8 @@ MAINTAINER Selenium <selenium-developers@googlegroups.com>
 #================================================
 # Customize sources for apt-get
 #================================================
-RUN  echo "deb http://archive.ubuntu.com/ubuntu vivid main universe\n" > /etc/apt/sources.list \
-  && echo "deb http://archive.ubuntu.com/ubuntu vivid-updates main universe\n" >> /etc/apt/sources.list
+RUN  echo "deb http://archive.ubuntu.com/ubuntu wily main universe\n" > /etc/apt/sources.list \
+  && echo "deb http://archive.ubuntu.com/ubuntu wily-updates main universe\n" >> /etc/apt/sources.list
 
 #========================
 # Miscellaneous packages


### PR DESCRIPTION
I ran into issues trying to install some stuff using apt-get, and it turned out to be because the sources file was still using sources for 15.04. I have verified that using the correct sources, the make command still builds all docker images successfully.