### PR TITLE
Just make the version tag consistent with each other

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -41,7 +41,7 @@ Issues without a reproduction script are likely to stall and eventually be close
 ## Environment
 
 OS: <!-- Windows 10? OSX? -->
-Docker-Selenium image version: <!-- 3, 3.4, 3.141.59-krypton etc
+Docker-Selenium image version: <!-- 3, 3.141, 3.141.59-krypton etc
 Also provide the docker image id 
 -->
 Docker version: 

--- a/.github/ISSUE_TEMPLATE/bug.md
+++ b/.github/ISSUE_TEMPLATE/bug.md
@@ -41,7 +41,7 @@ Issues without a reproduction script are likely to stall and eventually be close
 ## Environment
 
 OS: <!-- Windows 10? OSX? -->
-Docker-Selenium image version: <!-- 3, 3.4, 3.141.59-krypton etc
+Docker-Selenium image version: <!-- 3, 3.141, 3.141.59-krypton etc
 Also provide the docker image id 
 -->
 Docker version: 

--- a/.github/ISSUE_TEMPLATE/regression.md
+++ b/.github/ISSUE_TEMPLATE/regression.md
@@ -47,7 +47,7 @@ Issues without a reproduction script are likely to stall and eventually be close
 ## Environment
 
 OS: <!-- Windows 10? OSX? -->
-Docker-Selenium image version: <!-- 3, 3.4, 3.141.59-krypton etc
+Docker-Selenium image version: <!-- 3, 3.141, 3.141.59-krypton etc
 Also provide the docker image id 
 -->
 Docker version: 


### PR DESCRIPTION
This PR is trying to reduce the confusion of the version tags in the Github issue templates. 

`3`, `3.141`, `3.141.59-krypton` are pointing to the same docker image. 

I was even thinking to include `3.141.59`, let me know if we want to pursue that.