### PR TITLE
Add support for Selenium 2.53.1 and Firefox 47.0.1

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -27,7 +27,9 @@ RUN apt-get update -qqy \
 # Selenium
 #==========
 RUN  mkdir -p /opt/selenium \
-  && wget --no-verbose https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar -O /opt/selenium/selenium-server-standalone.jar
+  && wget --no-verbose https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.0.jar -O /opt/selenium/selenium-server-standalone-2.53.0.jar \
+  && wget --no-verbose https://selenium-release.storage.googleapis.com/2.53/selenium-server-standalone-2.53.1.jar -O /opt/selenium/selenium-server-standalone-2.53.1.jar
+ENV SELENIUM_VERSION=2.53.1
 
 #========================================
 # Add normal user with passwordless sudo

--- a/Hub/Dockerfile
+++ b/Hub/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/base:2.53.0
+FROM selenium/base:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 #========================

--- a/Hub/entry_point.sh
+++ b/Hub/entry_point.sh
@@ -18,7 +18,7 @@ function shutdown {
     echo "shutdown complete"
 }
 
-java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   -role hub \
   -hubConfig $CONF \
   ${SE_OPTS} &

--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := selenium
-VERSION := $(or $(VERSION),$(VERSION),'2.53.0')
+VERSION := $(or $(VERSION),$(VERSION),'2.53.1')
 PLATFORM := $(shell uname -s)
 BUILD_ARGS := $(BUILD_ARGS)
 
@@ -85,17 +85,17 @@ firefox_debug: generate_firefox_debug firefox
 	cd ./NodeFirefoxDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox-debug:$(VERSION) .
 
 tag_latest:
-	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:latest
-	docker tag $(NAME)/hub:$(VERSION) $(NAME)/hub:latest
-	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:latest
-	docker tag $(NAME)/node-chrome:$(VERSION) $(NAME)/node-chrome:latest
-	docker tag $(NAME)/node-firefox:$(VERSION) $(NAME)/node-firefox:latest
-	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:latest
-	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:latest
-	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:latest
-	docker tag $(NAME)/standalone-firefox:$(VERSION) $(NAME)/standalone-firefox:latest
-	docker tag $(NAME)/standalone-chrome-debug:$(VERSION) $(NAME)/standalone-chrome-debug:latest
-	docker tag $(NAME)/standalone-firefox-debug:$(VERSION) $(NAME)/standalone-firefox-debug:latest
+	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:2.53.1
+	docker tag $(NAME)/hub:$(VERSION) $(NAME)/hub:2.53.1
+	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:2.53.1
+	docker tag $(NAME)/node-chrome:$(VERSION) $(NAME)/node-chrome:2.53.1
+	docker tag $(NAME)/node-firefox:$(VERSION) $(NAME)/node-firefox:2.53.1
+	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:2.53.1
+	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:2.53.1
+	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:2.53.1
+	docker tag $(NAME)/standalone-firefox:$(VERSION) $(NAME)/standalone-firefox:2.53.1
+	docker tag $(NAME)/standalone-chrome-debug:$(VERSION) $(NAME)/standalone-chrome-debug:2.53.1
+	docker tag $(NAME)/standalone-firefox-debug:$(VERSION) $(NAME)/standalone-firefox-debug:2.53.1
 
 release: tag_latest
 	@if ! docker images $(NAME)/base | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/base version $(VERSION) is not yet built. Please run 'make build'"; false; fi

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/base:2.53.0
+FROM selenium/base:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 ENV DEBIAN_FRONTEND noninteractive

--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -33,7 +33,7 @@ fi
 
 SERVERNUM=$(get_server_num)
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     ${REMOTE_HOST_PARAM} \

--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -25,6 +25,10 @@ if [ ! -z "$REMOTE_HOST" ]; then
   REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
 fi
 
