### PR TITLE
Fix issue with shebang length being too long in pip executable

### DIFF
--- a/tests/bootstrap.sh
+++ b/tests/bootstrap.sh
@@ -8,9 +8,9 @@ if [ "${TRAVIS:-false}" = "false" ]; then
 fi
 
 
-pip install selenium===3.14.1 \
-            docker===3.5.0 \
-            | grep -v 'Requirement already satisfied'
+python -m pip install selenium===3.14.1 \
+                      docker===3.5.0 \
+                      | grep -v 'Requirement already satisfied'
 
 python test.py $1 $2
 ret_code=$?


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

I was trying to run `docker-selenium` test suite on my Jenkins instance, and ran into an issue where the pip executable's shebang length being too long. Jenkins tends to have very long directory path. Here's an example:

```
#!/bb/jenkins/workspace/icense_docker-selenium_PR-1-GNCWWURZ32MIKRWRAGOJLHHRNQDNWKSNBSNTKV5GAN44JPAJLVLQ/tests/docker-selenium-tests/bin/python2
```

The error:

```
-bash: /bb/jenkins/workspace/icense_docker-selenium_PR-1-GNCWWURZ32MIKRWRAGOJLHHRNQDNWKSNBSNTKV5GAN44JPAJLVLQ/tests/docker-selenium-tests/bin/pip: /bb/jenkins/workspace/icense_docker-selenium_PR-1-GNCWWURZ32MIKRWRAGOJLHHRNQDN: bad interpreter: No such file or directory
```

This fix uses the suggestion suggested in https://github.com/pypa/virtualenv/issues/596#issuecomment-411485104

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

/cc @diemol 