### PR TITLE
Fix apt to apt-get

### DIFF
--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -25,16 +25,16 @@ ENV LANGUAGE ${LANG_WHICH}_${LANG_WHERE}.${ENCODING}
 ENV LANG ${LANGUAGE}
 # Layer size: small: ~9 MB
 # Layer size: small: ~9 MB MB (with --no-install-recommends)
-RUN apt -qqy update \
-  && apt -qqy --no-install-recommends install \
+RUN apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install \
     language-pack-en \
     tzdata \
     locales \
   && locale-gen ${LANGUAGE} \
   && dpkg-reconfigure --frontend noninteractive locales \
-  && apt -qyy autoremove \
+  && apt-get -qyy autoremove \
   && rm -rf /var/lib/apt/lists/* \
-  && apt -qyy clean
+  && apt-get -qyy clean
 
 #================
 # Font libraries
@@ -56,8 +56,8 @@ RUN apt -qqy update \
 #  https://github.com/SeleniumHQ/docker-selenium/issues/383#issuecomment-278367069
 # Layer size: small: 36.28 MB (with --no-install-recommends)
 # Layer size: small: 36.28 MB
-RUN apt -qqy update \
-  && apt -qqy --no-install-recommends install \
+RUN apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install \
     libfontconfig \
     libfreetype6 \
     xfonts-cyrillic \
@@ -68,7 +68,7 @@ RUN apt -qqy update \
     fonts-tlwg-loma-otf \
     ttf-ubuntu-font-family \
   && rm -rf /var/lib/apt/lists/* \
-  && apt -qyy clean
+  && apt-get -qyy clean
 
 #===================================================
 # Run the following commands as non-privileged user

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -18,16 +18,16 @@ ENV LANGUAGE ${LANG_WHICH}_${LANG_WHERE}.${ENCODING}
 ENV LANG ${LANGUAGE}
 # Layer size: small: ~9 MB
 # Layer size: small: ~9 MB MB (with --no-install-recommends)
-RUN apt -qqy update \
-  && apt -qqy --no-install-recommends install \
+RUN apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install \
     language-pack-en \
     tzdata \
     locales \
   && locale-gen ${LANGUAGE} \
   && dpkg-reconfigure --frontend noninteractive locales \
-  && apt -qyy autoremove \
+  && apt-get -qyy autoremove \
   && rm -rf /var/lib/apt/lists/* \
-  && apt -qyy clean
+  && apt-get -qyy clean
 
 #================
 # Font libraries
@@ -49,8 +49,8 @@ RUN apt -qqy update \
 #  https://github.com/SeleniumHQ/docker-selenium/issues/383#issuecomment-278367069
 # Layer size: small: 36.28 MB (with --no-install-recommends)
 # Layer size: small: 36.28 MB
-RUN apt -qqy update \
-  && apt -qqy --no-install-recommends install \
+RUN apt-get -qqy update \
+  && apt-get -qqy --no-install-recommends install \
     libfontconfig \
     libfreetype6 \
     xfonts-cyrillic \
@@ -61,7 +61,7 @@ RUN apt -qqy update \
     fonts-tlwg-loma-otf \
     ttf-ubuntu-font-family \
   && rm -rf /var/lib/apt/lists/* \
-  && apt -qyy clean
+  && apt-get -qyy clean
 
 #===================================================
 # Run the following commands as non-privileged user


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

Fixing warning logs while building NodeBase docker image:

`WARNING: apt does not have a stable CLI interface. Use with caution in scripts.`