### PR TITLE
get chrome version from chrome -version

### DIFF
--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-CHROME_VERSION=$( sudo dpkg -s google-chrome-stable | grep Version | cut -d " " -f 2 | cut -d "-" -f 1 )
+CHROME_VERSION=$(/opt/google/chrome/chrome -version | awk '{ print $3 }')
 
 cat <<_EOF
 {


### PR DESCRIPTION
this retrieves the version without the need for sudo, which causes problems when you deploy in a container environment with tighter security guidelines like openshift.

Feel free to refine/improve it or use a different approach. The main thing here is not to use sudo.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
