### PR TITLE
Allow to change hub port

### DIFF
--- a/Hub/Dockerfile.txt
+++ b/Hub/Dockerfile.txt
@@ -22,6 +22,8 @@ ENV GRID_BROWSER_TIMEOUT 0
 ENV GRID_TIMEOUT 30
 # Debug
 ENV GRID_DEBUG false
+# As integer, maps to "port"
+ENV GRID_HUB_PORT 4444
 
 COPY generate_config \
     entry_point.sh \

--- a/Hub/generate_config
+++ b/Hub/generate_config
@@ -3,7 +3,7 @@
 cat <<_EOF
 {
   "host": null,
-  "port": 4444,
+  "port": $GRID_HUB_PORT,
   "role": "hub",
   "maxSession": $GRID_MAX_SESSION,
   "newSessionWaitTimeout": $GRID_NEW_SESSION_WAIT_TIMEOUT,


### PR DESCRIPTION
Because it was not possible to change hub port
now it can be changed by GRID_HUB_PORT env variable

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
