### PR TITLE
Change FIREFOX_VERSION from ENV to ARG + apt cache clean

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get update -qqy \
     sudo \
     unzip \
     wget \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && sed -i 's/securerandom\.source=file:\/dev\/random/securerandom\.source=file:\/dev\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
 
 #==========

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -17,7 +17,7 @@ RUN echo "${TZ}" > /etc/timezone \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     xvfb \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================
 # Scripts to run Selenium Node

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -19,7 +19,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get -qqy install \
     ${CHROME_VERSION:-google-chrome-stable} \
   && rm /etc/apt/sources.list.d/google-chrome.list \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==================
 # Chrome webdriver

--- a/NodeChromeDebug/Dockerfile
+++ b/NodeChromeDebug/Dockerfile
@@ -13,7 +13,7 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -27,7 +27,7 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=======
 # Fonts
@@ -39,7 +39,7 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=========
 # fluxbox
@@ -48,7 +48,7 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================
 # Scripts to run Selenium Node

--- a/NodeDebug/Dockerfile.txt
+++ b/NodeDebug/Dockerfile.txt
@@ -8,7 +8,7 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -22,7 +22,7 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=======
 # Fonts
@@ -34,7 +34,7 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=========
 # fluxbox
@@ -43,7 +43,7 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================
 # Scripts to run Selenium Node

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -5,7 +5,7 @@ USER root
 #=========
 # Firefox
 #=========
-ENV FIREFOX_VERSION 47.0.1
+ARG FIREFOX_VERSION=47.0.1
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* \
@@ -20,7 +20,7 @@ RUN apt-get update -qqy \
 #============
 # GeckoDriver
 #============
-ENV GECKODRIVER_VERSION 0.10.0
+ARG GECKODRIVER_VERSION=0.10.0
 RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -8,7 +8,7 @@ USER root
 ARG FIREFOX_VERSION=47.0.1
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
   && apt-get -y purge firefox \
   && rm -rf /opt/firefox \

--- a/NodeFirefoxDebug/Dockerfile.txt
+++ b/NodeFirefoxDebug/Dockerfile.txt
@@ -9,7 +9,7 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -23,7 +23,7 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=======
 # Fonts
@@ -35,7 +35,7 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=========
 # fluxbox
@@ -44,7 +44,7 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================
 # Scripts to run Selenium Node

--- a/StandaloneChromeDebug/Dockerfile
+++ b/StandaloneChromeDebug/Dockerfile
@@ -13,7 +13,7 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -27,7 +27,7 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=======
 # Fonts
@@ -39,7 +39,7 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=========
 # fluxbox
@@ -48,7 +48,7 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================
 # Scripts to run Selenium Node

--- a/StandaloneFirefoxDebug/Dockerfile
+++ b/StandaloneFirefoxDebug/Dockerfile
@@ -13,7 +13,7 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -27,7 +27,7 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=======
 # Fonts
@@ -39,7 +39,7 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=========
 # fluxbox
@@ -48,7 +48,7 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/*
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================
 # Scripts to run Selenium Node


### PR DESCRIPTION
As FIREFOX_VERSION seems to be used only at build, it should be an ARG to not be confused with env variables. This modification was done for chrome image but not for firefox one.