### PR TITLE
Moving port assignment to environment variable to allow for assignment

### DIFF
--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -44,6 +44,7 @@ RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.stor
 ENV NODE_MAX_INSTANCES 1
 ENV NODE_MAX_SESSION 1
 ENV NODE_REGISTER_CYCLE 5000
+ENV NODE_PORT 5555
 COPY generate_config /opt/selenium/generate_config
 RUN chmod +x /opt/selenium/generate_config
 

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -39,6 +39,7 @@ RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.stor
 ENV NODE_MAX_INSTANCES 1
 ENV NODE_MAX_SESSION 1
 ENV NODE_REGISTER_CYCLE 5000
+ENV NODE_PORT 5555
 COPY generate_config /opt/selenium/generate_config
 RUN chmod +x /opt/selenium/generate_config
 

--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -11,7 +11,7 @@ echo "
   ],
   \"proxy\": \"org.openqa.grid.selenium.proxy.DefaultRemoteProxy\",
   \"maxSession\": $NODE_MAX_SESSION,
-  \"port\": 5555,
+  \"port\": $NODE_PORT,
   \"register\": true,
   \"registerCycle\": $NODE_REGISTER_CYCLE
 }" 

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -40,6 +40,7 @@ RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geck
 ENV NODE_MAX_INSTANCES 1
 ENV NODE_MAX_SESSION 1
 ENV NODE_REGISTER_CYCLE 5000
+ENV NODE_PORT 5555
 COPY generate_config /opt/selenium/generate_config
 RUN chmod +x /opt/selenium/generate_config \
   && chown -R seluser:seluser /opt/selenium

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -35,6 +35,7 @@ RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geck
 ENV NODE_MAX_INSTANCES 1
 ENV NODE_MAX_SESSION 1
 ENV NODE_REGISTER_CYCLE 5000
+ENV NODE_PORT 5555
 COPY generate_config /opt/selenium/generate_config
 RUN chmod +x /opt/selenium/generate_config \
   && chown -R seluser:seluser /opt/selenium

--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -11,7 +11,7 @@ echo "
   ],
   \"proxy\": \"org.openqa.grid.selenium.proxy.DefaultRemoteProxy\",
   \"maxSession\": $NODE_MAX_SESSION,
-  \"port\": 5555,
+  \"port\": $NODE_PORT,
   \"register\": true,
   \"registerCycle\": $NODE_REGISTER_CYCLE
 }" 


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

This PR will allow the selenium nodes to be run from marathon/mesos. Before you were unable to assign the port at the proper time when the container was being built. This way allows the dynamically assigned port from mesos to be assigned to the node container.

This has been tested in marathon and I am able to scale the nodes as needed when using a docker image built with this configuration. An example marathon definition file can be provided to show how this works if needed.

This is a better way of doing the fix described in this PR that is currently open:
https://github.com/SeleniumHQ/docker-selenium/pull/104