### PR TITLE
HUB_HOST and HUB_PORT to handle hub and nodes

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -10,8 +10,20 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
+# In the long term the idea is to remove $HUB_PORT_4444_TCP_ADDR and $HUB_PORT_4444_TCP_PORT and only work with
+# $HUB_HOST and $HUB_PORT
+if [ ! -z "$HUB_HOST" ]; then
+  HUB_PORT_PARAM=4444
+  if [ ! -z "$HUB_PORT" ]; then
+      HUB_PORT_PARAM=${HUB_PORT}
+  fi
+  echo "Connecting to the Hub using the host ${HUB_HOST} and port ${HUB_PORT_PARAM}"
+  HUB_PORT_4444_TCP_ADDR=${HUB_HOST}
+  HUB_PORT_4444_TCP_PORT=${HUB_PORT_PARAM}
+fi
+
 if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
-  echo Not linked with a running Hub container 1>&2
+  echo "Not linked with a running Hub container" 1>&2
   exit 1
 fi
 

--- a/NodeDebug/entry_point.sh
+++ b/NodeDebug/entry_point.sh
@@ -12,8 +12,20 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
+# In the long term the idea is to remove $HUB_PORT_4444_TCP_ADDR and $HUB_PORT_4444_TCP_PORT and only work with
+# $HUB_HOST and $HUB_PORT
+if [ ! -z "$HUB_HOST" ]; then
+  HUB_PORT_PARAM=4444
+  if [ ! -z "$HUB_PORT" ]; then
+      HUB_PORT_PARAM=${HUB_PORT}
+  fi
+  echo "Connecting to the Hub using the host ${HUB_HOST} and port ${HUB_PORT_PARAM}"
+  HUB_PORT_4444_TCP_ADDR=${HUB_HOST}
+  HUB_PORT_4444_TCP_PORT=${HUB_PORT_PARAM}
+fi
+
 if [ -z "$HUB_PORT_4444_TCP_ADDR" ]; then
-  echo Not linked with a running Hub container 1>&2
+  echo "Not linked with a running Hub container" 1>&2
   exit 1
 fi
 

--- a/README.md
+++ b/README.md
@@ -164,7 +164,7 @@ can be used to supply the hub a url where the node is reachable under your speci
 
 ``` bash
 # Assuming a hub was already started
-$ docker run -d -e REMOTE_HOST="http://node_ip|node_name:node_port" selenium/node-firefox:3.8.1-bohrium
+$ docker run -d -e HUB_HOST=<hub_ip|hub_name> -e REMOTE_HOST="http://node_ip|node_name:node_port" selenium/node-firefox:3.8.1-bohrium
 ```
 
 ## Building the images

--- a/README.md
+++ b/README.md
@@ -69,8 +69,8 @@ A docker [network](https://docs.docker.com/engine/reference/commandline/network_
 ``` bash
 $ docker network create grid
 $ docker run -d -p 4444:4444 --net grid --name selenium-hub selenium/hub:3.8.1-bohrium
-$ docker run -d -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-chrome:3.8.1-bohrium
-$ docker run -d -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-firefox:3.8.1-bohrium
+$ docker run -d --net grid -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-chrome:3.8.1-bohrium
+$ docker run -d --net grid -e HUB_HOST=selenium-hub -v /dev/shm:/dev/shm selenium/node-firefox:3.8.1-bohrium
 ```
 
 When you are done using the grid and the containers have exited, the network can be removed with the following command:

--- a/README.md
+++ b/README.md
@@ -155,14 +155,16 @@ or `REMOTE_HOST` can be used.
 You can pass the `HUB_HOST` and `HUB_PORT` options to provide the hub address to a node when needed.
 
 ``` bash
-$ docker run -d -p 4444:4444 -e HUB_HOST=<hub_ip|hub_name> -e HUB_PORT=4444 selenium/node-chrome:3.8.1-bohrium
+# Assuming a hub was already started
+$ docker run -d -e HUB_HOST=<hub_ip|hub_name> -e HUB_PORT=4444 selenium/node-chrome:3.8.1-bohrium
 ```
 
 Some network topologies might prevent the hub to reach the node through the url given at registration time, `REMOTE_HOST`
 can be used to supply the hub a url where the node is reachable under your specific network configuration 
 
 ``` bash
-$ docker run -d -p 4444:4444 -e REMOTE_HOST="http://node_ip|node_name:node_port" selenium/node-firefox:3.8.1-bohrium
+# Assuming a hub was already started
+$ docker run -d -e REMOTE_HOST="http://node_ip|node_name:node_port" selenium/node-firefox:3.8.1-bohrium
 ```
 
 ## Building the images


### PR DESCRIPTION
This PR has the following objectives:

- Introduce `HUB_HOST` and `HUB_PORT` as a replacement to deprecate `HUB_PORT_4444_TCP_ADDR` and `HUB_PORT_4444_TCP_ADDR`.
  - In the entry scripts `HUB_HOST` and `HUB_PORT` will map to `HUB_PORT_4444_TCP_ADDR` and `HUB_PORT_4444_TCP_ADDR`, and when people use `--link` with the proposed container name in the examples `selenium-hub:hub`, it will continue to work.
  - `HUB_PORT_4444_TCP_ADDR` and `HUB_PORT_4444_TCP_ADDR` won't be mentioned anymore in the docs, so ideally people will migrate to this new env vars gradually.
  - If a user has the hub with the default 4444 port, then only `HUB_HOST` would be needed, since `HUB_PORT` is defaulting to 4444. The user is also able to overwrite `HUB_PORT` in case the hub is listening to a different port.

- Improving the README showing a "docker network" way to start the grid and a simple docker-compose example, with the intention that users tend to use these ones more than the `--link` option.

Credits to @SpencerMalone and @rubytester since most of the content comes from their work and ideas in #136 and #133.

@ddavison, could you please have a look? Let me know if something doesn't look straightforward to you. 

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
