### PR TITLE
Adding START_XVFB as a env var to start (or not) Xvfb

### DIFF
--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -89,6 +89,7 @@ ENV SCREEN_WIDTH 1360
 ENV SCREEN_HEIGHT 1020
 ENV SCREEN_DEPTH 24
 ENV DISPLAY :99.0
+ENV START_XVFB true
 
 #========================
 # Selenium Configuration

--- a/NodeBase/start-xvfb.sh
+++ b/NodeBase/start-xvfb.sh
@@ -1,7 +1,11 @@
 #!/usr/bin/env bash
 
-export GEOMETRY="${SCREEN_WIDTH}""x""${SCREEN_HEIGHT}""x""${SCREEN_DEPTH}"
+if [ "${START_XVFB}" = true ] ; then
+  export GEOMETRY="${SCREEN_WIDTH}""x""${SCREEN_HEIGHT}""x""${SCREEN_DEPTH}"
 
-rm -f /tmp/.X*lock
+  rm -f /tmp/.X*lock
 
-/usr/bin/Xvfb ${DISPLAY} -screen 0 ${GEOMETRY} -ac +extension RANDR
+  /usr/bin/Xvfb ${DISPLAY} -screen 0 ${GEOMETRY} -ac +extension RANDR
+else
+  echo "Xvfb won't start. Chrome/Firefox can only run in headless mode. Remember to set the 'headless' flag in your test."
+fi

--- a/NodeDebug/start-fluxbox.sh
+++ b/NodeDebug/start-fluxbox.sh
@@ -2,4 +2,8 @@
 #
 # IMPORTANT: Change this file only in directory NodeDebug!
 
-fluxbox -display ${DISPLAY}
+if [ "${START_XVFB}" = true ] ; then
+  fluxbox -display ${DISPLAY}
+else
+  echo "Fluxbox won't start because Xvfb is configured to not start."
+fi

--- a/NodeDebug/start-vnc.sh
+++ b/NodeDebug/start-vnc.sh
@@ -2,21 +2,25 @@
 #
 # IMPORTANT: Change this file only in directory NodeDebug!
 
-if [ ! -z $VNC_NO_PASSWORD ]; then
-    echo "Starting VNC server without password authentication"
-    X11VNC_OPTS=
-else
-    X11VNC_OPTS=-usepw
-fi
-
-for i in $(seq 1 10)
-do
-  sleep 1
-  xdpyinfo -display ${DISPLAY} >/dev/null 2>&1
-  if [ $? -eq 0 ]; then
-    break
+if [ "${START_XVFB}" = true ] ; then
+  if [ ! -z $VNC_NO_PASSWORD ]; then
+      echo "Starting VNC server without password authentication"
+      X11VNC_OPTS=
+  else
+      X11VNC_OPTS=-usepw
   fi
-  echo "Waiting for Xvfb..."
-done
 
-x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -display ${DISPLAY}
+  for i in $(seq 1 10)
+  do
+    sleep 1
+    xdpyinfo -display ${DISPLAY} >/dev/null 2>&1
+    if [ $? -eq 0 ]; then
+      break
+    fi
+    echo "Waiting for Xvfb..."
+  done
+
+  x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -display ${DISPLAY}
+else
+  echo "Vnc won't start because Xvfb is configured to not start."
+fi


### PR DESCRIPTION
If a user wants to run Chrome and Firefox in headless mode and thinks that Xvfb
uses too many resources. Fixes #429 and fixes #567.

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
