### PR TITLE
Allow proxy env variables to be set/inherited

### DIFF
--- a/tests/test.py
+++ b/tests/test.py
@@ -17,6 +17,9 @@ client = docker.from_env()
 NAMESPACE = os.environ.get('NAMESPACE')
 VERSION = os.environ.get('VERSION')
 USE_RANDOM_USER_ID = os.environ.get('USE_RANDOM_USER_ID')
+http_proxy = os.environ.get('http_proxy', '')
+https_proxy = os.environ.get('https_proxy', '')
+no_proxy = os.environ.get('no_proxy', '')
 
 IMAGE_NAME_MAP = {
     # Hub
@@ -100,6 +103,11 @@ def launch_container(container, **kwargs):
     logger.info("Running %s container..." % container)
     container_id = client.containers.run("%s/%s:%s" % (NAMESPACE, IMAGE_NAME_MAP[container], VERSION),
                                          detach=True,
+                                         environment={
+                                             'http_proxy': http_proxy,
+                                             'https_proxy': https_proxy,
+                                             'no_proxy': no_proxy
+                                         },
                                          **kwargs).short_id
     logger.info("%s up and running" % container)
     return container_id


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

When run in an environment that's behind a firewall, a proxy is sometimes needed to reach the Internet. I find this fix to be necessary for the tests to pass in our environment. I'm not sure if it's an appropriate change, but I figured I should at least submit.

- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)

/cc @diemol 