### PR TITLE
Allow to change the grid hub host

### DIFF
--- a/Hub/Dockerfile.txt
+++ b/Hub/Dockerfile.txt
@@ -24,7 +24,9 @@ ENV GRID_TIMEOUT 30
 ENV GRID_DEBUG false
 # As integer, maps to "port"
 ENV GRID_HUB_PORT 4444
-
+# As string, maps to "host"
+ENV GRID_HUB_HOST "0.0.0.0"
+ 
 COPY generate_config \
     entry_point.sh \
     /opt/bin/

--- a/Hub/generate_config
+++ b/Hub/generate_config
@@ -2,6 +2,7 @@
 
 cat <<_EOF
 {
+  "host": "$GRID_HUB_HOST",
   "port": $GRID_HUB_PORT,
   "role": "hub",
   "maxSession": $GRID_MAX_SESSION,


### PR DESCRIPTION
This allows users to specify the IP to which the hub can be bind to instead of default eth0 interface. This is especially useful when there is a need to restrict access to the selenium hub by binding it to `127.0.0.1`

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