+if [ ! -z "$FIREFOX_VERSION" ]; then
+  sudo ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-base:2.53.0
+FROM selenium/node-base:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeChromeDebug/Dockerfile
+++ b/NodeChromeDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome:2.53.0
+FROM selenium/node-chrome:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeChromeDebug/README.md
+++ b/NodeChromeDebug/README.md
@@ -38,7 +38,7 @@ If you are running Boot2Docker on Mac then you already have a [VNC client](http:
 When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
 
 ``` dockerfile
-FROM selenium/node-chrome-debug:2.53.0
+FROM selenium/node-chrome-debug:2.53.1
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -38,7 +38,7 @@ env | cut -f 1 -d "=" | sort > asroot
   $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     ${REMOTE_HOST_PARAM} \

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -25,6 +25,10 @@ if [ ! -z "$REMOTE_HOST" ]; then
   REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
 fi
 
+if [ ! -z "$FIREFOX_VERSION" ]; then
+  sudo ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi

--- a/NodeDebug/README.template.md
+++ b/NodeDebug/README.template.md
@@ -38,7 +38,7 @@ If you are running Boot2Docker on Mac then you already have a [VNC client](http:
 When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
 
 ``` dockerfile
-FROM selenium/##BASE##-debug:2.53.0
+FROM selenium/##BASE##-debug:2.53.1
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -6,17 +6,19 @@ USER root
 #=========
 # Firefox
 #=========
-ENV FIREFOX_VERSION 45.0.2
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* \
-  && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
-  && apt-get -y purge firefox \
-  && rm -rf /opt/firefox \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+  && apt-get -y purge firefox
+RUN wget --no-verbose -O /tmp/firefox-45.0.2.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/45.0.2/linux-x86_64/en-US/firefox-45.0.2.tar.bz2 \
+  && wget --no-verbose -O /tmp/firefox-46.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/46.0.1/linux-x86_64/en-US/firefox-46.0.1.tar.bz2 \
+  && wget --no-verbose -O /tmp/firefox-47.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/47.0.1/linux-x86_64/en-US/firefox-47.0.1.tar.bz2
+RUN mkdir -p /opt/firefox/45.0.2 && tar -C /opt/firefox/45.0.2 --strip-components 1 -xjf /tmp/firefox-45.0.2.tar.bz2 \
+  && mkdir -p /opt/firefox/46.0.1 && tar -C /opt/firefox/46.0.1 --strip-components 1 -xjf /tmp/firefox-46.0.1.tar.bz2 \
+  && mkdir -p /opt/firefox/47.0.1 && tar -C /opt/firefox/47.0.1 --strip-components 1 -xjf /tmp/firefox-47.0.1.tar.bz2 \
+  && rm /tmp/firefox-*.tar.bz2
+ENV FIREFOX_VERSION 47.0.1
+RUN ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
 
 #========================
 # Selenium Configuration

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -10,15 +10,14 @@ RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get -y purge firefox
-RUN wget --no-verbose -O /tmp/firefox-45.0.2.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/45.0.2/linux-x86_64/en-US/firefox-45.0.2.tar.bz2 \
-  && wget --no-verbose -O /tmp/firefox-46.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/46.0.1/linux-x86_64/en-US/firefox-46.0.1.tar.bz2 \
-  && wget --no-verbose -O /tmp/firefox-47.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/47.0.1/linux-x86_64/en-US/firefox-47.0.1.tar.bz2
-RUN mkdir -p /opt/firefox/45.0.2 && tar -C /opt/firefox/45.0.2 --strip-components 1 -xjf /tmp/firefox-45.0.2.tar.bz2 \
-  && mkdir -p /opt/firefox/46.0.1 && tar -C /opt/firefox/46.0.1 --strip-components 1 -xjf /tmp/firefox-46.0.1.tar.bz2 \
-  && mkdir -p /opt/firefox/47.0.1 && tar -C /opt/firefox/47.0.1 --strip-components 1 -xjf /tmp/firefox-47.0.1.tar.bz2 \
-  && rm /tmp/firefox-*.tar.bz2
 ENV FIREFOX_VERSION 47.0.1
-RUN ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+RUN for VERSION in 47.0.1 46.0.1 45.0.2; do \
+    wget --no-verbose -O /tmp/firefox-$VERSION.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-x86_64/en-US/firefox-$VERSION.tar.bz2 \
+    && mkdir -p /opt/firefox/$VERSION \
+    && tar -C /opt/firefox/$VERSION --strip-components 1 -xjf /tmp/firefox-$VERSION.tar.bz2 \
+    && rm /tmp/firefox-$VERSION.tar.bz2 \
+  ;done
+RUN ln -fs /opt/firefox/$FIREFOX_VERSION/firefox /usr/bin/firefox
 
 #========================
 # Selenium Configuration

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-base:2.53.0
+FROM selenium/node-base:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -9,15 +9,14 @@ RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* \
   && apt-get -y purge firefox
-RUN wget --no-verbose -O /tmp/firefox-45.0.2.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/45.0.2/linux-x86_64/en-US/firefox-45.0.2.tar.bz2 \
-  && wget --no-verbose -O /tmp/firefox-46.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/46.0.1/linux-x86_64/en-US/firefox-46.0.1.tar.bz2 \
-  && wget --no-verbose -O /tmp/firefox-47.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/47.0.1/linux-x86_64/en-US/firefox-47.0.1.tar.bz2
-RUN mkdir -p /opt/firefox/45.0.2 && tar -C /opt/firefox/45.0.2 --strip-components 1 -xjf /tmp/firefox-45.0.2.tar.bz2 \
-  && mkdir -p /opt/firefox/46.0.1 && tar -C /opt/firefox/46.0.1 --strip-components 1 -xjf /tmp/firefox-46.0.1.tar.bz2 \
-  && mkdir -p /opt/firefox/47.0.1 && tar -C /opt/firefox/47.0.1 --strip-components 1 -xjf /tmp/firefox-47.0.1.tar.bz2 \
-  && rm /tmp/firefox-*.tar.bz2
 ENV FIREFOX_VERSION 47.0.1
-RUN ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+RUN for VERSION in 47.0.1 46.0.1 45.0.2; do \
+    wget --no-verbose -O /tmp/firefox-$VERSION.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$VERSION/linux-x86_64/en-US/firefox-$VERSION.tar.bz2 \
+    && mkdir -p /opt/firefox/$VERSION \
+    && tar -C /opt/firefox/$VERSION --strip-components 1 -xjf /tmp/firefox-$VERSION.tar.bz2 \
+    && rm /tmp/firefox-$VERSION.tar.bz2 \
+  ;done
+RUN ln -fs /opt/firefox/$FIREFOX_VERSION/firefox /usr/bin/firefox
 
 #========================
 # Selenium Configuration

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -5,17 +5,19 @@ USER root
 #=========
 # Firefox
 #=========
-ENV FIREFOX_VERSION 45.0.2
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* \
-  && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
-  && apt-get -y purge firefox \
-  && rm -rf /opt/firefox \
-  && tar -C /opt -xjf /tmp/firefox.tar.bz2 \
-  && rm /tmp/firefox.tar.bz2 \
-  && mv /opt/firefox /opt/firefox-$FIREFOX_VERSION \
-  && ln -fs /opt/firefox-$FIREFOX_VERSION/firefox /usr/bin/firefox
+  && apt-get -y purge firefox
+RUN wget --no-verbose -O /tmp/firefox-45.0.2.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/45.0.2/linux-x86_64/en-US/firefox-45.0.2.tar.bz2 \
+  && wget --no-verbose -O /tmp/firefox-46.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/46.0.1/linux-x86_64/en-US/firefox-46.0.1.tar.bz2 \
+  && wget --no-verbose -O /tmp/firefox-47.0.1.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/47.0.1/linux-x86_64/en-US/firefox-47.0.1.tar.bz2
+RUN mkdir -p /opt/firefox/45.0.2 && tar -C /opt/firefox/45.0.2 --strip-components 1 -xjf /tmp/firefox-45.0.2.tar.bz2 \
+  && mkdir -p /opt/firefox/46.0.1 && tar -C /opt/firefox/46.0.1 --strip-components 1 -xjf /tmp/firefox-46.0.1.tar.bz2 \
+  && mkdir -p /opt/firefox/47.0.1 && tar -C /opt/firefox/47.0.1 --strip-components 1 -xjf /tmp/firefox-47.0.1.tar.bz2 \
+  && rm /tmp/firefox-*.tar.bz2
+ENV FIREFOX_VERSION 47.0.1
+RUN ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
 
 #========================
 # Selenium Configuration

--- a/NodeFirefoxDebug/Dockerfile
+++ b/NodeFirefoxDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-firefox:2.53.0
+FROM selenium/node-firefox:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/NodeFirefoxDebug/README.md
+++ b/NodeFirefoxDebug/README.md
@@ -38,7 +38,7 @@ If you are running Boot2Docker on Mac then you already have a [VNC client](http:
 When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
 
 ``` dockerfile
-FROM selenium/node-firefox-debug:2.53.0
+FROM selenium/node-firefox-debug:2.53.1
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -38,7 +38,7 @@ env | cut -f 1 -d "=" | sort > asroot
   $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
     -role node \
     -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
     ${REMOTE_HOST_PARAM} \

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -25,6 +25,10 @@ if [ ! -z "$REMOTE_HOST" ]; then
   REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
 fi
 
+if [ ! -z "$FIREFOX_VERSION" ]; then
+  sudo ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi

--- a/README.md
+++ b/README.md
@@ -62,12 +62,13 @@ By default the latest stable versions will be used, however you can override
 these using the following environment variables:
 
 - `SELENIUM_VERSION` - version of the Selenium server
+- `FIREFOX_VERSION` - version of Firefox (only applies to Firefox images)
 
-For example, the following will start a standalone Firefox server using
-Selenium 2.53.0:
+For example, the following will start a standalone server using Selenium 2.53.0
+and Firefox 45.0.2:
 
 ```bash
-$ docker run -d -p 4444:4444 -e SELENIUM_VERSION=2.53.0 selenium/standalone-firefox:2.53.1
+$ docker run -d -p 4444:4444 -e SELENIUM_VERSION=2.53.0 -e FIREFOX_VERSION=45.0.2 selenium/standalone-firefox:2.53.1
 ```
 
 ### JAVA_OPTS Java Environment Options

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ Images included:
 When executing docker run for an image with chrome browser please add volume mount `-v /dev/shm:/dev/shm` to use the host's shared memory.
 
 ``` bash
-$ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.53.0
+$ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-chrome:2.53.1
 ```
 
 This is a workaround to node-chrome crash in docker container issue: https://code.google.com/p/chromium/issues/detail?id=519952 
@@ -34,9 +34,9 @@ This is a workaround to node-chrome crash in docker container issue: https://cod
 ### Standalone Chrome and Firefox
 
 ``` bash
-$ docker run -d -p 4444:4444 selenium/standalone-chrome:2.53.0
+$ docker run -d -p 4444:4444 selenium/standalone-chrome:2.53.1
 # OR
-$ docker run -d -p 4444:4444 selenium/standalone-firefox:2.53.0
+$ docker run -d -p 4444:4444 selenium/standalone-firefox:2.53.1
 ```
 
 _Note: Only one standalone image can run on port_ `4444` _at a time._
@@ -46,14 +46,28 @@ To inspect visually what the browser is doing use the `standalone-chrome-debug` 
 ### Selenium Grid Hub
 
 ``` bash
-$ docker run -d -p 4444:4444 --name selenium-hub selenium/hub:2.53.0
+$ docker run -d -p 4444:4444 --name selenium-hub selenium/hub:2.53.1
 ```
 
 ### Chrome and Firefox Grid Nodes
 
 ``` bash
-$ docker run -d --link selenium-hub:hub selenium/node-chrome:2.53.0
-$ docker run -d --link selenium-hub:hub selenium/node-firefox:2.53.0
+$ docker run -d --link selenium-hub:hub selenium/node-chrome:2.53.1
+$ docker run -d --link selenium-hub:hub selenium/node-firefox:2.53.1
+```
+
+### Specifying versions
+
+By default the latest stable versions will be used, however you can override
+these using the following environment variables:
+
+- `SELENIUM_VERSION` - version of the Selenium server
+
+For example, the following will start a standalone Firefox server using
+Selenium 2.53.0:
+
+```bash
+$ docker run -d -p 4444:4444 -e SELENIUM_VERSION=2.53.0 selenium/standalone-firefox:2.53.1
 ```
 
 ### JAVA_OPTS Java Environment Options
@@ -61,7 +75,7 @@ $ docker run -d --link selenium-hub:hub selenium/node-firefox:2.53.0
 You can pass `JAVA_OPTS` environment variable to java process.
 
 ``` bash
-$ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/hub:2.53.0
+$ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/hub:2.53.1
 ```
 
 ### SE_OPTS Selenium Configuration Options
@@ -69,7 +83,7 @@ $ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/
 You can pass `SE_OPTS` variable with additional commandline parameters for starting a hub or a node.
 
 ``` bash
-$ docker run -d -p 4444:4444 -e SE_OPTS=-debug --name selenium-hub selenium/hub:2.53.0
+$ docker run -d -p 4444:4444 -e SE_OPTS=-debug --name selenium-hub selenium/hub:2.53.1
 ```
 
 ## Building the images
@@ -99,10 +113,10 @@ _Note: Omitting_ `VERSION=local` _will build the images with the current version
 ##### Example: Spawn a container for testing in Chrome:
 
 ``` bash
-$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.53.0
+$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.53.1
 $ CH=$(docker run --rm --name=ch \
     --link selenium-hub:hub -v /e2e/uploads:/e2e/uploads \
-    selenium/node-chrome:2.53.0)
+    selenium/node-chrome:2.53.1)
 ```
 
 _Note:_ `-v /e2e/uploads:/e2e/uploads` _is optional in case you are testing browser uploads on your web app you will probably need to share a directory for this._
@@ -112,10 +126,10 @@ _Note:_ `-v /e2e/uploads:/e2e/uploads` _is optional in case you are testing brow
 This command line is the same as for Chrome. Remember that the Selenium running container is able to launch either Chrome or Firefox, the idea around having 2 separate containers, one for each browser is for convenience plus avoiding certain `:focus` issues your web app may encounter during end-to-end test automation.
 
 ``` bash
-$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.53.0
+$ docker run -d --name selenium-hub -p 4444:4444 selenium/hub:2.53.1
 $ FF=$(docker run --rm --name=fx \
     --link selenium-hub:hub -v /e2e/uploads:/e2e/uploads \
-    selenium/node-firefox:2.53.0)
+    selenium/node-firefox:2.53.1)
 ```
 
 _Note: Since a Docker container is not meant to preserve state and spawning a new one takes less than 3 seconds you will likely want to remove containers after each end-to-end test with_ `--rm` _command. You need to think of your Docker containers as single processes, not as running virtual machines, in case you are familiar with [Vagrant](https://www.vagrantup.com/)._
@@ -124,28 +138,28 @@ _Note: Since a Docker container is not meant to preserve state and spawning a ne
 
 In the event you wish to visually see what the browser is doing you will want to run the `debug` variant of node or standalone images (substitute a free port that you wish to connect to on VNC for <port4VNC>; 5900 is fine if it is free, but of course you can only run one node on that port):
 ``` bash
