### PR TITLE
Moving locale setting from debug to normal images. 

### DIFF
--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -1,13 +1,33 @@
 USER root
 
 #==============
-# VNC and Xvfb
+# Xvfb
 #==============
 RUN apt-get update -qqy \
   && apt-get -qqy install \
-    locales \
     xvfb \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+#==============================
+# Locale and encoding settings
+#==============================
+ENV LANG_WHICH en
+ENV LANG_WHERE US
+ENV ENCODING UTF-8
+ENV LANGUAGE ${LANG_WHICH}_${LANG_WHERE}.${ENCODING}
+ENV LANG ${LANGUAGE}
+# Layer size: small: ~9 MB
+# Layer size: small: ~9 MB MB (with --no-install-recommends)
+RUN apt -qqy update \
+  && apt -qqy --no-install-recommends install \
+    language-pack-en \
+    tzdata \
+    locales \
+  && locale-gen ${LANGUAGE} \
+  && dpkg-reconfigure --frontend noninteractive locales \
+  && apt -qyy autoremove \
+  && rm -rf /var/lib/apt/lists/* \
+  && apt -qyy clean
 
 #================
 # Font libraries

--- a/NodeDebug/Dockerfile.txt
+++ b/NodeDebug/Dockerfile.txt
@@ -8,18 +8,6 @@ RUN apt-get update -qqy \
   x11vnc \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-#=================
-# Locale settings
-#=================
-ENV LANGUAGE en_US.UTF-8
-ENV LANG en_US.UTF-8
-RUN locale-gen en_US.UTF-8 \
-  && dpkg-reconfigure --frontend noninteractive locales \
-  && apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install \
-    language-pack-en \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
-
 #=========
 # fluxbox
 # A fast, lightweight and responsive window manager


### PR DESCRIPTION
This was causing uneven behaviour, since the debug images had a more proper config, bugs were reported about things working on debug images and not on normal images. Fixes #657

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
