### PR TITLE
Fix typo "deattached" in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,8 +89,8 @@ snippet as your `docker-compose.yaml`, save it locally and in the same folder ru
 
 ##### Version 2
 ```yaml
-# To execute this docker-compose yml file use docker-compose -f <file_name> up
-# Add the "-d" flag at the end for deattached execution
+# To execute this docker-compose yml file use `docker-compose -f <file_name> up`
+# Add the `-d` flag at the end for detached execution
 version: '2'
 services:
   firefox:
@@ -119,8 +119,8 @@ services:
 
 ##### Version 3
 ```yaml
-# To execute this docker-compose yml file use docker-compose -f <file_name> up
-# Add the "-d" flag at the end for deattached execution
+# To execute this docker-compose yml file use `docker-compose -f <file_name> up`
+# Add the `-d` flag at the end for detached execution
 version: "3"
 services:
   selenium-hub:


### PR DESCRIPTION
- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