-$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-chrome-debug:2.53.0
-$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-firefox-debug:2.53.0
+$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-chrome-debug:2.53.1
+$ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-firefox-debug:2.53.1
 ```
 e.g.:
 ``` bash
-$ docker run -d -P -p 5900:5900 --link selenium-hub:hub selenium/node-chrome-debug:2.53.0
-$ docker run -d -P -p 5901:5900 --link selenium-hub:hub selenium/node-firefox-debug:2.53.0
+$ docker run -d -P -p 5900:5900 --link selenium-hub:hub selenium/node-chrome-debug:2.53.1
+$ docker run -d -P -p 5901:5900 --link selenium-hub:hub selenium/node-firefox-debug:2.53.1
 ```
 
 to connect to the Chrome node on 5900 and the Firefox node on 5901 (assuming those node are free, and reachable).
 
-And for standalone: 
+And for standalone:
 ``` bash
-$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-chrome-debug:2.53.0
+$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-chrome-debug:2.53.1
 # OR
-$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-firefox-debug:2.53.0
+$ docker run -d -p 4444:4444 -p <port4VNC>:5900 selenium/standalone-firefox-debug:2.53.1
 ```
 or
 ``` bash
-$ docker run -d -p 4444:4444 -p 5900:5900 selenium/standalone-chrome-debug:2.53.0
+$ docker run -d -p 4444:4444 -p 5900:5900 selenium/standalone-chrome-debug:2.53.1
 # OR
