### PR TITLE
Update to docker environment variable deprecation

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -10,7 +10,8 @@ if [ ! -e /opt/selenium/config.json ]; then
 fi
 
 # Can't check this anymore as the these environment variables are not supported by 
-# docker-compose v2 file
+# docker-compose v2 file or docker link itself
+# See https://docs.docker.com/compose/link-env-deprecated/
 #if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
 #  echo Not linked with a running Hub container 1>&2
 #  exit 1

--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -9,10 +9,12 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
-if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
-  echo Not linked with a running Hub container 1>&2
-  exit 1
-fi
+# Can't check this anymore as the these environment variables are not supported by 
+# docker-compose v2 file
+#if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
+#  echo Not linked with a running Hub container 1>&2
+#  exit 1
+#fi
 
 function shutdown {
   kill -s SIGTERM $NODE_PID
@@ -35,7 +37,7 @@ SERVERNUM=$(get_server_num)
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
-    -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
+    -hub http://hub:4444/grid/register \
     ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json \
     ${SE_OPTS} &


### PR DESCRIPTION
Now we can't check for environment variables for link. As they have been deprecated

https://docs.docker.com/compose/link-env-deprecated/
