### PR TITLE
Use `apt-get clean`

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -21,7 +21,8 @@ RUN apt-get update -qqy \
     sudo \
     unzip \
     wget \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
   && sed -i 's/securerandom\.source=file:\/dev\/random/securerandom\.source=file:\/dev\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
 
 #===================

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -8,7 +8,8 @@ RUN apt-get update -qqy \
   && apt-get -qqy install \
     locales \
     xvfb \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #==============================
 # Scripts to run Selenium Node

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -17,7 +17,8 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
   && apt-get -qqy install \
     ${CHROME_VERSION:-google-chrome-stable} \
   && rm /etc/apt/sources.list.d/google-chrome.list \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #==================
 # Chrome webdriver

--- a/NodeDebug/Dockerfile.txt
+++ b/NodeDebug/Dockerfile.txt
@@ -6,7 +6,8 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -20,7 +21,8 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #=======
 # Fonts
@@ -32,7 +34,8 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #=========
 # fluxbox
@@ -41,7 +44,8 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #==============================
 # Scripts to run Selenium Node

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -6,7 +6,8 @@ USER root
 ARG FIREFOX_VERSION=53.0
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install firefox \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2 \
   && apt-get -y purge firefox \
   && rm -rf /opt/firefox \

--- a/NodeFirefoxDebug/Dockerfile.txt
+++ b/NodeFirefoxDebug/Dockerfile.txt
@@ -9,7 +9,8 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
   x11vnc \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean \
   && mkdir -p /root/.vnc \
   && x11vnc -storepasswd secret ~/.vnc/passwd
 
@@ -23,7 +24,8 @@ RUN locale-gen en_US.UTF-8 \
   && apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
     language-pack-en \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #=======
 # Fonts
@@ -35,7 +37,8 @@ RUN apt-get update -qqy \
     xfonts-75dpi \
     xfonts-cyrillic \
     xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #=========
 # fluxbox
@@ -44,7 +47,8 @@ RUN apt-get update -qqy \
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     fluxbox \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+  && rm -rf /var/lib/apt/lists/* \
+  && apt-get clean
 
 #==============================
 # Scripts to run Selenium Node


### PR DESCRIPTION
Instead of `rm -rf /var/cache/apt/archives`, which causes an error on
RHEL 7.3 (see SeleniumHQ/docker-selenium#458), do `apt-get clean`
instead

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
