### PR TITLE
Remove quote to work headless mode

### DIFF
--- a/NodeChrome/chrome_launcher.sh
+++ b/NodeChrome/chrome_launcher.sh
@@ -82,6 +82,6 @@ exec 2> >(exec cat >&2)
 # Note: exec -a below is a bashism.
 # DOCKER SELENIUM NOTE: Strait copy of script installed by Chrome with the exception of adding
 # the --no-sandbox flag here.
-exec -a "$0" "$HERE/chrome" --no-sandbox "$PROFILE_DIRECTORY_FLAG" \
+exec -a "$0" "$HERE/chrome" --no-sandbox $PROFILE_DIRECTORY_FLAG \
   "$@"
 exec -a "$0" /etc/alternatives/google-chrome --no-sandbox "$@"


### PR DESCRIPTION
`docker run --rm --cap-add SYS_ADMIN selenium/standalone-chrome-debug /opt/google/chrome/chrome --no-sandbox --headless --disable-gpu --dump-dom http://example.com` works but 
`docker run --rm --cap-add SYS_ADMIN selenium/standalone-chrome-debug google-chrome --no-sandbox --headless --disable-gpu --dump-dom http://example.com` doesn't because of this quote.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
