### PR TITLE
Config generation at runtime + buildtime

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 source /opt/bin/functions.sh
+/opt/bin/generate_config > /opt/selenium/config.json
 
 export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
 

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -40,5 +40,5 @@ COPY generate_config /opt/bin/generate_config
 #=================================
 COPY chrome_launcher.sh /opt/google/chrome/google-chrome
 
-# Generating config inside the image rather than with entry_point.sh
+# Generating a default config during build time
 RUN /opt/bin/generate_config > /opt/selenium/config.json

--- a/NodeChromeDebug/entry_point.sh
+++ b/NodeChromeDebug/entry_point.sh
@@ -3,6 +3,7 @@
 # IMPORTANT: Change this file only in directory NodeDebug!
 
 source /opt/bin/functions.sh
+/opt/bin/generate_config > /opt/selenium/config.json
 
 export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
 

--- a/NodeDebug/entry_point.sh
+++ b/NodeDebug/entry_point.sh
@@ -3,6 +3,7 @@
 # IMPORTANT: Change this file only in directory NodeDebug!
 
 source /opt/bin/functions.sh
+/opt/bin/generate_config > /opt/selenium/config.json
 
 export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
 

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -36,5 +36,5 @@ COPY generate_config /opt/bin/generate_config
 # When logging into the container
 RUN sudo echo ""
 
-# Generating config inside the image rather than with entry_point.sh
+# Generating a default config during build time
 RUN /opt/bin/generate_config > /opt/selenium/config.json

--- a/NodeFirefoxDebug/entry_point.sh
+++ b/NodeFirefoxDebug/entry_point.sh
@@ -3,6 +3,7 @@
 # IMPORTANT: Change this file only in directory NodeDebug!
 
 source /opt/bin/functions.sh
+/opt/bin/generate_config > /opt/selenium/config.json
 
 export GEOMETRY="$SCREEN_WIDTH""x""$SCREEN_HEIGHT""x""$SCREEN_DEPTH"
 


### PR DESCRIPTION
Hi,
As @junhui pointed out, my previous pull request (#502) broke the ability to pass environment variables for config generation.

I believe a fix could be to generate config at build time (it creates a default config file), and at runtime. As it is actually done with the Hub : [Hub/Dockerfile#L39](https://github.com/SeleniumHQ/docker-selenium/blob/1fbe302c398d45dd16a1faa6929ebc0811741f89/Hub/Dockerfile#L39) and [Hub/entry_point.sh#L6](https://github.com/SeleniumHQ/docker-selenium/blob/0f12883b3deac2a1bc63552a98f51704a07e288c/Hub/entry_point.sh#L6). See [issue 502 last comment](https://github.com/SeleniumHQ/docker-selenium/pull/502#issuecomment-318816235).

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
