### PR TITLE
Made it possible to build customers version of these docker images.

### DIFF
--- a/Hub/generate.sh
+++ b/Hub/generate.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 VERSION=$1
+NAME=$2
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > ./Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> ./Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> ./Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> ./Dockerfile
-echo FROM selenium/base:$VERSION >> ./Dockerfile
+echo FROM $NAME/base:$VERSION >> ./Dockerfile
 cat ./Dockerfile.txt >> ./Dockerfile

--- a/Makefile
+++ b/Makefile
@@ -28,61 +28,61 @@ base:
 	cd ./Base && docker build $(BUILD_ARGS) -t $(NAME)/base:$(VERSION) .
 
 generate_hub:
-	cd ./Hub && ./generate.sh $(VERSION)
+	cd ./Hub && ./generate.sh $(VERSION) $(NAME)
 
 hub: base generate_hub
 	cd ./Hub && docker build $(BUILD_ARGS) -t $(NAME)/hub:$(VERSION) .
 
 generate_nodebase:
-	cd ./NodeBase && ./generate.sh $(VERSION)
+	cd ./NodeBase && ./generate.sh $(VERSION) $(NAME)
 
 nodebase: base generate_nodebase
 	cd ./NodeBase && docker build $(BUILD_ARGS) -t $(NAME)/node-base:$(VERSION) .
 
 generate_chrome:
-	cd ./NodeChrome && ./generate.sh $(VERSION)
+	cd ./NodeChrome && ./generate.sh $(VERSION) $(NAME)
 
 chrome: nodebase generate_chrome
 	cd ./NodeChrome && docker build $(BUILD_ARGS) -t $(NAME)/node-chrome:$(VERSION) .
 
 generate_firefox:
-	cd ./NodeFirefox && ./generate.sh $(VERSION)
+	cd ./NodeFirefox && ./generate.sh $(VERSION) $(NAME)
 
 firefox: nodebase generate_firefox
 	cd ./NodeFirefox && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox:$(VERSION) .
 
 generate_standalone_firefox:
-	cd ./Standalone && ./generate.sh StandaloneFirefox node-firefox Firefox $(VERSION)
+	cd ./Standalone && ./generate.sh StandaloneFirefox node-firefox Firefox $(VERSION) $(NAME)
 
 standalone_firefox: generate_standalone_firefox firefox
 	cd ./StandaloneFirefox && docker build $(BUILD_ARGS) -t $(NAME)/standalone-firefox:$(VERSION) .
 
 generate_standalone_firefox_debug:
-	cd ./StandaloneDebug && ./generate.sh StandaloneFirefoxDebug standalone-firefox Firefox $(VERSION)
+	cd ./StandaloneDebug && ./generate.sh StandaloneFirefoxDebug standalone-firefox Firefox $(VERSION) $(NAME)
 
 standalone_firefox_debug: generate_standalone_firefox_debug standalone_firefox
 	cd ./StandaloneFirefoxDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-firefox-debug:$(VERSION) .
 
 generate_standalone_chrome:
-	cd ./Standalone && ./generate.sh StandaloneChrome node-chrome Chrome $(VERSION)
+	cd ./Standalone && ./generate.sh StandaloneChrome node-chrome Chrome $(VERSION) $(NAME)
 
 standalone_chrome: generate_standalone_chrome chrome
 	cd ./StandaloneChrome && docker build $(BUILD_ARGS) -t $(NAME)/standalone-chrome:$(VERSION) .
 
 generate_standalone_chrome_debug:
-	cd ./StandaloneDebug && ./generate.sh StandaloneChromeDebug standalone-chrome Chrome $(VERSION)
+	cd ./StandaloneDebug && ./generate.sh StandaloneChromeDebug standalone-chrome Chrome $(VERSION) $(NAME)
 
 standalone_chrome_debug: generate_standalone_chrome_debug standalone_chrome
 	cd ./StandaloneChromeDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-chrome-debug:$(VERSION) .
 
 generate_chrome_debug:
-	cd ./NodeDebug && ./generate.sh NodeChromeDebug node-chrome Chrome $(VERSION)
+	cd ./NodeDebug && ./generate.sh NodeChromeDebug node-chrome Chrome $(VERSION) $(NAME)
 
 chrome_debug: generate_chrome_debug chrome
 	cd ./NodeChromeDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-chrome-debug:$(VERSION) .
 
 generate_firefox_debug:
