### PR TITLE
Upgrade to GeckoDriver 0.11.1

### DIFF
--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -20,15 +20,14 @@ RUN apt-get update -qqy \
 #============
 # GeckoDriver
 #============
-ARG GECKODRIVER_VERSION=0.10.0
+ARG GECKODRIVER_VERSION=0.11.1
 RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geckodriver/releases/download/v$GECKODRIVER_VERSION/geckodriver-v$GECKODRIVER_VERSION-linux64.tar.gz \
   && rm -rf /opt/geckodriver \
   && tar -C /opt -zxf /tmp/geckodriver.tar.gz \
   && rm /tmp/geckodriver.tar.gz \
   && mv /opt/geckodriver /opt/geckodriver-$GECKODRIVER_VERSION \
   && chmod 755 /opt/geckodriver-$GECKODRIVER_VERSION \
-  && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver \
-  && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/wires
+  && ln -fs /opt/geckodriver-$GECKODRIVER_VERSION /usr/bin/geckodriver
 
 #========================
 # Selenium Configuration


### PR DESCRIPTION
Use latest version of GeckoDriver, which contains bugfixes. Also, we no longer need the 'wires' binary to be present.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

