### PR TITLE
Add missing chrome_debug dependency

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -75,7 +75,7 @@ standalone_chrome: generate_standalone_chrome chrome
 generate_standalone_chrome_debug:
 	cd ./StandaloneDebug && ./generate.sh StandaloneChromeDebug node-chrome-debug Chrome $(VERSION) $(NAMESPACE) $(AUTHORS)
 
-standalone_chrome_debug: generate_standalone_chrome_debug standalone_chrome
+standalone_chrome_debug: chrome_debug generate_standalone_chrome_debug standalone_chrome
 	cd ./StandaloneChromeDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-chrome-debug:$(VERSION) .
 
 generate_chrome_debug:


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Fix for: https://github.com/SeleniumHQ/docker-selenium/issues/599