### PR TITLE
Update ChromeDriver to version 2.24

### DIFF
--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -24,7 +24,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ENV CHROME_DRIVER_VERSION 2.23
+ENV CHROME_DRIVER_VERSION 2.24
 RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \


### PR DESCRIPTION
Chrome 53 with ChromeDriver 2.23 has issues where typing TAB in a text input would insert the tab character (\t) instead of stepping to the next form element, see bug https://bugs.chromium.org/p/chromedriver/issues/detail?id=1484. This has been resolved in ChromeDriver 2.24, so update to that latest version.