### PR TITLE
feat(encrypt-vnc): add encrypted WebSocket proxy

### DIFF
--- a/NodeChromeDebug/Dockerfile
+++ b/NodeChromeDebug/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update -qqy \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
+#============
+# Websockify
+#============
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    websockify python-pkg-resources \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+
 #=================
 # Locale settings
 #=================
@@ -57,3 +65,4 @@ COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
 
 EXPOSE 5900
+EXPOSE 6900

--- a/NodeChromeDebug/README.md
+++ b/NodeChromeDebug/README.md
@@ -43,6 +43,15 @@ FROM selenium/node-chrome-debug:3.0.1-germanium
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```
 
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/node-chrome-debug
+```
+
+##### Example: Connect with noVNC via encrypted WebSockets:
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -63,4 +63,6 @@ fluxbox -display $DISPLAY &
 
 x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
 
+websockify --key /cert/ssl.key --cert /cert/ssl.cert 0.0.0.0:6900 0.0.0.0:5900 &
+
 wait $NODE_PID

--- a/NodeDebug/Dockerfile.txt
+++ b/NodeDebug/Dockerfile.txt
@@ -12,6 +12,14 @@ RUN apt-get update -qqy \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
+#============
+# Websockify
+#============
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    websockify python-pkg-resources \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+
 #=================
 # Locale settings
 #=================
@@ -52,3 +60,4 @@ COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
 
 EXPOSE 5900
+EXPOSE 6900

--- a/NodeDebug/README.template.md
+++ b/NodeDebug/README.template.md
@@ -43,6 +43,15 @@ FROM selenium/##BASE##-debug:3.0.1-germanium
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```
 
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/##BASE##-debug
+```
+
+##### Example: Connect with noVNC via encrypted WebSockets:
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/NodeDebug/debug-script.sh
+++ b/NodeDebug/debug-script.sh
@@ -12,3 +12,5 @@ done
 fluxbox -display $DISPLAY &
 
 x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY
+
+websockify --key /cert/ssl.key --cert /cert/ssl.cert 0.0.0.0:6900 0.0.0.0:5900 &

--- a/NodeDebug/generate.sh
+++ b/NodeDebug/generate.sh
@@ -32,6 +32,8 @@ fluxbox -display $DISPLAY \&\
 \
 x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY \&\
 \
+websockify --key \/cert\/ssl.key --cert \/cert\/ssl.cert 0.0.0.0:6900 0.0.0.0:5900 \&\
+\
 wait \$NODE_PID/' \
   > $FOLDER/entry_point.sh
 

--- a/NodeFirefoxDebug/Dockerfile
+++ b/NodeFirefoxDebug/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update -qqy \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
+#============
+# Websockify
+#============
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    websockify python-pkg-resources \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+
 #=================
 # Locale settings
 #=================
@@ -57,3 +65,4 @@ COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
 
 EXPOSE 5900
+EXPOSE 6900

--- a/NodeFirefoxDebug/Dockerfile.txt
+++ b/NodeFirefoxDebug/Dockerfile.txt
@@ -13,6 +13,14 @@ RUN apt-get update -qqy \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
+#============
+# Websockify
+#============
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    websockify python-pkg-resources \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+
 #=================
 # Locale settings
 #=================
@@ -53,3 +61,4 @@ COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
 
 EXPOSE 5900
+EXPOSE 6900

--- a/NodeFirefoxDebug/README.md
+++ b/NodeFirefoxDebug/README.md
@@ -43,6 +43,15 @@ FROM selenium/node-firefox-debug:3.0.1-germanium
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```
 
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/node-firefox-debug
+```
+
+##### Example: Connect with noVNC via encrypted WebSockets:
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -63,4 +63,6 @@ fluxbox -display $DISPLAY &
 
 x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
 
+websockify --key /cert/ssl.key --cert /cert/ssl.cert 0.0.0.0:6900 0.0.0.0:5900 &
+
 wait $NODE_PID

--- a/README.md
+++ b/README.md
@@ -113,7 +113,7 @@ _Note: Since a Docker container is not meant to preserve state and spawning a ne
 
 ## Debugging
 
