### PR TITLE
Add support for applicationName capability

### DIFF
--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -9,7 +9,8 @@ echo "
       \"version\": \"$CHROME_VERSION\",
       \"browserName\": \"chrome\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
-      \"seleniumProtocol\": \"WebDriver\"
+      \"seleniumProtocol\": \"WebDriver\",
+      \"applicationName\": \"$NODE_APPLICATION_NAME\"
     }
   ],
   \"proxy\": \"org.openqa.grid.selenium.proxy.DefaultRemoteProxy\",

--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -9,7 +9,8 @@ echo "
       \"version\": \"$FIREFOX_VERSION\",
       \"browserName\": \"firefox\",
       \"maxInstances\": $NODE_MAX_INSTANCES,
-      \"seleniumProtocol\": \"WebDriver\"
+      \"seleniumProtocol\": \"WebDriver\",
+      \"applicationName\": \"$NODE_APPLICATION_NAME\"
     }
   ],
   \"proxy\": \"org.openqa.grid.selenium.proxy.DefaultRemoteProxy\",


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

This capability is not documented, but there are requests for it to be.

SeleniumHQ/selenium-google-code-issue-archive#3660 (originally
https://groups.google.com/group/selenium-users/browse_thread/thread/3d1b0405c6e93653?hl=es&noredirect=true)

I had a use case for it in our setup.