### PR TITLE
Fix crashes in x11vnc

### DIFF
--- a/NodeDebug/start-vnc.sh
+++ b/NodeDebug/start-vnc.sh
@@ -19,8 +19,8 @@ if [ "${START_XVFB}" = true ] ; then
     fi
     echo "Waiting for Xvfb..."
   done
-
-  x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -display ${DISPLAY}
+  # -noxrecord fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=859213 in x11vnc 0.9.13-2
+  x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -display ${DISPLAY} -noxrecord
 else
   echo "Vnc won't start because Xvfb is configured to not start."
 fi


### PR DESCRIPTION
x11vnc 0.9.13-2 crashes frequently with the message "stack smashing detected". Adding -noxrecord prevents those crashes.

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->


- [ ] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
