### PR TITLE
Add DBUS_SESSION_BUS_ADDRESS to env_keep (Fixes #358)

### DIFF
--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -51,6 +51,10 @@ RUN chmod +x /opt/google/chrome/google-chrome
 
 RUN chown -R seluser:seluser /opt/selenium
 
+# Ensure that the environment variable below is preserved when using sudo -i
+# https://github.com/SeleniumHQ/docker-selenium/issues/358
+RUN echo 'Defaults env_keep += "DBUS_SESSION_BUS_ADDRESS"' >> /etc/sudoers
+
 USER seluser
 # Following line fixes
 # https://github.com/SeleniumHQ/docker-selenium/issues/87


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
