### PR TITLE
Preserve the test return code for non-travis environments

### DIFF
--- a/tests/bootstrap.sh
+++ b/tests/bootstrap.sh
@@ -13,7 +13,10 @@ pip install selenium===3.14.1 \
             | grep -v 'Requirement already satisfied'
 
 python test.py $1 $2
+ret_code=$?
 
 if [ "${TRAVIS:-false}" = "false" ]; then
   deactivate
 fi
+
+exit $ret_code


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

Before, even if the test fails, in non-Travis environment, the test script still return 0 because of `deactivate`. This preserves the return code from the test step so it could be returned correctly.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

/cc @diemol 
