### PR TITLE
Derive Chromedriver version to install from used Chrome (#885)

### DIFF
--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -40,8 +40,12 @@ USER seluser
 # can specify versions by CHROME_DRIVER_VERSION
 # Latest released version will be used by default
 #============================================
-ARG CHROME_DRIVER_VERSION="73.0.3683.68"
-RUN CD_VERSION=$(echo $CHROME_DRIVER_VERSION) \
+RUN CHROME_STRING=$(google-chrome --version) \ 
+  && CHROME_VERSION_STRING=$(echo "${CHROME_STRING}" | grep -oP "\d+\.\d+\.\d+\.\d+") \
+  && CHROME_MAYOR_VERSION=$(echo "${CHROME_VERSION_STRING%%.*}") \
+  && wget --no-verbose -O /tmp/LATEST_RELEASE "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAYOR_VERSION}" \
+  && CD_VERSION=$(cat "/tmp/LATEST_RELEASE") \
+  && rm /tmp/LATEST_RELEASE \
   && echo "Using chromedriver version: "$CD_VERSION \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -40,12 +40,17 @@ USER seluser
 # can specify versions by CHROME_DRIVER_VERSION
 # Latest released version will be used by default
 #============================================
+ARG CHROME_DRIVER_VERSION
 RUN CHROME_STRING=$(google-chrome --version) \ 
   && CHROME_VERSION_STRING=$(echo "${CHROME_STRING}" | grep -oP "\d+\.\d+\.\d+\.\d+") \
   && CHROME_MAYOR_VERSION=$(echo "${CHROME_VERSION_STRING%%.*}") \
   && wget --no-verbose -O /tmp/LATEST_RELEASE "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAYOR_VERSION}" \
   && CD_VERSION=$(cat "/tmp/LATEST_RELEASE") \
   && rm /tmp/LATEST_RELEASE \
+  && if [ -z "$CHROME_DRIVER_VERSION" ]; \
+     then CHROME_DRIVER_VERSION="${CD_VERSION}"; \
+     fi \
+  && CD_VERSION=$(echo $CHROME_DRIVER_VERSION) \
   && echo "Using chromedriver version: "$CD_VERSION \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -33,8 +33,12 @@ USER seluser
 # can specify versions by CHROME_DRIVER_VERSION
 # Latest released version will be used by default
 #============================================
-ARG CHROME_DRIVER_VERSION="73.0.3683.68"
-RUN CD_VERSION=$(echo $CHROME_DRIVER_VERSION) \
+RUN CHROME_STRING=$(google-chrome --version) \ 
+  && CHROME_VERSION_STRING=$(echo "${CHROME_STRING}" | grep -oP "\d+\.\d+\.\d+\.\d+") \
+  && CHROME_MAYOR_VERSION=$(echo "${CHROME_VERSION_STRING%%.*}") \
+  && wget --no-verbose -O /tmp/LATEST_RELEASE "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAYOR_VERSION}" \
+  && CD_VERSION=$(cat "/tmp/LATEST_RELEASE") \
+  && rm /tmp/LATEST_RELEASE \
   && echo "Using chromedriver version: "$CD_VERSION \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -33,12 +33,17 @@ USER seluser
 # can specify versions by CHROME_DRIVER_VERSION
 # Latest released version will be used by default
 #============================================
+ARG CHROME_DRIVER_VERSION
 RUN CHROME_STRING=$(google-chrome --version) \ 
   && CHROME_VERSION_STRING=$(echo "${CHROME_STRING}" | grep -oP "\d+\.\d+\.\d+\.\d+") \
   && CHROME_MAYOR_VERSION=$(echo "${CHROME_VERSION_STRING%%.*}") \
   && wget --no-verbose -O /tmp/LATEST_RELEASE "https://chromedriver.storage.googleapis.com/LATEST_RELEASE_${CHROME_MAYOR_VERSION}" \
   && CD_VERSION=$(cat "/tmp/LATEST_RELEASE") \
   && rm /tmp/LATEST_RELEASE \
+  && if [ -z "$CHROME_DRIVER_VERSION" ]; \
+     then CHROME_DRIVER_VERSION="${CD_VERSION}"; \
+     fi \
+  && CD_VERSION=$(echo $CHROME_DRIVER_VERSION) \
   && echo "Using chromedriver version: "$CD_VERSION \
   && wget --no-verbose -O /tmp/chromedriver_linux64.zip https://chromedriver.storage.googleapis.com/$CD_VERSION/chromedriver_linux64.zip \
   && rm -rf /opt/selenium/chromedriver \


### PR DESCRIPTION
This should replace the currently hardcoded chromedriver version string by making use of Googles new versioning scheme as well as the LASTEST_RELEASE file they provide for each major version of Chrome and Chromedriver, allowing for a match between those two.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
