### PR TITLE
Allow X11 forwarding

### DIFF
--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -22,6 +22,7 @@ RUN echo "${TZ}" > /etc/timezone \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     xvfb \
+    x11-xserver-utils \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================

--- a/StandaloneChrome/entry_point.sh
+++ b/StandaloneChrome/entry_point.sh
@@ -17,9 +17,15 @@ SERVERNUM=$(get_server_num)
 
 rm -f /tmp/.X*lock
 
-xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+# Use xvfb only if there is not an x server running already
+if xset q &>/dev/null; then
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
-  ${SE_OPTS} &
+    ${SE_OPTS} &
+else
+  xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+    java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+    ${SE_OPTS} &
+fi
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT

--- a/StandaloneFirefox/entry_point.sh
+++ b/StandaloneFirefox/entry_point.sh
@@ -17,9 +17,15 @@ SERVERNUM=$(get_server_num)
 
 rm -f /tmp/.X*lock
 
-xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+# Use xvfb only if there is not an x server running already
+if xset q &>/dev/null; then
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
-  ${SE_OPTS} &
+    ${SE_OPTS} &
+else
+  xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+    java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+    ${SE_OPTS} &
+fi
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Running the browser inside xvfb by default prevents users from
forwarding their hosts' X socket to the container. When attempting to
run:

`docker run -e -e DISPLAY=$DISPLAY -v /tmp/.X11-unix:/tmp/.X11-unix selenium/standalone-chrome`

Here, we only run inside xvfb after checking whether there is not an
existing X server. Adds the `x11-xserver-utils` package to the NodeBase
image, used for that query.