### PR TITLE
Grabbing the display created by Xvfb and passing it to x11vnc

### DIFF
--- a/NodeBase/entry_point.sh
+++ b/NodeBase/entry_point.sh
@@ -53,4 +53,4 @@ xvfb-run -a --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT
-wait $NODE_PID
+wait ${NODE_PID}

--- a/NodeDebug/entry_point.sh
+++ b/NodeDebug/entry_point.sh
@@ -52,33 +52,35 @@ fi
 
 rm -f /tmp/.X*lock
 
-xvfb-run -a --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
+# Creating a file descriptor, where the DISPLAY will be saved ("6" was arbitrarily chosen)
+exec 6>/tmp/display.log
+xvfb-run -a --server-args="-screen 0 $GEOMETRY -ac +extension RANDR -displayfd 6" \
   java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
     -role node \
-    -hub http://$HUB_PORT_4444_TCP_ADDR:$HUB_PORT_4444_TCP_PORT/grid/register \
+    -hub http://${HUB_PORT_4444_TCP_ADDR}:${HUB_PORT_4444_TCP_PORT}/grid/register \
     ${REMOTE_HOST_PARAM} \
     -nodeConfig /opt/selenium/config.json \
     ${SE_OPTS} &
 NODE_PID=$!
+exec 6>&-
 
 trap shutdown SIGTERM SIGINT
 for i in $(seq 1 10)
 do
-  DISPLAY=$(xvfb-run printenv DISPLAY)
-  if [ -z "$DISPLAY" ]; then
-    echo "\$DISPLAY env variable is empty"
-    break
+  sleep 1
+  export DISPLAY=:$(cat /tmp/display.log)
+  if [ "${DISPLAY}" != ":" ]; then
+    echo "Display ${DISPLAY} allocated"
   fi
-  xdpyinfo -display $DISPLAY >/dev/null 2>&1
+  xdpyinfo -display ${DISPLAY} >/dev/null 2>&1
   if [ $? -eq 0 ]; then
     break
   fi
-  echo Waiting xvfb...
-  sleep 0.5
+  echo "Waiting xvfb..."
 done
 
-fluxbox -display $DISPLAY &
+fluxbox -display ${DISPLAY} &
 
-x11vnc $X11VNC_OPTS -forever -shared -rfbport 5900 -display $DISPLAY &
+x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -display ${DISPLAY} &
 
-wait $NODE_PID
+wait ${NODE_PID}

--- a/Standalone/entry_point.sh
+++ b/Standalone/entry_point.sh
@@ -21,4 +21,4 @@ xvfb-run -a --server-args="-screen 0 $GEOMETRY -ac +extension RANDR" \
 NODE_PID=$!
 
 trap shutdown SIGTERM SIGINT
-wait $NODE_PID
+wait ${NODE_PID}


### PR DESCRIPTION
https://github.com/SeleniumHQ/docker-selenium/commit/8fdb9290a5f9869e402f16fe5d2712caa1c39c54 improved the use of Xvfb by using the `-a` flag to allocate a free DISPLAY, this PR fixes that part for the debug images, since VNC was not starting because DISPLAY was not found.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
