### PR TITLE
Fix work with environment variables at `xvfb-run`

### DIFF
--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -36,9 +36,9 @@ SERVERNUM=$(get_server_num)
 rm -f /tmp/.X*lock
 
 env | cut -f 1 -d "=" | sort > asroot
-  sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
-  sudo -E -i -u seluser \
-  $(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done) \
+sudo -E -u seluser -i env | cut -f 1 -d "=" | sort > asseluser
+sudo -E -i -u seluser \
+  "$(for E in $(grep -vxFf asseluser asroot); do echo $E=$(eval echo \$$E); done)" \
   DISPLAY=$DISPLAY \
   xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \


### PR DESCRIPTION
This fix makes it possible to use the environment variable with whitespaces, e.g. `-e SE_OPTS='-browserTimeout 86400 -timeout 86400'`
like here https://github.com/Accenture/adop-docker-compose/issues/193

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
