### PR TITLE
Seeing intermittent failures on restart of nodes due to a failure to …

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -32,6 +32,9 @@ fi
 # TODO: Look into http://www.seleniumhq.org/docs/05_selenium_rc.jsp#browser-side-logs
 
 SERVERNUM=$(get_server_num)
+
+rm -f /tmp/.X*lock
+
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \


### PR DESCRIPTION
…start xvfb.

The issue is documented here:

https://github.com/SeleniumHQ/docker-selenium/issues/91

Looks to be a problem with the lock files preventing a restart intermittently. Adding a line here to remove the lock files on startup.