### PR TITLE
Update chromedriver to 2.24

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,5 @@
 NAME := selenium
-VERSION := $(or $(VERSION),$(VERSION),'2.53.1')
+VERSION := $(or $(VERSION),$(VERSION),'2.53.1.chromedriver224')
 PLATFORM := $(shell uname -s)
 BUILD_ARGS := $(BUILD_ARGS)
 

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -24,7 +24,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ENV CHROME_DRIVER_VERSION 2.23
+ENV CHROME_DRIVER_VERSION 2.24
 RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \


### PR DESCRIPTION
This fixes some bugs and matches vagrant, so 2.24 is the way to go.