### PR TITLE
Add DBUS_SESSION_BUS_ADDRESS to /etc/environment (Fixes #358)

### DIFF
--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -56,7 +56,8 @@ RUN chmod +x /opt/google/chrome/google-chrome
 
 RUN chown -R seluser:seluser /opt/selenium
 
-USER seluser
 # Following line fixes
 # https://github.com/SeleniumHQ/docker-selenium/issues/87
-ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+RUN echo "DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /etc/environment
+
+USER seluser


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Making this for the alternative approach suggested on https://github.com/SeleniumHQ/docker-selenium/pull/381.