### PR TITLE
add chinese font in base contaimer

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -20,6 +20,7 @@ RUN apt-get update -qqy \
     sudo \
     unzip \
     wget \
+    fonts-noto-cjk \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && sed -i 's/securerandom\.source=file:\/dev\/random/securerandom\.source=file:\/dev\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
 


### PR DESCRIPTION
The screenshots in selenium chrome node shows that Chinese characters display with square boxes. Install Chinese font could solve the problem.