-	cd ./NodeDebug && ./generate.sh NodeFirefoxDebug node-firefox Firefox $(VERSION)
+	cd ./NodeDebug && ./generate.sh NodeFirefoxDebug node-firefox Firefox $(VERSION) $(NAME)
 
 firefox_debug: generate_firefox_debug firefox
 	cd ./NodeFirefoxDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox-debug:$(VERSION) .

--- a/NodeBase/generate.sh
+++ b/NodeBase/generate.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 VERSION=$1
+NAME=$2
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > ./Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> ./Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> ./Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> ./Dockerfile
-echo FROM selenium/base:$VERSION >> ./Dockerfile
+echo FROM $NAME/base:$VERSION >> ./Dockerfile
 cat ./Dockerfile.txt >> ./Dockerfile

--- a/NodeChrome/generate.sh
+++ b/NodeChrome/generate.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 VERSION=$1
+NAME=$2
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > ./Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> ./Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> ./Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> ./Dockerfile
-echo FROM selenium/node-base:$VERSION >> ./Dockerfile
+echo FROM $NAME/node-base:$VERSION >> ./Dockerfile
 cat ./Dockerfile.txt >> ./Dockerfile

--- a/NodeDebug/generate.sh
+++ b/NodeDebug/generate.sh
@@ -3,12 +3,13 @@ FOLDER=../$1
 BASE=$2
 BROWSER=$3
 VERSION=$4
+NAME=$5
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > $FOLDER/Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> $FOLDER/Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> $FOLDER/Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> $FOLDER/Dockerfile
-echo FROM selenium/$BASE:$VERSION >> $FOLDER/Dockerfile
+echo FROM $NAME/$BASE:$VERSION >> $FOLDER/Dockerfile
 cat ./Dockerfile.txt >> $FOLDER/Dockerfile
 
 cat ../NodeBase/entry_point.sh \

--- a/NodeFirefox/generate.sh
+++ b/NodeFirefox/generate.sh
@@ -1,9 +1,10 @@
 #!/bin/bash
 VERSION=$1
+NAME=$2
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > ./Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> ./Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> ./Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> ./Dockerfile
-echo FROM selenium/node-base:$VERSION >> ./Dockerfile
+echo FROM $NAME/node-base:$VERSION >> ./Dockerfile
 cat ./Dockerfile.txt >> ./Dockerfile

--- a/Standalone/generate.sh
+++ b/Standalone/generate.sh
@@ -3,12 +3,13 @@ FOLDER=../$1
 BASE=$2
 BROWSER=$3
 VERSION=$4
+NAME=$5
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > $FOLDER/Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> $FOLDER/Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> $FOLDER/Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> $FOLDER/Dockerfile
-echo FROM selenium/$BASE:$VERSION >> $FOLDER/Dockerfile
+echo FROM $NAME/$BASE:$VERSION >> $FOLDER/Dockerfile
 cat ./Dockerfile.txt >> $FOLDER/Dockerfile
 
 cp ./entry_point.sh $FOLDER

--- a/StandaloneDebug/generate.sh
+++ b/StandaloneDebug/generate.sh
@@ -3,12 +3,13 @@ FOLDER=../$1
 BASE=$2
 BROWSER=$3
 VERSION=$4
+NAME=$5
 
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > $FOLDER/Dockerfile
 echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> $FOLDER/Dockerfile
 echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> $FOLDER/Dockerfile
 echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> $FOLDER/Dockerfile
-echo FROM selenium/$BASE:$VERSION >> $FOLDER/Dockerfile
+echo FROM $NAME/$BASE:$VERSION >> $FOLDER/Dockerfile
 cat ../NodeDebug/Dockerfile.txt >> $FOLDER/Dockerfile
 
 cp ./entry_point.sh $FOLDER


### PR DESCRIPTION
I tried to build private copies of these images and manually set
NAME and VERSION when launching make. Unfortunately it turned out
that the NAME did not propagate so for example NodeFirefox wanted to
build on selenium/node-base:MY_VERSION which failed since that didn't
exist. This patch propagates NAME to the generate.sh-scripts so the
images build on each other.

- [ X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
