### PR TITLE
add “version” property to the capabilities object in generate_config …

### DIFF
--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -1,9 +1,11 @@
 #!/bin/bash
+CHROME_VERSION=$( sudo dpkg -s google-chrome-stable | grep Version | cut -d " " -f 2 | cut -d "-" -f 1 )
 
 echo "
 {
   \"capabilities\": [
     {
+      \"version\": \"$CHROME_VERSION\",
       \"browserName\": \"chrome\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
       \"seleniumProtocol\": \"WebDriver\"

--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -1,11 +1,10 @@
 #!/bin/bash
-CHROME_VERSION=$( sudo dpkg -s google-chrome-stable | grep Version | cut -d " " -f 2 | cut -d "-" -f 1 )
+#CHROME_VERSION=$( sudo dpkg -s google-chrome-stable | grep Version | cut -d " " -f 2 | cut -d "-" -f 1 )
 
 echo "
 {
   \"capabilities\": [
     {
-      \"version\": \"$CHROME_VERSION\",
       \"browserName\": \"chrome\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
       \"seleniumProtocol\": \"WebDriver\"

--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -1,12 +1,11 @@
 #!/bin/bash
 
-FIREFOX_VERSION=$( firefox -version | cut -d " " -f 3 )
+#FIREFOX_VERSION=$( firefox -version | cut -d " " -f 3 )
 
 echo "
 {
   \"capabilities\": [
     {
-      \"version\": \"$FIREFOX_VERSION\",
       \"browserName\": \"firefox\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
       \"seleniumProtocol\": \"WebDriver\"

--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+FIREFOX_VERSION=$( firefox -version | cut -d " " -f 3 )
+
 echo "
 {
   \"capabilities\": [
     {
+      \"version\": \"$FIREFOX_VERSION\",
       \"browserName\": \"firefox\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
       \"seleniumProtocol\": \"WebDriver\"
@@ -14,5 +17,5 @@ echo "
   \"port\": 5555,
   \"register\": true,
   \"registerCycle\": $NODE_REGISTER_CYCLE
-}" 
+}"
 


### PR DESCRIPTION
Add a version property to the capabilities in the generated json config for nodes.

I think it makes sense to add the version property. It is a standard capability property and will be helpful for instance if a selenium grid is set up with multiple versions of the same browser (support version based capability matching).


- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