-In the event you wish to visually see what the browser is doing you will want to run the `debug` variant of node or standalone images. A VNC server will run on port 5900. You are free to map that to any free external port that you wish.  Example: <port4VNC>: 5900) you will only be able to run 1 node per port so if you wish to include a second node, or more, you will have to use different ports, the 5900 as the internal port will have to remain the same though as thats the VNC service on the node. The second example below shows how to run multiple nodes and with different VNC ports open:
+In the event you wish to visually see what the browser is doing you will want to run the `debug` variant of node or standalone images. A VNC server will run on port 5900 and a WebSocket proxy on port 6900. You are free to map that to any free external port that you wish.  (Example: `<port4VNC>: 5900`) you will only be able to run 1 node per port so if you wish to include a second node, or more, you will have to use different ports, the 5900 as the internal port will have to remain the same though as that's the VNC service on the node. The second example below shows how to run multiple nodes and with different VNC ports open:
 ``` bash
 $ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-chrome-debug:3.0.1-germanium
 $ docker run -d -P -p <port4VNC>:5900 --link selenium-hub:hub selenium/node-firefox-debug:3.0.1-germanium
@@ -161,6 +161,15 @@ When you are prompted for the password it is `secret`. If you wish to change thi
 
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```
+
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/standalone-##BROWSER_LC##-debug
+```
+
+#### noVNC example
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
 
 ### Troubleshooting
 

--- a/StandaloneChromeDebug/Dockerfile
+++ b/StandaloneChromeDebug/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update -qqy \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
+#============
+# Websockify
+#============
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    websockify python-pkg-resources \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+
 #=================
 # Locale settings
 #=================
@@ -57,3 +65,4 @@ COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
 
 EXPOSE 5900
+EXPOSE 6900

--- a/StandaloneChromeDebug/README.md
+++ b/StandaloneChromeDebug/README.md
@@ -22,6 +22,15 @@ $ docker port <container-name|container-id> 4444
 #=> 0.0.0.0:49338
 ```
 
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/standalone-chrome-debug
+```
+
+##### Example: Connect with noVNC via encrypted WebSockets:
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/StandaloneDebug/README.template.md
+++ b/StandaloneDebug/README.template.md
@@ -22,6 +22,15 @@ $ docker port <container-name|container-id> 4444
 #=> 0.0.0.0:49338
 ```
 
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/standalone-##BROWSER_LC##-debug
+```
+
+##### Example: Connect with noVNC via encrypted WebSockets:
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -47,4 +47,6 @@ fluxbox -display $DISPLAY &
 
 x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
 
+websockify --key /cert/ssl.key --cert /cert/ssl.cert 0.0.0.0:6900 0.0.0.0:5900 &
+
 wait $NODE_PID

--- a/StandaloneFirefoxDebug/Dockerfile
+++ b/StandaloneFirefoxDebug/Dockerfile
@@ -17,6 +17,14 @@ RUN apt-get update -qqy \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
+#============
+# Websockify
+#============
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    websockify python-pkg-resources \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+
 #=================
 # Locale settings
 #=================
@@ -57,3 +65,4 @@ COPY entry_point.sh /opt/bin/entry_point.sh
 RUN chmod +x /opt/bin/entry_point.sh
 
 EXPOSE 5900
+EXPOSE 6900

--- a/StandaloneFirefoxDebug/README.md
+++ b/StandaloneFirefoxDebug/README.md
@@ -22,6 +22,15 @@ $ docker port <container-name|container-id> 4444
 #=> 0.0.0.0:49338
 ```
 
+### Encrypted WebSockets
+To connect to the VNC server via encrypted WebSockets, point your docker image to a directory containing `ssl.cert` and `ssl.key` files and expose the internal WebSocket proxy port 6900.
+``` bash
+$ docker run -d -p 6900:6900 -v /path/to/certificate/dir:/cert selenium/standalone-firefox-debug
+```
+
+##### Example: Connect with noVNC via encrypted WebSockets:
+http://novnc.com/noVNC/vnc_auto.html?host=your.domain.here&port=6900&encrypt=1
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 


### PR DESCRIPTION
This commit introduces a WebSocket proxy on port 6900 for encrypted VNC
sessions via WebSocket clients like noVNC.

Usage: See README.md

- [ X ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
