### PR TITLE
Update NodeFirefox to use Firefox 52.0

### DIFF
--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -5,7 +5,7 @@ USER root
 #=========
 # Firefox
 #=========
-ARG FIREFOX_VERSION=51.0.1
+ARG FIREFOX_VERSION=52.0
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Firefox 52.0 was released yesterday: https://www.mozilla.org/en-US/firefox/52.0/releasenotes/