### PR TITLE
Fix for issue with not being able to pass environment variables into node containers at runtime

### DIFF
--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -30,26 +30,6 @@ ENV SCREEN_HEIGHT 1020
 ENV SCREEN_DEPTH 24
 ENV DISPLAY :99.0
 
-#========================
-# Selenium Configuration
-#========================
-# As integer, maps to "maxInstances"
-ENV NODE_MAX_INSTANCES 1
-# As integer, maps to "maxSession"
-ENV NODE_MAX_SESSION 1
-# As integer, maps to "port"
-ENV NODE_PORT 5555
-# In milliseconds, maps to "registerCycle"
-ENV NODE_REGISTER_CYCLE 5000
-# In milliseconds, maps to "nodePolling"
-ENV NODE_POLLING 5000
-# In milliseconds, maps to "unregisterIfStillDownAfter"
-ENV NODE_UNREGISTER_IF_STILL_DOWN_AFTER 60000
-# As integer, maps to "downPollingLimit"
-ENV NODE_DOWN_POLLING_LIMIT 2
-# As string, maps to "applicationName"
-ENV NODE_APPLICATION_NAME ""
-
 # Following line fixes https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
 

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -38,6 +38,26 @@ RUN CD_VERSION=$(if [ ${CHROME_DRIVER_VERSION:-latest} = "latest" ]; then echo $
   && chmod 755 /opt/selenium/chromedriver-$CD_VERSION\
   && sudo ln -fs /opt/selenium/chromedriver-$CD_VERSION/usr/bin/chromedriver
 
+#========================
+# Selenium Configuration
+#========================
+# As integer, maps to "maxInstances"
+ENV NODE_MAX_INSTANCES 1
+# As integer, maps to "maxSession"
+ENV NODE_MAX_SESSION 1
+# As integer, maps to "port"
+ENV NODE_PORT 5555
+# In milliseconds, maps to "registerCycle"
+ENV NODE_REGISTER_CYCLE 5000
+# In milliseconds, maps to "nodePolling"
+ENV NODE_POLLING 5000
+# In milliseconds, maps to "unregisterIfStillDownAfter"
+ENV NODE_UNREGISTER_IF_STILL_DOWN_AFTER 60000
+# As integer, maps to "downPollingLimit"
+ENV NODE_DOWN_POLLING_LIMIT 2
+# As string, maps to "applicationName"
+ENV NODE_APPLICATION_NAME ""
+
 COPY generate_config /opt/bin/generate_config
 
 #=================================

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -29,12 +29,27 @@ RUN wget --no-verbose -O /tmp/geckodriver.tar.gz https://github.com/mozilla/geck
 
 USER seluser
 
-COPY generate_config /opt/bin/generate_config
+#========================
+# Selenium Configuration
+#========================
+# As integer, maps to "maxInstances"
+ENV NODE_MAX_INSTANCES 1
+# As integer, maps to "maxSession"
+ENV NODE_MAX_SESSION 1
+# As integer, maps to "port"
+ENV NODE_PORT 5555
+# In milliseconds, maps to "registerCycle"
+ENV NODE_REGISTER_CYCLE 5000
+# In milliseconds, maps to "nodePolling"
+ENV NODE_POLLING 5000
+# In milliseconds, maps to "unregisterIfStillDownAfter"
+ENV NODE_UNREGISTER_IF_STILL_DOWN_AFTER 60000
+# As integer, maps to "downPollingLimit"
+ENV NODE_DOWN_POLLING_LIMIT 2
+# As string, maps to "applicationName"
+ENV NODE_APPLICATION_NAME ""
 
-# Running this command as sudo just to avoid the message:
-# To run a command as administrator (user "root"), use "sudo <command>". See "man sudo_root" for details.
-# When logging into the container
-RUN sudo echo ""
+COPY generate_config /opt/bin/generate_config
 
 # Generating a default config during build time
 RUN /opt/bin/generate_config > /opt/selenium/config.json


### PR DESCRIPTION
When changes were introduced to generate default config during build
time with #502 and then with #529, it broke the ability to pass in
environment variables to the node containers at runtime. This fix aims
to provide the ability to do both i.e. continue to pass environment
variables at runtime and generate a default config at build time for
the node.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
