### PR TITLE
Add node host as a configurable variable

### DIFF
--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -91,6 +91,8 @@ ENV DISPLAY :99.0
 ENV NODE_MAX_INSTANCES 1
 # As integer, maps to "maxSession"
 ENV NODE_MAX_SESSION 1
+# As address, maps to "host"
+ENV NODE_HOST 0.0.0.0
 # As integer, maps to "port"
 ENV NODE_PORT 5555
 # In milliseconds, maps to "registerCycle"

--- a/NodeChrome/generate_config
+++ b/NodeChrome/generate_config
@@ -15,6 +15,7 @@ cat <<_EOF
   ],
   "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
   "maxSession": $NODE_MAX_SESSION,
+  "host": $NODE_HOST,
   "port": $NODE_PORT,
   "register": true,
   "registerCycle": $NODE_REGISTER_CYCLE,

--- a/NodeFirefox/generate_config
+++ b/NodeFirefox/generate_config
@@ -23,6 +23,7 @@ cat <<_EOF
   ],
   "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
   "maxSession": $NODE_MAX_SESSION,
+  "host": $NODE_HOST,
   "port": $NODE_PORT,
   "register": true,
   "registerCycle": $NODE_REGISTER_CYCLE,


### PR DESCRIPTION
The Node's host can now be configured through `NODE_HOST` environment variable, defaults to `0.0.0.0`.

____________

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
