### PR TITLE
Upgrade packages in base image

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -17,6 +17,7 @@ ENV DEBIAN_FRONTEND=noninteractive \
 # Includes minimal runtime used for executing non GUI Java programs
 #========================
 RUN apt-get -qqy update \
+  && apt-get upgrade -y \
   && apt-get -qqy --no-install-recommends install \
     bzip2 \
     ca-certificates \


### PR DESCRIPTION
There are numerous upgrades available to the Ubuntu base packages. These range from security updates to bug fixes. It makes sense to upgrade these packages to patch any security vulnerabilities and fix any potential bugs.

The Ubuntu LTS packages are usually very conservative, so there is limited (although possibly) some risk of breakages. This risk already exists for all installed packages though, as they will take the newest version.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
