### PR TITLE
Support Arbitrary User IDs for OpenShift

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -47,6 +47,7 @@ RUN useradd seluser \
   && usermod -a -G sudo seluser \
   && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
   && echo 'seluser:secret' | chpasswd
+ENV HOME=/home/seluser
 
 #=======================================
 # Create shared / common bin directory
@@ -71,4 +72,6 @@ USER seluser
 RUN  sudo mkdir -p /opt/selenium \
   && sudo chown seluser:seluser /opt/selenium \
   && wget --no-verbose https://selenium-release.storage.googleapis.com/3.14/selenium-server-standalone-3.14.0.jar \
-    -O /opt/selenium/selenium-server-standalone.jar
+    -O /opt/selenium/selenium-server-standalone.jar \
+  && sudo chgrp -R 0 /opt/selenium $HOME \
+  && sudo chmod -R g=u /opt/selenium $HOME


### PR DESCRIPTION
To quote from the official [OpenShift documentation](https://docs.openshift.com/container-platform/3.9/creating_images/guidelines.html):

> By default, OpenShift Container Platform runs containers using an arbitrarily assigned user ID. This provides additional security against processes escaping the container due to a container engine vulnerability and thereby achieving escalated permissions on the host node.

> For an image to support running as an arbitrary user, directories and files that may be written to by processes in the image should be owned by the root group and be read/writable by that group. Files to be executed should also have group execute permissions.

With this change it should be possible to run the Selenium images on OpenShift without further modifications.

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->


- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
