### PR TITLE
Add -e /dev/stdout to xvfb-run

### DIFF
--- a/Standalone/entry_point.sh
+++ b/Standalone/entry_point.sh
@@ -19,7 +19,7 @@ SERVERNUM=$(get_server_num)
 
 rm -f /tmp/.X*lock
 
-xvfb-run -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+xvfb-run -e /dev/stdout -n $SERVERNUM --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
   ${SE_OPTS} &
 NODE_PID=$!


### PR DESCRIPTION
So when Xvfb failed to start we have a remote ideas of what went wrong.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
