### PR TITLE
Installing fonts only in one place

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -25,8 +25,6 @@ RUN apt-get -qqy update \
     sudo \
     unzip \
     wget \
-    ttf-wqy-microhei \
-    ttf-wqy-zenhei \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && sed -i 's/securerandom\.source=file:\/dev\/random/securerandom\.source=file:\/dev\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
 

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -9,6 +9,40 @@ RUN apt-get update -qqy \
     xvfb \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
+#================
+# Font libraries
+#================
+# libfontconfig            ~1 MB
+# libfreetype6             ~1 MB
+# xfonts-cyrillic          ~2 MB
+# xfonts-scalable          ~2 MB
+# fonts-liberation         ~3 MB
+# fonts-ipafont-gothic     ~13 MB
+# fonts-wqy-zenhei         ~17 MB
+# fonts-tlwg-loma-otf      ~300 KB
+# ttf-ubuntu-font-family   ~5 MB
+#   Ubuntu Font Family, sans-serif typeface hinted for clarity
+# Removed packages:
+# xfonts-100dpi            ~6 MB
+# xfonts-75dpi             ~6 MB
+# Regarding fonts-liberation see:
+#  https://github.com/SeleniumHQ/docker-selenium/issues/383#issuecomment-278367069
+# Layer size: small: 36.28 MB (with --no-install-recommends)
+# Layer size: small: 36.28 MB
+RUN apt -qqy update \
+  && apt -qqy --no-install-recommends install \
+    libfontconfig \
+    libfreetype6 \
+    xfonts-cyrillic \
+    xfonts-scalable \
+    fonts-liberation \
+    fonts-ipafont-gothic \
+    fonts-wqy-zenhei \
+    fonts-tlwg-loma-otf \
+    ttf-ubuntu-font-family \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt -qyy clean
+
 #===================================================
 # Run the following commands as non-privileged user
 #===================================================

--- a/NodeDebug/Dockerfile.txt
+++ b/NodeDebug/Dockerfile.txt
@@ -20,18 +20,6 @@ RUN locale-gen en_US.UTF-8 \
     language-pack-en \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-#=======
-# Fonts
-#=======
-RUN apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install \
-    fonts-ipafont-gothic \
-    xfonts-100dpi \
-    xfonts-75dpi \
-    xfonts-cyrillic \
-    xfonts-scalable \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 #=========
 # fluxbox
 # A fast, lightweight and responsive window manager


### PR DESCRIPTION
Fonts were only being installed in the debug images, which creates different behaviours between the normal and the debug images.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
