### PR TITLE
change depth from 12 to 24. Using 12 gave an xvfb error when starting…

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,7 +200,7 @@ $ docker run -d -e HUB_HOST=<hub_ip|hub_name> -e REMOTE_HOST="http://node_ip|nod
 By default, nodes start with a screen resolution of 1360 x 1020 with a color depth of 24 bits.  These settings can be adjusted by specifying `SCREEN_WIDTH`, `SCREEN_HEIGHT` and/or `ENV SCREEN_DEPTH` environmental variables when starting the container.
 
 ``` bash
-docker run -d -e SCREEN_WIDTH=1366 -e SCREEN_HEIGHT=768 -e SCREEN_DEPTH=12 selenium/standalone-firefox
+docker run -d -e SCREEN_WIDTH=1366 -e SCREEN_HEIGHT=768 -e SCREEN_DEPTH=24 selenium/standalone-firefox
 ```
 
 ### Increasing the number of browser instances/slots


### PR DESCRIPTION
… container

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
