### PR TITLE
add “version” property to capabilities object in generate_config

### DIFF
--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+CHROME_VERSION=$( sudo dpkg -s google-chrome-stable | grep Version | cut -d " " -f 2 | cut -d "-" -f 1 )
+
 echo "
 {
   \"capabilities\": [
     {
+      \"version\": \"$CHROME_VERSION\",
       \"browserName\": \"chrome\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
       \"seleniumProtocol\": \"WebDriver\"

--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -1,9 +1,12 @@
 #!/bin/bash
 
+FIREFOX_VERSION=$( firefox -version | cut -d " " -f 3 )
+
 echo "
 {
   \"capabilities\": [
     {
+      \"version\": \"$FIREFOX_VERSION\",
       \"browserName\": \"firefox\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
       \"seleniumProtocol\": \"WebDriver\"


### PR DESCRIPTION
I think that it would make sense to add a "version" property to the capabilites object in generate_config.
The version property is a standard capability key and is helpful for instance in grid setups with multiple versions of the same browser type (version based capability matching).

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
