### PR TITLE
Fixing #87 (again), #465 and similar ones

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -227,10 +227,10 @@ release: tag_major_minor
 	docker push $(NAME)/standalone-firefox-debug:$(MAJOR_MINOR_PATCH)
 
 test:
-	./test.sh
-	./sa-test.sh
-	./test.sh debug
-	./sa-test.sh debug
+	VERSION=$(VERSION) ./test.sh
+	VERSION=$(VERSION) ./sa-test.sh
+	VERSION=$(VERSION) ./test.sh debug
+	VERSION=$(VERSION) ./sa-test.sh debug
 
 .PHONY: \
 	all \

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -10,7 +10,6 @@ RUN apt-get update -qqy \
   && apt-get -qqy install \
     locales \
     xvfb \
-    dbus \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -57,15 +57,14 @@ COPY generate_config /opt/selenium/generate_config
 RUN chmod +x /opt/selenium/generate_config
 
 #=================================
-# Chrome Launch Script Modication
+# Chrome Launch Script Modification
 #=================================
 COPY chrome_launcher.sh /opt/google/chrome/google-chrome
 RUN chmod +x /opt/google/chrome/google-chrome
 
 RUN chown -R seluser:seluser /opt/selenium
 
-# Following line fixes
-# https://github.com/SeleniumHQ/docker-selenium/issues/87
-RUN echo "DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /etc/environment
+# Following line fixes https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 USER seluser

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -53,8 +53,7 @@ COPY generate_config /opt/selenium/generate_config
 RUN chmod +x /opt/selenium/generate_config \
   && chown -R seluser:seluser /opt/selenium
 
-# Following line fixes
-# https://github.com/SeleniumHQ/docker-selenium/issues/87
-RUN echo "DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /etc/environment
+# Following line fixes https://github.com/SeleniumHQ/docker-selenium/issues/87
+ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 
 USER seluser

--- a/sa-test.sh
+++ b/sa-test.sh
@@ -1,6 +1,7 @@
 #!/usr/bin/env bash
 
 DEBUG=''
+VERSION=${VERSION:-3.4.0-bismuth}
 
 if [ -n "$1" ] && [ $1 == 'debug' ]; then
   DEBUG='-debug'
@@ -13,7 +14,7 @@ function test_standalone {
   BROWSER=$1
   echo Starting Selenium standalone-$BROWSER$DEBUG container
 
-  SA=$(docker run -d selenium/standalone-$BROWSER$DEBUG:3.4.0-bismuth)
+  SA=$(docker run -d selenium/standalone-$BROWSER$DEBUG:${VERSION})
   SA_NAME=$(docker inspect -f '{{ .Name  }}' $SA | sed s:/::)
   TEST_CMD="node smoke-$BROWSER.js"
 

--- a/test.sh
+++ b/test.sh
@@ -24,7 +24,7 @@ echo Building test container image
 docker build -t selenium/test:local ./Test
 
 echo 'Starting Selenium Hub Container...'
-HUB=$(docker run -d selenium/hub:3.4.0-bismuth)
+HUB=$(docker run -d selenium/hub:${VERSION})
 HUB_NAME=$(docker inspect -f '{{ .Name  }}' $HUB | sed s:/::)
 echo 'Waiting for Hub to come online...'
 docker logs -f $HUB &


### PR DESCRIPTION

Originally #87 was solved by #182 by adding `ENV DBUS_SESSION_BUS_ADDRESS=/dev/null` to the Chrome and Firefox Dockerfiles. 

Nevertheless #358 was raised and due to that the command changed via #386 to `RUN echo "DBUS_SESSION_BUS_ADDRESS=/dev/null" >> /etc/environment`. 

But after that, #87 started showing up again.

So this PR leaves the Dockerfiles in the same state as the commit made in #182 that fixed #87.

I tested the locally generated Chrome images it with the current tests but also with a simple test that help me to reproduce #465 and #87. Here is the [simple test](https://gist.github.com/diemol/df6f97b35c3943358a78d8200bbeae35)

I was not able to reproduce the error reported in #358, maybe @Sovetnikov or @a-k-g can provide a test case to reproduce it before this PR is considered to be merged?

@testphreak, maybe you can also generate the images locally based on this PR and test it?






- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
