### PR TITLE
NodeChrome: Updating CHROME_DRIVER_VERSION to 2.28

### DIFF
--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -24,7 +24,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 #==================
 # Chrome webdriver
 #==================
-ARG CHROME_DRIVER_VERSION=2.27
+ARG CHROME_DRIVER_VERSION=2.28
 RUN wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CHROME_DRIVER_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \
   && unzip /tmp/chromedriver_linux64.zip -d /opt/selenium \


### PR DESCRIPTION
Changes include:
- Fixes a bug which blocked ChromeDriver automation extension from loading and thereby causing window resizing/positioning & screenshot functionalities to break.
- Fixes a bug where NetLog json files were being truncated.
- Fixes a bug which caused ChromeDriver to timeout and/or hang randomly while a dialog is showing.
- Fixes a bug which caused FindElements to fail in some scenarios.
- Various updates to work with Chrome 57+ .

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
