### PR TITLE
Fix example usage of `-debug` flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ $ docker run -d -p 4444:4444 -e JAVA_OPTS=-Xmx512m --name selenium-hub selenium/
 You can pass `SE_OPTS` variable with additional commandline parameters for starting a hub or a node.
 
 ``` bash
-$ docker run -d -p 4444:4444 -e SE_OPTS=-debug --name selenium-hub selenium/hub:3.2.0-actinium
+$ docker run -d -p 4444:4444 -e SE_OPTS="-debug true" --name selenium-hub selenium/hub:3.2.0-actinium
 ```
 
 ### PHANTOMJS_OPTS PhantomJS Configuration Options


### PR DESCRIPTION
The CLI changed and now wants the `-debug` flag to be passed with a boolean value.

See SeleniumHQ/selenium@705be71ce9ec7e3825cb1633d3da40ab75a8819f.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
