### PR TITLE
Using python 2.7

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 language: python
+python: 2.7
 
 sudo: required
 


### PR DESCRIPTION
Travis is now defaulting to Python 3.6, we still need 2.7 until someone takes the time to upgrade the tests.

![image](https://user-images.githubusercontent.com/5992658/56648300-0e39d000-66be-11e9-82f3-a7b6b1e36d8f.png)


- [x] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