-$ docker run -d -p 4444:4444 -p 5901:5900 selenium/standalone-firefox-debug:2.53.0
+$ docker run -d -p 4444:4444 -p 5901:5900 selenium/standalone-firefox-debug:2.53.1
 ```
 
 You can acquire the port that the VNC server is exposed to by running:
@@ -163,8 +177,8 @@ If you are running [Boot2Docker](https://docs.docker.com/installation/mac/) on O
 
 When you are prompted for the password it is `secret`. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a Docker image that derives from the posted ones which reconfigures it:
 ``` dockerfile
-#FROM selenium/node-chrome-debug:2.53.0
-#FROM selenium/node-firefox-debug:2.53.0
+#FROM selenium/node-chrome-debug:2.53.1
+#FROM selenium/node-firefox-debug:2.53.1
 #Choose the FROM statement that works for you.
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
@@ -176,11 +190,11 @@ RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 $ docker images
 #=>
 REPOSITORY                      TAG                 IMAGE ID            CREATED             VIRTUAL SIZE
-selenium/node-firefox           2.53.0              69f762d0d79e        29 minutes ago      552.1 MB
-selenium/node-chrome            2.53.0              9dd73160660b        30 minutes ago      723.6 MB
-selenium/node-base              2.53.0              1b7a0b7024b1        32 minutes ago      426.1 MB
-selenium/hub                    2.53.0              2570bbb98229        33 minutes ago      394.4 MB
-selenium/base                   2.53.0              33478d455dab        33 minutes ago      362.6 MB
+selenium/node-firefox           2.53.1              69f762d0d79e        29 minutes ago      552.1 MB
+selenium/node-chrome            2.53.1              9dd73160660b        30 minutes ago      723.6 MB
+selenium/node-base              2.53.1              1b7a0b7024b1        32 minutes ago      426.1 MB
+selenium/hub                    2.53.1              2570bbb98229        33 minutes ago      394.4 MB
+selenium/base                   2.53.1              33478d455dab        33 minutes ago      362.6 MB
 ubuntu                          16.04               0b7735b9290f        6 days ago          123.7 MB
 ```
 

--- a/Standalone/entry_point.sh
+++ b/Standalone/entry_point.sh
@@ -15,7 +15,7 @@ fi
 
 SERVERNUM=$(get_server_num)
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   ${SE_OPTS} &
 NODE_PID=$!
 

--- a/Standalone/entry_point.sh
+++ b/Standalone/entry_point.sh
@@ -9,6 +9,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+if [ ! -z "$FIREFOX_VERSION" ]; then
+  sudo ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi

--- a/StandaloneChrome/Dockerfile
+++ b/StandaloneChrome/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-chrome:2.53.0
+FROM selenium/node-chrome:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneChrome/entry_point.sh
+++ b/StandaloneChrome/entry_point.sh
@@ -15,7 +15,7 @@ fi
 
 SERVERNUM=$(get_server_num)
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   ${SE_OPTS} &
 NODE_PID=$!
 

--- a/StandaloneChrome/entry_point.sh
+++ b/StandaloneChrome/entry_point.sh
@@ -9,6 +9,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+if [ ! -z "$FIREFOX_VERSION" ]; then
+  sudo ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi

--- a/StandaloneChromeDebug/Dockerfile
+++ b/StandaloneChromeDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-chrome:2.53.0
+FROM selenium/standalone-chrome:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneChromeDebug/entry_point.sh
+++ b/StandaloneChromeDebug/entry_point.sh
@@ -21,7 +21,7 @@ sudo -E -i -u seluser \
   $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   ${SE_OPTS} &
 NODE_PID=$!
 

--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -20,7 +20,7 @@ sudo -E -i -u seluser \
   $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   ${SE_OPTS} &
 NODE_PID=$!
 

--- a/StandaloneFirefox/Dockerfile
+++ b/StandaloneFirefox/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/node-firefox:2.53.0
+FROM selenium/node-firefox:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneFirefox/entry_point.sh
+++ b/StandaloneFirefox/entry_point.sh
@@ -15,7 +15,7 @@ fi
 
 SERVERNUM=$(get_server_num)
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   ${SE_OPTS} &
 NODE_PID=$!
 

--- a/StandaloneFirefox/entry_point.sh
+++ b/StandaloneFirefox/entry_point.sh
@@ -9,6 +9,10 @@ function shutdown {
   wait $NODE_PID
 }
 
+if [ ! -z "$FIREFOX_VERSION" ]; then
+  sudo ln -fs /opt/firefox/${FIREFOX_VERSION}/firefox /usr/bin/firefox
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi

--- a/StandaloneFirefoxDebug/Dockerfile
+++ b/StandaloneFirefoxDebug/Dockerfile
@@ -1,4 +1,4 @@
-FROM selenium/standalone-firefox:2.53.0
+FROM selenium/standalone-firefox:2.53.1
 MAINTAINER Selenium <selenium-developers@googlegroups.com>
 
 USER root

--- a/StandaloneFirefoxDebug/entry_point.sh
+++ b/StandaloneFirefoxDebug/entry_point.sh
@@ -20,7 +20,7 @@ sudo -E -i -u seluser \
   $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
-  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+  java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone-${SELENIUM_VERSION}.jar \
   ${SE_OPTS} &
 NODE_PID=$!
 

--- a/sa-test.sh
+++ b/sa-test.sh
@@ -13,7 +13,7 @@ function test_standalone {
   BROWSER=$1
   echo Starting Selenium standalone-$BROWSER$DEBUG container
 
-  SA=$(docker run -d selenium/standalone-$BROWSER$DEBUG:2.53.0)
+  SA=$(docker run -d selenium/standalone-$BROWSER$DEBUG:2.53.1)
   SA_NAME=$(docker inspect -f '{{ .Name  }}' $SA | sed s:/::)
   TEST_CMD="node smoke-$BROWSER.js"
 

--- a/test.sh
+++ b/test.sh
@@ -23,16 +23,16 @@ echo Building test container image
 docker build -t selenium/test:local ./Test
 
 echo 'Starting Selenium Hub Container...'
-HUB=$(docker run -d selenium/hub:2.53.0)
+HUB=$(docker run -d selenium/hub:2.53.1)
 HUB_NAME=$(docker inspect -f '{{ .Name  }}' $HUB | sed s:/::)
 echo 'Waiting for Hub to come online...'
 docker logs -f $HUB &
 sleep 2
 
 echo 'Starting Selenium Chrome node...'
-NODE_CHROME=$(docker run -d --link $HUB_NAME:hub  selenium/node-chrome$DEBUG:2.53.0)
+NODE_CHROME=$(docker run -d --link $HUB_NAME:hub  selenium/node-chrome$DEBUG:2.53.1)
 echo 'Starting Selenium Firefox node...'
-NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub selenium/node-firefox$DEBUG:2.53.0)
+NODE_FIREFOX=$(docker run -d --link $HUB_NAME:hub selenium/node-firefox$DEBUG:2.53.1)
 docker logs -f $NODE_CHROME &
 docker logs -f $NODE_FIREFOX &
 echo 'Waiting for nodes to register and come online...'


### PR DESCRIPTION
This adds support for Selenium 2.53.1 and Firefox 47.0.1 in addition to making them the default versions, however I have also introduced an environment variable for each to allow users to opt for previous versions. This will allow us to introduce beta versions that will not be the defaults, and will also offer the ability to workaround compatibility issues between the various dependencies.

This essentially makes #226 and #250 obsolete (except for the ChromeDriver update, but that was also taken care of in #234).