### PR TITLE
Handle environment vars. with space properly

### DIFF
--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -18,10 +18,14 @@ fi
 rm -f /tmp/.X*lock
 
 SERVERNUM=$(get_server_num)
-env | cut -f 1 -d "=" | sort > asroot
-sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
+
+env | sort -k 1 -t '=' > asroot
+sudo -E -u seluser -i env | sort -k 1 -t '=' > asseluser
+
+# The .bash_aliases file will run when starting xvfb with the seluser below
+join -v 1 -j 1 -t '=' --nocheck-order asroot asseluser > /home/seluser/.bash_aliases
+
 sudo -E -i -u seluser \
-  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

If you have this environment variable:

`no_proxy=*.local, 169.254/16`

it is very hard to get the quoting correct. It is easier to just write
the correct entries to the seluser's .bash_aliases file, which will be
included by .bashrc when running xvfb-run as the seluser.