### PR TITLE
Add mp4 playback ability in firefox for html5

### DIFF
--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -18,6 +18,12 @@ RUN apt-get update -qqy \
   && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
   && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
 
+#=============================
+# Install mp4 video libraries
+#=============================
+RUN apt-get update -qqy \
+  && apt-get -qqy --no-install-recommends install gstreamer1.0-libav
+
 #========================
 # Selenium Configuration
 #========================

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -8,7 +8,9 @@ USER root
 #=========
 ENV FIREFOX_VERSION 45.0.2
 RUN apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install firefox \
+  && apt-get -qqy --no-install-recommends install \
+       gstreamer1.0-libav \
+       firefox \
   && rm -rf /var/lib/apt/lists/* \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
   && apt-get -y purge firefox \


### PR DESCRIPTION
## Problem
- Address inability to play mp4 video within html5 for firefox.
## Solution
- Add installation of the `gstreamer1.0-libav` and its subsequent dependencies for `NodeFirefox`.
## Testing
- [x] Build and launch a firefox container that connects to a Selenium Grid Hub container from this project.
- [x] Launch Selenium tests that required mp4 video playback capabilities. 
- [x] Tests Pass.

I could potentially roll this fix into the docker `RUN` command for firefox, but it was broken out for clarity.  If you would like me to include it within that call, please let me know.
