### PR TITLE
Update Firefox to version 50.0

### DIFF
--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -5,7 +5,7 @@ USER root
 #=========
 # Firefox
 #=========
-ARG FIREFOX_VERSION=49.0.1
+ARG FIREFOX_VERSION=50.0
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Updates NodeFirefox to use Firefox 50.0, which fixes a number of bugs when using Marionette.

