### PR TITLE
added ENV variable VNC_NO_PASSWORD to disable password auth

### DIFF
--- a/NodeDebug/entry_point.sh
+++ b/NodeDebug/entry_point.sh
@@ -40,6 +40,13 @@ if [ ! -z "$REMOTE_HOST" ]; then
   REMOTE_HOST_PARAM="-remoteHost $REMOTE_HOST"
 fi
 
+if [ ! -z $VNC_NO_PASSWORD ]; then
+    echo "starting VNC server without password authentication"
+    X11VNC_OPTS=
+else
+    X11VNC_OPTS=-usepw
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi
@@ -71,6 +78,6 @@ done
 
 fluxbox -display $DISPLAY &
 
-x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
+x11vnc $X11VNC_OPTS -forever -shared -rfbport 5900 -display $DISPLAY &
 
 wait $NODE_PID

--- a/README.md
+++ b/README.md
@@ -261,6 +261,8 @@ When you are prompted for the password it is `secret`. If you wish to change thi
 RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
 ```
 
+If you want to run VNC without password authentication you can set the environment variable `VNC_NO_PASSWORD=1`.
+
 ### Troubleshooting
 
 All output is sent to stdout so it can be inspected by running:

--- a/StandaloneDebug/entry_point.sh
+++ b/StandaloneDebug/entry_point.sh
@@ -11,6 +11,13 @@ function shutdown {
   wait $NODE_PID
 }
 
+if [ ! -z $VNC_NO_PASSWORD ]; then
+    echo "starting VNC server without password authentication"
+    X11VNC_OPTS=
+else
+    X11VNC_OPTS=-usepw
+fi
+
 if [ ! -z "$SE_OPTS" ]; then
   echo "appending selenium options: ${SE_OPTS}"
 fi
@@ -38,6 +45,6 @@ done
 
 fluxbox -display $DISPLAY &
 
-x11vnc -forever -usepw -shared -rfbport 5900 -display $DISPLAY &
+x11vnc $X11VNC_OPTS -forever -shared -rfbport 5900 -display $DISPLAY &
 
 wait $NODE_PID


### PR DESCRIPTION
fixes #701

Just supplying an empty password does not work, therefore I added a check which sets the proper command param.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
