### PR TITLE
Update geckodriver log level from environment

### DIFF
--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 FIREFOX_VERSION=$( firefox -version | cut -d " " -f 3 )
+DRIVER_LOGLEVEL=${DRIVER_LOGLEVEL:-info}
 
 cat <<_EOF
 {
@@ -10,7 +11,14 @@ cat <<_EOF
       "browserName": "firefox",
       "maxInstances": $NODE_MAX_INSTANCES,
       "seleniumProtocol": "WebDriver",
-      "applicationName": "$NODE_APPLICATION_NAME"
+      "applicationName": "$NODE_APPLICATION_NAME",
+      "moz:firefoxOptions":
+        {
+          "log":
+            {
+              "level": "$DRIVER_LOGLEVEL"
+            }
+        }
     }
   ],
   "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",


### PR DESCRIPTION
Allow the geckodriver log level to be set from the environment, such as:

    docker run --env DRIVER_LOGLEVEL=trace

If unset, the default "info" level is used.

This was requested on https://github.com/mozilla/geckodriver/issues/1015.

* [X] By placing an X in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://goo.gl/a2VrTx).