### PR TITLE
pulseaudio installation on StandaloneFirefoxDebug Dockerfile

### DIFF
--- a/StandaloneFirefoxDebug/Dockerfile
+++ b/StandaloneFirefoxDebug/Dockerfile
@@ -8,6 +8,11 @@ LABEL authors=SeleniumHQ
 USER seluser
 
 #====================================
+# Installation of pulseaudio to support WebRTC with audio streams
+#====================================
+RUN sudo apt-get update && sudo apt-get install -y pulseaudio
+
+#====================================
 # Scripts to run Selenium Standalone
 #====================================
 COPY entry_point.sh /opt/bin/entry_point.sh


### PR DESCRIPTION
- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Installation of *pulseaudio* package on **selenium/standalone-firefox-debug** to support WebRTC audio streams (see [https://bugzilla.mozilla.org/show_bug.cgi?id=1247056](https://bugzilla.mozilla.org/show_bug.cgi?id=1247056)).

This simple change allows Standalone Firefox Debug to host WebRTC tests that include audio streams. Otherwise, WebRTC transmissions fail without any proper error message.