### PR TITLE
Clear the X server lock in the standalone images

### DIFF
--- a/Standalone/entry_point.sh
+++ b/Standalone/entry_point.sh
@@ -14,6 +14,9 @@ if [ ! -z "$SE_OPTS" ]; then
 fi
 
 SERVERNUM=$(get_server_num)
+
+rm -f /tmp/.X*lock
+
 xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
   ${SE_OPTS} &


### PR DESCRIPTION
This mirrors the fix in #230 into the `entry_point.sh` for the standalone images. `make generate_all` needs to be redone.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

