### PR TITLE
Fix xvfb-run failure when environment variables with spaces exist

### DIFF
--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -20,12 +20,12 @@ rm -f /tmp/.X*lock
 SERVERNUM=$(get_server_num)
 env | cut -f 1 -d "=" | sort > asroot
 sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
-sudo -E -i -u seluser \
-  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
+sudo -E -i -u seluser bash -c "\
+  $(for E in $(grep -vxFf asseluser asroot); do echo $E="'$(eval echo \$$E)'"; done) \
   DISPLAY=$DISPLAY \
-  xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+  xvfb-run -n $SERVERNUM --server-args=\"-screen 0 $GEOMETRY -ac +extension RANDR\" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
-  ${SE_OPTS} &
+  ${SE_OPTS} &"
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT


### PR DESCRIPTION
## Description

There is a bug in the StandaloneDebug `entry_point.sh` that, when encountering an environment variable with a space in it's value, causes the `xvfb-run ...` step to fail. This is due to how the command inlines environment variables found in the root user's environment that  are not present in the seluser's environment into the `xvfb-run ...` step. 
## Notes
- Initially tried fixing the inline, but couldn't get the return codes to work with all the subshell slinging, so I opted for an environment file and simply sourcing it inline with the `xvfb-run ...`
- Thought using envdir instead instead, but opted for not adding packages and going at it in a more traditional way.
- Resolves #227
- The issue was originally introduced in https://github.com/SeleniumHQ/docker-selenium/pull/131
## How to reproduce

After adding an environment variable with a space, ie: `NO_PROXY="*.local, 10.254/16"` to my `docker run`, the error is immediately reproducible:

```
$ make standalone_chrome_debug
...
Successfully built 6a0b1ab25668

$ docker run -e NO_PROXY="*.local, 10.254/16" --rm selenium/standalone-chrome-debug:2.53.0 env
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin
HOSTNAME=6a00c5bf0dd2
NO_PROXY=*.local, 10.254/16
DEBIAN_FRONTEND=noninteractive
DEBCONF_NONINTERACTIVE_SEEN=true
TZ=US/Pacific
SCREEN_WIDTH=1360
SCREEN_HEIGHT=1020
SCREEN_DEPTH=24
DISPLAY=:99.0
CHROME_DRIVER_VERSION=2.21
DBUS_SESSION_BUS_ADDRESS=/dev/null
LANGUAGE=en_US.UTF-8
LANG=en_US.UTF-8
HOME=/root

$ docker run -e NO_PROXY="*.local, 10.254/16" --rm selenium/standalone-chrome-debug:2.53.0
Waiting xvfb...
-bash: 10.254/16: No such file or directory
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
Waiting xvfb...
```
## Testing

```
$ git checkout fix/xvfb-run_env_constructor
$ make standalone_chrome_debug
$ docker run -e NO_PROXY="*.local, 10.254/16" --rm selenium/standalone-chrome-debug:2.53.0
Waiting xvfb...
Failed to read: session.ignoreBorder
Setting default value
...
20/07/2016 15:03:47 screen setup finished.
20/07/2016 15:03:47

The VNC desktop is:      c5399f058668:0
...
<etc>
```
