### PR TITLE
Support basic Opera docker node

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,36 @@ MAJOR := $(word 1,$(subst ., ,$(VERSION)))
 MINOR := $(word 2,$(subst ., ,$(VERSION)))
 MAJOR_MINOR_PATCH := $(word 1,$(subst -, ,$(VERSION)))
 
-all: hub chrome firefox opera chrome_debug firefox_debug standalone_chrome standalone_firefox standalone_chrome_debug standalone_firefox_debug
+all: \
+	hub \
+	chrome \
+	firefox \
+	opera \
+	chrome_debug \
+	firefox_debug \
+	opera_debug \
+	standalone_chrome \
+	standalone_firefox \
+	standalone_opera \
+	standalone_chrome_debug \
+	standalone_firefox_debug \
+	standalone_opera_debug
 
 generate_all:	\
 	generate_hub \
 	generate_nodebase \
 	generate_chrome \
 	generate_firefox \
+	generate_opera \
 	generate_chrome_debug \
 	generate_firefox_debug \
+	generate_opera_debug \
 	generate_standalone_firefox \
 	generate_standalone_chrome \
+	generate_standalone_opera \
 	generate_standalone_firefox_debug \
-	generate_standalone_chrome_debug
+	generate_standalone_chrome_debug \
+	generate_standalone_opera_debug
 
 build: all
 
@@ -83,6 +100,18 @@ generate_standalone_chrome_debug:
 standalone_chrome_debug: chrome_debug generate_standalone_chrome_debug
 	cd ./StandaloneChromeDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-chrome-debug:$(VERSION) .
 
+generate_standalone_opera:
+	cd ./Standalone && ./generate.sh StandaloneOpera node-opera Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+standalone_opera: opera generate_standalone_opera
+	cd ./StandaloneOpera && docker build $(BUILD_ARGS) -t $(NAME)/standalone-opera:$(VERSION) .
+
+generate_standalone_opera_debug:
+	cd ./StandaloneOpera && ./generate.sh StandaloneOperaDebug node-opera-debug Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+standalone_opera_debug: opera_debug generate_standalone_opera_debug
+	cd ./StandaloneOperaDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-opera-debug:$(VERSION) .
+
 generate_chrome_debug:
 	cd ./NodeDebug && ./generate.sh NodeChromeDebug node-chrome Chrome $(VERSION) $(NAMESPACE) $(AUTHORS)
 
@@ -95,6 +124,12 @@ generate_firefox_debug:
 firefox_debug: generate_firefox_debug firefox
 	cd ./NodeFirefoxDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox-debug:$(VERSION) .
 
+generate_opera_debug:
+	cd ./NodeDebug && ./generate.sh NodeOperaDebug node-opera Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+chrome_debug: generate_opera_debug opera
+	cd ./NodeOperaDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-opera-debug:$(VERSION) .
+
 tag_latest:
 	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:latest
 	docker tag $(NAME)/hub:$(VERSION) $(NAME)/hub:latest
@@ -104,10 +139,13 @@ tag_latest:
 	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:latest
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:latest
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:latest
+	docker tag $(NAME)/node-opera-debug:$(VERSION) $(NAME)/node-opera-debug:latest
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:latest
 	docker tag $(NAME)/standalone-firefox:$(VERSION) $(NAME)/standalone-firefox:latest
+	docker tag $(NAME)/standalone-opera:$(VERSION) $(NAME)/standalone-opera:latest
 	docker tag $(NAME)/standalone-chrome-debug:$(VERSION) $(NAME)/standalone-chrome-debug:latest
 	docker tag $(NAME)/standalone-firefox-debug:$(VERSION) $(NAME)/standalone-firefox-debug:latest
+	docker tag $(NAME)/standalone-opera-debug:$(VERSION) $(NAME)/standalone-opera-debug:latest
 
 release_latest:
 	docker push $(NAME)/base:latest
@@ -118,10 +156,13 @@ release_latest:
 	docker push $(NAME)/node-opera:latest
 	docker push $(NAME)/node-chrome-debug:latest
 	docker push $(NAME)/node-firefox-debug:latest
+	docker push $(NAME)/node-opera-debug:latest
 	docker push $(NAME)/standalone-chrome:latest
 	docker push $(NAME)/standalone-firefox:latest
+	docker push $(NAME)/standalone-opera:latest
 	docker push $(NAME)/standalone-chrome-debug:latest
 	docker push $(NAME)/standalone-firefox-debug:latest
+	docker push $(NAME)/standalone-opera-debug:latest
 
 tag_major_minor:
 	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:$(MAJOR)
@@ -132,10 +173,13 @@ tag_major_minor:
 	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:$(MAJOR)
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:$(MAJOR)
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:$(MAJOR)
+	docker tag $(NAME)/node-opera-debug:$(VERSION) $(NAME)/node-opera-debug:$(MAJOR)
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:$(MAJOR)
 	docker tag $(NAME)/standalone-firefox:$(VERSION) $(NAME)/standalone-firefox:$(MAJOR)
+	docker tag $(NAME)/standalone-opera:$(VERSION) $(NAME)/standalone-opera:$(MAJOR)
 	docker tag $(NAME)/standalone-chrome-debug:$(VERSION) $(NAME)/standalone-chrome-debug:$(MAJOR)
 	docker tag $(NAME)/standalone-firefox-debug:$(VERSION) $(NAME)/standalone-firefox-debug:$(MAJOR)
+	docker tag $(NAME)/standalone-opera-debug:$(VERSION) $(NAME)/standalone-opera-debug:$(MAJOR)
 	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/hub:$(VERSION) $(NAME)/hub:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:$(MAJOR).$(MINOR)
@@ -144,10 +188,13 @@ tag_major_minor:
 	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:$(MAJOR).$(MINOR)
+	docker tag $(NAME)/node-opera-debug:$(VERSION) $(NAME)/node-opera-debug:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/standalone-firefox:$(VERSION) $(NAME)/standalone-firefox:$(MAJOR).$(MINOR)
+	docker tag $(NAME)/standalone-opera:$(VERSION) $(NAME)/standalone-opera:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/standalone-chrome-debug:$(VERSION) $(NAME)/standalone-chrome-debug:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/standalone-firefox-debug:$(VERSION) $(NAME)/standalone-firefox-debug:$(MAJOR).$(MINOR)
+	docker tag $(NAME)/standalone-opera-debug:$(VERSION) $(NAME)/standalone-opera-debug:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/hub:$(VERSION) $(NAME)/hub:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:$(MAJOR_MINOR_PATCH)
@@ -156,10 +203,13 @@ tag_major_minor:
 	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:$(MAJOR_MINOR_PATCH)
+	docker tag $(NAME)/node-opera-debug:$(VERSION) $(NAME)/node-opera-debug:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/standalone-firefox:$(VERSION) $(NAME)/standalone-firefox:$(MAJOR_MINOR_PATCH)
+	docker tag $(NAME)/standalone-opera:$(VERSION) $(NAME)/standalone-opera:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/standalone-chrome-debug:$(VERSION) $(NAME)/standalone-chrome-debug:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/standalone-firefox-debug:$(VERSION) $(NAME)/standalone-firefox-debug:$(MAJOR_MINOR_PATCH)
+	docker tag $(NAME)/standalone-opera-debug:$(VERSION) $(NAME)/standalone-opera-debug:$(MAJOR_MINOR_PATCH)
 
 release: tag_major_minor
 	@if ! docker images $(NAME)/base | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/base version $(VERSION) is not yet built. Please run 'make build'"; false; fi
@@ -170,10 +220,13 @@ release: tag_major_minor
 	@if ! docker images $(NAME)/node-opera | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-opera version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/node-chrome-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-chrome-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/node-firefox-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-firefox-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	@if ! docker images $(NAME)/node-opera-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-opera-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/standalone-chrome | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-chrome version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/standalone-firefox | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-firefox version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	@if ! docker images $(NAME)/standalone-opera | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-opera version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/standalone-chrome-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-chrome-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/standalone-firefox-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-firefox-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	@if ! docker images $(NAME)/standalone-opera-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-opera-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	docker push $(NAME)/base:$(VERSION)
 	docker push $(NAME)/hub:$(VERSION)
 	docker push $(NAME)/node-base:$(VERSION)
@@ -182,10 +235,13 @@ release: tag_major_minor
 	docker push $(NAME)/node-opera:$(VERSION)
 	docker push $(NAME)/node-chrome-debug:$(VERSION)
 	docker push $(NAME)/node-firefox-debug:$(VERSION)
+	docker push $(NAME)/node-opera-debug:$(VERSION)
 	docker push $(NAME)/standalone-chrome:$(VERSION)
 	docker push $(NAME)/standalone-firefox:$(VERSION)
+	docker push $(NAME)/standalone-opera:$(VERSION)
 	docker push $(NAME)/standalone-chrome-debug:$(VERSION)
 	docker push $(NAME)/standalone-firefox-debug:$(VERSION)
+	docker push $(NAME)/standalone-opera-debug:$(VERSION)
 	docker push $(NAME)/base:$(MAJOR)
 	docker push $(NAME)/hub:$(MAJOR)
 	docker push $(NAME)/node-base:$(MAJOR)
@@ -194,10 +250,13 @@ release: tag_major_minor
 	docker push $(NAME)/node-opera:$(MAJOR)
 	docker push $(NAME)/node-chrome-debug:$(MAJOR)
 	docker push $(NAME)/node-firefox-debug:$(MAJOR)
+	docker push $(NAME)/node-opera-debug:$(MAJOR)
 	docker push $(NAME)/standalone-chrome:$(MAJOR)
 	docker push $(NAME)/standalone-firefox:$(MAJOR)
+	docker push $(NAME)/standalone-opera:$(MAJOR)
 	docker push $(NAME)/standalone-chrome-debug:$(MAJOR)
 	docker push $(NAME)/standalone-firefox-debug:$(MAJOR)
+	docker push $(NAME)/standalone-opera-debug:$(MAJOR)
 	docker push $(NAME)/base:$(MAJOR).$(MINOR)
 	docker push $(NAME)/hub:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-base:$(MAJOR).$(MINOR)
@@ -206,10 +265,13 @@ release: tag_major_minor
 	docker push $(NAME)/node-opera:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-chrome-debug:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-firefox-debug:$(MAJOR).$(MINOR)
+	docker push $(NAME)/node-opera-debug:$(MAJOR).$(MINOR)
 	docker push $(NAME)/standalone-chrome:$(MAJOR).$(MINOR)
 	docker push $(NAME)/standalone-firefox:$(MAJOR).$(MINOR)
+	docker push $(NAME)/standalone-opera:$(MAJOR).$(MINOR)
 	docker push $(NAME)/standalone-chrome-debug:$(MAJOR).$(MINOR)
 	docker push $(NAME)/standalone-firefox-debug:$(MAJOR).$(MINOR)
+	docker push $(NAME)/standalone-opera-debug:$(MAJOR).$(MINOR)
 	docker push $(NAME)/base:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/hub:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-base:$(MAJOR_MINOR_PATCH)
@@ -218,10 +280,13 @@ release: tag_major_minor
 	docker push $(NAME)/node-opera:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-chrome-debug:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-firefox-debug:$(MAJOR_MINOR_PATCH)
+	docker push $(NAME)/node-opera-debug:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/standalone-chrome:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/standalone-firefox:$(MAJOR_MINOR_PATCH)
+	docker push $(NAME)/standalone-opera:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/standalone-chrome-debug:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/standalone-firefox-debug:$(MAJOR_MINOR_PATCH)
+	docker push $(NAME)/standalone-opera-debug:$(MAJOR_MINOR_PATCH)
 
 test: test_chrome \
  test_firefox \
@@ -261,6 +326,15 @@ test_firefox_standalone_debug:
 test_opera:
 	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh NodeOpera
 
+test_opera_debug:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh NodeOperaDebug
+
+test_opera_standalone:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh StandaloneOpera
+
+test_opera_standalone_debug:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh StandaloneOperaDebug
+
 
 .PHONY: \
 	all \
@@ -272,6 +346,7 @@ test_opera:
 	firefox \
 	firefox_debug \
 	opera \
+	opera_debug \
 	generate_all \
 	generate_hub \
 	generate_nodebase \
@@ -280,16 +355,21 @@ test_opera:
 	generate_opera \
 	generate_chrome_debug \
 	generate_firefox_debug \
+	generate_opera_debug \
 	generate_standalone_chrome \
 	generate_standalone_firefox \
+	generate_standalone_opera \
 	generate_standalone_chrome_debug \
 	generate_standalone_firefox_debug \
+	generate_standalone_opera_debug \
 	hub \
 	nodebase \
 	release \
 	standalone_chrome \
 	standalone_firefox \
+	standalone_opera \
 	standalone_chrome_debug \
 	standalone_firefox_debug \
+	standalone_opera_debug \
 	tag_latest \
 	test

--- a/Makefile
+++ b/Makefile
@@ -8,7 +8,7 @@ MAJOR := $(word 1,$(subst ., ,$(VERSION)))
 MINOR := $(word 2,$(subst ., ,$(VERSION)))
 MAJOR_MINOR_PATCH := $(word 1,$(subst -, ,$(VERSION)))
 
-all: hub chrome firefox chrome_debug firefox_debug standalone_chrome standalone_firefox standalone_chrome_debug standalone_firefox_debug
+all: hub chrome firefox opera chrome_debug firefox_debug standalone_chrome standalone_firefox standalone_chrome_debug standalone_firefox_debug
 
 generate_all:	\
 	generate_hub \
@@ -53,6 +53,12 @@ generate_firefox:
 firefox: nodebase generate_firefox
 	cd ./NodeFirefox && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox:$(VERSION) .
 
+generate_opera:
+	cd ./NodeOpera && ./generate.sh $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+opera: nodebase generate_opera
+	cd ./NodeOpera && docker build $(BUILD_ARGS) -t $(NAME)/node-opera:$(VERSION) .
+
 generate_standalone_firefox:
 	cd ./Standalone && ./generate.sh StandaloneFirefox node-firefox Firefox $(VERSION) $(NAMESPACE) $(AUTHORS)
 
@@ -95,6 +101,7 @@ tag_latest:
 	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:latest
 	docker tag $(NAME)/node-chrome:$(VERSION) $(NAME)/node-chrome:latest
 	docker tag $(NAME)/node-firefox:$(VERSION) $(NAME)/node-firefox:latest
+	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:latest
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:latest
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:latest
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:latest
@@ -108,6 +115,7 @@ release_latest:
 	docker push $(NAME)/node-base:latest
 	docker push $(NAME)/node-chrome:latest
 	docker push $(NAME)/node-firefox:latest
+	docker push $(NAME)/node-opera:latest
 	docker push $(NAME)/node-chrome-debug:latest
 	docker push $(NAME)/node-firefox-debug:latest
 	docker push $(NAME)/standalone-chrome:latest
@@ -121,6 +129,7 @@ tag_major_minor:
 	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:$(MAJOR)
 	docker tag $(NAME)/node-chrome:$(VERSION) $(NAME)/node-chrome:$(MAJOR)
 	docker tag $(NAME)/node-firefox:$(VERSION) $(NAME)/node-firefox:$(MAJOR)
+	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:$(MAJOR)
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:$(MAJOR)
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:$(MAJOR)
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:$(MAJOR)
@@ -132,6 +141,7 @@ tag_major_minor:
 	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-chrome:$(VERSION) $(NAME)/node-chrome:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-firefox:$(VERSION) $(NAME)/node-firefox:$(MAJOR).$(MINOR)
+	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:$(MAJOR).$(MINOR)
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:$(MAJOR).$(MINOR)
@@ -143,6 +153,7 @@ tag_major_minor:
 	docker tag $(NAME)/node-base:$(VERSION) $(NAME)/node-base:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-chrome:$(VERSION) $(NAME)/node-chrome:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-firefox:$(VERSION) $(NAME)/node-firefox:$(MAJOR_MINOR_PATCH)
+	docker tag $(NAME)/node-opera:$(VERSION) $(NAME)/node-opera:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-chrome-debug:$(VERSION) $(NAME)/node-chrome-debug:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/node-firefox-debug:$(VERSION) $(NAME)/node-firefox-debug:$(MAJOR_MINOR_PATCH)
 	docker tag $(NAME)/standalone-chrome:$(VERSION) $(NAME)/standalone-chrome:$(MAJOR_MINOR_PATCH)
@@ -156,6 +167,7 @@ release: tag_major_minor
 	@if ! docker images $(NAME)/node-base | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-base version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/node-chrome | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-chrome version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/node-firefox | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-firefox version $(VERSION) is not yet built. Please run 'make build'"; false; fi
+	@if ! docker images $(NAME)/node-opera | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-opera version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/node-chrome-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-chrome-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/node-firefox-debug | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/node-firefox-debug version $(VERSION) is not yet built. Please run 'make build'"; false; fi
 	@if ! docker images $(NAME)/standalone-chrome | awk '{ print $$2 }' | grep -q -F $(VERSION); then echo "$(NAME)/standalone-chrome version $(VERSION) is not yet built. Please run 'make build'"; false; fi
@@ -167,6 +179,7 @@ release: tag_major_minor
 	docker push $(NAME)/node-base:$(VERSION)
 	docker push $(NAME)/node-chrome:$(VERSION)
 	docker push $(NAME)/node-firefox:$(VERSION)
+	docker push $(NAME)/node-opera:$(VERSION)
 	docker push $(NAME)/node-chrome-debug:$(VERSION)
 	docker push $(NAME)/node-firefox-debug:$(VERSION)
 	docker push $(NAME)/standalone-chrome:$(VERSION)
@@ -178,6 +191,7 @@ release: tag_major_minor
 	docker push $(NAME)/node-base:$(MAJOR)
 	docker push $(NAME)/node-chrome:$(MAJOR)
 	docker push $(NAME)/node-firefox:$(MAJOR)
+	docker push $(NAME)/node-opera:$(MAJOR)
 	docker push $(NAME)/node-chrome-debug:$(MAJOR)
 	docker push $(NAME)/node-firefox-debug:$(MAJOR)
 	docker push $(NAME)/standalone-chrome:$(MAJOR)
@@ -189,6 +203,7 @@ release: tag_major_minor
 	docker push $(NAME)/node-base:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-chrome:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-firefox:$(MAJOR).$(MINOR)
+	docker push $(NAME)/node-opera:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-chrome-debug:$(MAJOR).$(MINOR)
 	docker push $(NAME)/node-firefox-debug:$(MAJOR).$(MINOR)
 	docker push $(NAME)/standalone-chrome:$(MAJOR).$(MINOR)
@@ -200,6 +215,7 @@ release: tag_major_minor
 	docker push $(NAME)/node-base:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-chrome:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-firefox:$(MAJOR_MINOR_PATCH)
+	docker push $(NAME)/node-opera:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-chrome-debug:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/node-firefox-debug:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/standalone-chrome:$(MAJOR_MINOR_PATCH)
@@ -214,7 +230,8 @@ test: test_chrome \
  test_chrome_standalone \
  test_firefox_standalone \
  test_chrome_standalone_debug \
- test_firefox_standalone_debug
+ test_firefox_standalone_debug \
+ test_opera
 
 
 test_chrome:
@@ -241,6 +258,9 @@ test_firefox_standalone:
 test_firefox_standalone_debug:
 	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh StandaloneFirefoxDebug
 
+test_opera:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh NodeOpera
+
 
 .PHONY: \
 	all \
@@ -251,11 +271,13 @@ test_firefox_standalone_debug:
 	ci \
 	firefox \
 	firefox_debug \
+	opera \
 	generate_all \
 	generate_hub \
 	generate_nodebase \
 	generate_chrome \
 	generate_firefox \
+	generate_opera \
 	generate_chrome_debug \
 	generate_firefox_debug \
 	generate_standalone_chrome \

--- a/Makefile
+++ b/Makefile
@@ -107,7 +107,7 @@ standalone_opera: opera generate_standalone_opera
 	cd ./StandaloneOpera && docker build $(BUILD_ARGS) -t $(NAME)/standalone-opera:$(VERSION) .
 
 generate_standalone_opera_debug:
-	cd ./StandaloneOpera && ./generate.sh StandaloneOperaDebug node-opera-debug Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+	cd ./StandaloneDebug && ./generate.sh StandaloneOperaDebug node-opera-debug Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
 
 standalone_opera_debug: opera_debug generate_standalone_opera_debug
 	cd ./StandaloneOperaDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-opera-debug:$(VERSION) .
@@ -127,7 +127,7 @@ firefox_debug: generate_firefox_debug firefox
 generate_opera_debug:
 	cd ./NodeDebug && ./generate.sh NodeOperaDebug node-opera Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
 
-chrome_debug: generate_opera_debug opera
+opera_debug: generate_opera_debug opera
 	cd ./NodeOperaDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-opera-debug:$(VERSION) .
 
 tag_latest:
@@ -296,8 +296,10 @@ test: test_chrome \
  test_firefox_standalone \
  test_chrome_standalone_debug \
  test_firefox_standalone_debug \
- test_opera
-
+ test_opera \
+ test_opera_debug \
+ test_opera_standalone \
+ test_opera_standalone_debug
 
 test_chrome:
 	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh NodeChrome

--- a/NodeOpera/.gitignore
+++ b/NodeOpera/.gitignore
@@ -1,0 +1,2 @@
+# The Dockerfile will be generated.
+Dockerfile

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -1,7 +1,5 @@
 USER root
 
-USER root
-
 #=========
 # Opera
 #=========
@@ -10,7 +8,8 @@ RUN wget -O- http://deb.opera.com/archive.key | apt-key add - && \
      apt-get update && \
      apt-get -y --no-install-recommends install opera-stable && \
      opera --version && \
-     rm -rf /etc/apt/sources.list.d/opera-blink.list
+     rm -rf /etc/apt/sources.list.d/opera-stable.list && \
+     rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=================================
 # Opera Launch Script Wrapper

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -3,7 +3,6 @@ USER root
 #=========
 # Opera
 #=========
-ENV OPERA_VERSION=60.0.3255.170
 ENV OPERA_DRIVER_VERSION=v.2.45
 
 RUN wget -O- http://deb.opera.com/archive.key | apt-key add - && \

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -3,8 +3,6 @@ USER root
 #=========
 # Opera
 #=========
-ENV OPERA_DRIVER_VERSION=v.2.45
-
 RUN wget -O- http://deb.opera.com/archive.key | apt-key add - && \
      echo 'deb http://deb.opera.com/opera-stable/ stable non-free' > /etc/apt/sources.list.d/opera-blink.list
 
@@ -16,7 +14,7 @@ RUN apt-get update && \
 #=====================
 # OperaChromiumDriver
 #=====================
-RUN wget --no-verbose -O /tmp/operachromiumdriver.zip https://github.com/operasoftware/operachromiumdriver/releases/download/$OPERA_DRIVER_VERSION/operadriver_linux64.zip \
+RUN wget --no-verbose -O /tmp/operachromiumdriver.zip https://github.com/operasoftware/operachromiumdriver/releases/latest/download/operadriver_linux64.zip \
   && rm -rf /opt/operachromiumdriver \
   && unzip /tmp/operachromiumdriver.zip -d /opt/operachromiumdriver \
   && ln -fs /opt/operachromiumdriver /usr/bin/operachromiumdriver \

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -1,27 +1,34 @@
 USER root
 
+USER root
+
 #=========
 # Opera
 #=========
 RUN wget -O- http://deb.opera.com/archive.key | apt-key add - && \
-     echo 'deb http://deb.opera.com/opera-stable/ stable non-free' > /etc/apt/sources.list.d/opera-blink.list
-
-RUN apt-get update && \
+     echo 'deb http://deb.opera.com/opera-stable/ stable non-free' > /etc/apt/sources.list.d/opera-stable.list && \
+     apt-get update && \
      apt-get -y --no-install-recommends install opera-stable && \
      opera --version && \
-     rm -Rf /var/lib/apt/lists/*
+     rm -rf /etc/apt/sources.list.d/opera-blink.list
+
+#=================================
+# Opera Launch Script Wrapper
+#=================================
+#COPY wrap_opera_binary /opt/bin/wrap_opera_binary
+#RUN /opt/bin/wrap_opera_binary
+
+USER seluser
 
 #=====================
 # OperaChromiumDriver
 #=====================
 RUN wget --no-verbose -O /tmp/operachromiumdriver.zip https://github.com/operasoftware/operachromiumdriver/releases/latest/download/operadriver_linux64.zip \
   && rm -rf /opt/operachromiumdriver \
-  && unzip /tmp/operachromiumdriver.zip -d /opt/operachromiumdriver \
-  && ln -fs /opt/operachromiumdriver /usr/bin/operachromiumdriver \
-  && chmod 755 /opt/operachromiumdriver/ \
+  && unzip /tmp/operachromiumdriver.zip -d /opt/selenium \
+  && chmod 755 /opt/selenium/operadriver_linux64/operadriver \
+  && sudo ln -fs /opt/selenium/operadriver_linux64/operadriver /usr/bin/operadriver \
   && rm -rf /tmp/operachromiumdriver.zip
-
-USER seluser
 
 COPY ./generate_config /opt/bin/generate_config
 

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -1,0 +1,39 @@
+USER root
+
+#=========
+# Opera
+#=========
+ENV OPERA_VERSION=60.0.3255.170
+ENV OPERA_DRIVER_VERSION=v.2.45
+
+RUN wget -O- http://deb.opera.com/archive.key | apt-key add - && \
+     echo 'deb http://deb.opera.com/opera-stable/ stable non-free' > /etc/apt/sources.list.d/opera-blink.list
+
+RUN apt-get update && \
+     apt-get -y --no-install-recommends install opera-stable && \
+     opera --version && \
+     rm -Rf /var/lib/apt/lists/*
+
+#=====================
+# OperaChromiumDriver
+#=====================
+RUN wget --no-verbose -O /tmp/operachromiumdriver.zip https://github.com/operasoftware/operachromiumdriver/releases/download/$OPERA_DRIVER_VERSION/operadriver_linux64.zip \
+  && rm -rf /opt/operachromiumdriver \
+  && unzip /tmp/operachromiumdriver.zip -d /opt/operachromiumdriver \
+  && ln -fs /opt/operachromiumdriver /usr/bin/operachromiumdriver \
+  && chmod 755 /opt/operachromiumdriver/ \
+  && rm -rf /tmp/operachromiumdriver.zip
+
+USER seluser
+
+COPY ./generate_config /opt/bin/generate_config
+
+# Generation a default config during build time
+RUN /opt/bin/generate_config > /opt/selenium/config.json
+
+#==========
+# Relaxing permissions for OpenShift and other non-sudo environments
+#==========
+RUN sudo chmod -R 777 ${HOME} \
+  && sudo chgrp -R 0 ${HOME} \
+  && sudo chmod -R g=u ${HOME}

--- a/NodeOpera/README-short.txt
+++ b/NodeOpera/README-short.txt
@@ -1,0 +1,1 @@
+Selenium Node configured to run Opera

--- a/NodeOpera/README.md
+++ b/NodeOpera/README.md
@@ -1,0 +1,54 @@
+# Selenium Grid Node - Opera
+
+Selenium Node configured to run Opera
+
+## Dockerfile
+
+[`selenium/node-opera` Dockerfile](https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeOpera/Dockerfile)
+
+## How to use this image
+
+First, you will need a Selenium Grid Hub that the Node will connect to.
+
+```
+$ docker run -d -P --name selenium-hub selenium/hub
+```
+
+Once the hub is up and running will want to launch nodes that can run tests. You can run as many nodes as you wish.
+
+```
+$ docker run -d --link selenium-hub:hub selenium/node-opera
+```
+
+## What is Selenium?
+_Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
+
+Selenium has the support of some of the largest browser vendors who have taken (or are taking) steps to make Selenium a native part of their browser. It is also the core technology in countless other browser automation tools, APIs and frameworks.
+
+See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
+
+## License
+
+View [license information](https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md) for the software contained in this image.
+
+## Getting Help
+
+### User Group
+
+The first place where people ask for help about Selenium is the [Official User Group](https://groups.google.com/forum/#!forum/selenium-users). Here, you'll find that most of the time, someone already found the problem you are facing right now, and usually reached the solution for which you are looking.
+
+_Note: Please make sure to search the group before asking for something. Your question likely won't get answered if it was previously answered in another discussion!_
+
+### Chat Room
+
+The best place to ask for help is the user group (because they also keep the information accessible for others to read in the future). However, if you have a very important (or too simple) issue that needs a solution ASAP, you can always enter the IRC chat room. You might just find someone ready to help on `#selenium` at [Freenode](https://freenode.net/).
+
+### Issues
+
+If you have any problems with or questions about this image, please contact us through a [Github issue](https://github.com/SeleniumHQ/docker-selenium/issues). If you have any problems with or questions about Selenium, please contact us through Selenium's [Bug Tracker](https://code.google.com/p/selenium/issues/list).
+
+## Contributing
+
+There are many ways to [contribute](http://docs.seleniumhq.org/about/getting-involved.jsp) whether by answering user questions, additional docs, or pull request we look forward to hearing from you.
+
+If you do supply a patch we will need you to [sign the CLA](https://spreadsheets.google.com/spreadsheet/viewform?hl=en_US&formkey=dFFjXzBzM1VwekFlOWFWMjFFRjJMRFE6MQ#gid=0). We are part of [SFC](http://www.sfconservancy.org/)

--- a/NodeOpera/generate.sh
+++ b/NodeOpera/generate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+VERSION=$1
+NAMESPACE=$2
+AUTHORS=$3
+
+echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > ./Dockerfile
+echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> ./Dockerfile
+echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> ./Dockerfile
+echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> ./Dockerfile
+echo FROM $NAMESPACE/node-base:$VERSION >> ./Dockerfile
+echo LABEL authors="$AUTHORS" >> ./Dockerfile
+echo "" >> ./Dockerfile
+cat ./Dockerfile.txt >> ./Dockerfile

--- a/NodeOpera/generate_config
+++ b/NodeOpera/generate_config
@@ -1,0 +1,26 @@
+#!/bin/bash
+
+OPERA_VERSION=60.0.3255.170
+
+cat <<_EOF
+{
+  "capabilities": [
+    {
+      "version": "$OPERA_VERSION",
+      "browserName": "opera",
+      "maxInstances": $NODE_MAX_INSTANCES,
+      "seleniumProtocol": "WebDriver",
+      "applicationName": "$NODE_APPLICATION_NAME"
+    }
+  ],
+  "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
+  "maxSession": $NODE_MAX_SESSION,
+  "host": "$NODE_HOST",
+  "port": $NODE_PORT,
+  "register": true,
+  "registerCycle": $NODE_REGISTER_CYCLE,
+  "nodePolling": $NODE_POLLING,
+  "unregisterIfStillDownAfter": $NODE_UNREGISTER_IF_STILL_DOWN_AFTER,
+  "downPollingLimit": $NODE_DOWN_POLLING_LIMIT
+}
+_EOF

--- a/NodeOpera/generate_config
+++ b/NodeOpera/generate_config
@@ -10,6 +10,7 @@ cat <<_EOF
       "browserName": "opera",
       "maxInstances": $NODE_MAX_INSTANCES,
       "seleniumProtocol": "WebDriver",
+      "ensureCleanSession": "true",
       "applicationName": "$NODE_APPLICATION_NAME"
     }
   ],

--- a/NodeOpera/generate_config
+++ b/NodeOpera/generate_config
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-OPERA_VERSION=60.0.3255.170
+OPERA_VERSION=$(opera --version)
 
 cat <<_EOF
 {

--- a/NodeOpera/wrap_opera_binary
+++ b/NodeOpera/wrap_opera_binary
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+WRAPPER_PATH=$(readlink -f /usr/bin/opera)
+BASE_PATH="$WRAPPER_PATH-base"
+mv "$WRAPPER_PATH" "$BASE_PATH"
+
+cat > "$WRAPPER_PATH" <<_EOF
+#!/bin/bash
+
+# Note: exec -a below is a bashism.
+exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
+_EOF
+chmod +x "$WRAPPER_PATH"

--- a/NodeOperaDebug/README-short.txt
+++ b/NodeOperaDebug/README-short.txt
@@ -1,0 +1,1 @@
+_This image is only intended for development purposes!_ Runs a Selenium Grid Node with a VNC Server to allow you to visually see the browser being automated.

--- a/NodeOperaDebug/README.md
+++ b/NodeOperaDebug/README.md
@@ -1,0 +1,76 @@
+# Selenium Grid Node - Opera Debug
+
+_This image is only intended for development purposes!_ Runs a Selenium Grid Node with a VNC Server to allow you to visually see the browser being automated. Since it runs additional services to support this it is too heavy weight for usage within a Selenium Grid cluster.
+
+## Dockerfile
+
+[`selenium/node-opera` Dockerfile](https://github.com/SeleniumHQ/docker-selenium/blob/master/NodeOperaDebug/Dockerfile)
+
+## How to use this image
+
+First, you will need a Selenium Grid Hub that the Node will connect to.
+
+```
+$ docker run -d -P --name selenium-hub selenium/hub
+```
+
+Once the hub is up and running will want to launch nodes that can run tests. You can run as many nodes as you wish.
+
+```
+$ docker run -d -p 5900:5900 --link selenium-hub:hub selenium/node-opera-debug
+```
+
+You can acquire the port that the VNC server is exposed to by running:
+(Assuming that we mapped the ports like this: 49338:5900)
+``` bash
+$ docker port <container-name|container-id> 5900
+#=> 0.0.0.0:49338
+```
+
+In case you have [RealVNC](https://www.realvnc.com/) binary `vnc` in your path, you can always take a look, view only to avoid messing around your tests with an unintended mouse click or keyboard interrupt:
+``` bash
+$ ./bin/vncview 127.0.0.1:49338
+```
+
+If you are running Boot2Docker on Mac then you already have a [VNC client](http://www.davidtheexpert.com/post.php?id=5) built-in. You can connect by entering `vnc://<boot2docker-ip>:49160` in Safari or [Alfred](http://www.alfredapp.com/)
+
+When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
+
+``` dockerfile
+FROM selenium/node-opera-debug:3.141.59-radium
+
+RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
+```
+
+## What is Selenium?
+_Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
+
+Selenium has the support of some of the largest browser vendors who have taken (or are taking) steps to make Selenium a native part of their browser. It is also the core technology in countless other browser automation tools, APIs and frameworks.
+
+See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
+
+## License
+
+View [license information](https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md) for the software contained in this image.
+
+## Getting Help
+
+### User Group
+
+The first place where people ask for help about Selenium is the [Official User Group](https://groups.google.com/forum/#!forum/selenium-users). Here, you'll find that most of the time, someone already found the problem you are facing right now, and usually reached the solution for which you are looking.
+
+_Note: Please make sure to search the group before asking for something. Your question likely won't get answered if it was previously answered in another discussion!_
+
+### Chat Room
+
+The best place to ask for help is the user group (because they also keep the information accessible for others to read in the future). However, if you have a very important (or too simple) issue that needs a solution ASAP, you can always enter the IRC chat room. You might just find someone ready to help on `#selenium` at [Freenode](https://freenode.net/).
+
+### Issues
+
+If you have any problems with or questions about this image, please contact us through a [Github issue](https://github.com/SeleniumHQ/docker-selenium/issues). If you have any problems with or questions about Selenium, please contact us through Selenium's [Bug Tracker](https://code.google.com/p/selenium/issues/list).
+
+## Contributing
+
+There are many ways to [contribute](http://docs.seleniumhq.org/about/getting-involved.jsp) whether by answering user questions, additional docs, or pull request we look forward to hearing from you.
+
+If you do supply a patch we will need you to [sign the CLA](https://spreadsheets.google.com/spreadsheet/viewform?hl=en_US&formkey=dFFjXzBzM1VwekFlOWFWMjFFRjJMRFE6MQ#gid=0). We are part of [SFC](http://www.sfconservancy.org/)

--- a/README.md
+++ b/README.md
@@ -17,6 +17,7 @@ Images included:
 - __selenium/node-base__: Base image for Grid Nodes which includes a virtual desktop environment
 - __selenium/node-chrome__: Grid Node with Chrome installed, needs to be connected to a Grid Hub
 - __selenium/node-firefox__: Grid Node with Firefox installed, needs to be connected to a Grid Hub
+- __selenium/node-opera__: Selenium node with Opera installed, needs to be connected to a Selenium Grid Hub
 - __selenium/node-chrome-debug__: Grid Node with Chrome installed and runs a VNC server, needs to be connected to a Grid Hub
 - __selenium/node-firefox-debug__: Grid Node with Firefox installed and runs a VNC server, needs to be connected to a Grid Hub
 - __selenium/standalone-chrome__: Selenium Standalone with Chrome installed
@@ -24,7 +25,7 @@ Images included:
 - __selenium/standalone-chrome-debug__: Selenium Standalone with Chrome installed and runs a VNC server
 - __selenium/standalone-firefox-debug__: Selenium Standalone with Firefox installed and runs a VNC server
 
-##
+## 
 
 ## Running the images
 :exclamation: When executing `docker run` for an image with Chrome or Firefox please either mount `-v /dev/shm:/dev/shm` or use the flag `--shm-size=2g` to use the host's shared memory.

--- a/StandaloneOpera/README-short.txt
+++ b/StandaloneOpera/README-short.txt
@@ -1,0 +1,1 @@
+Selenium Standalone configured to run Opera

--- a/StandaloneOpera/README.md
+++ b/StandaloneOpera/README.md
@@ -1,0 +1,47 @@
+# Selenium Grid Standalone - Opera
+
+Selenium Standalone Server with Opera
+
+## Dockerfile
+
+[`selenium/standalone-opera` Dockerfile](https://github.com/SeleniumHQ/docker-selenium/blob/master/StandaloneOpera/Dockerfile)
+
+## How to use this image
+
+
+```
+$ docker run -d -p 4444:4444 -v /dev/shm:/dev/shm selenium/standalone-opera
+```
+
+## What is Selenium?
+_Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
+
+Selenium has the support of some of the largest browser vendors who have taken (or are taking) steps to make Selenium a native part of their browser. It is also the core technology in countless other browser automation tools, APIs and frameworks.
+
+See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
+
+## License
+
+View [license information](https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md) for the software contained in this image.
+
+## Getting Help
+
+### User Group
+
+The first place where people ask for help about Selenium is the [Official User Group](https://groups.google.com/forum/#!forum/selenium-users). Here, you'll find that most of the time, someone already found the problem you are facing right now, and usually reached the solution for which you are looking.
+
+_Note: Please make sure to search the group before asking for something. Your question likely won't get answered if it was previously answered in another discussion!_
+
+### Chat Room
+
+The best place to ask for help is the user group (because they also keep the information accessible for others to read in the future). However, if you have a very important (or too simple) issue that needs a solution ASAP, you can always enter the IRC chat room. You might just find someone ready to help on `#selenium` at [Freenode](https://freenode.net/) or [SeleniumHQ Slack](https://seleniumhq.herokuapp.com/)
+
+### Issues
+
+If you have any problems with or questions about this image, please contact us through a [Github issue](https://github.com/SeleniumHQ/docker-selenium/issues). If you have any problems with or questions about Selenium, please contact us through Selenium's [Bug Tracker](https://github.com/SeleniumHQ/selenium/issues).
+
+## Contributing
+
+There are many ways to [contribute](http://docs.seleniumhq.org/about/getting-involved.jsp) whether by answering user questions, additional docs, or pull request we look forward to hearing from you.
+
+If you do supply a patch we will need you to [sign the CLA](https://spreadsheets.google.com/spreadsheet/viewform?hl=en_US&formkey=dFFjXzBzM1VwekFlOWFWMjFFRjJMRFE6MQ#gid=0). We are part of [SFC](http://www.sfconservancy.org/)

--- a/StandaloneOperaDebug/README-short.txt
+++ b/StandaloneOperaDebug/README-short.txt
@@ -1,0 +1,1 @@
+_This image is only intended for development purposes!_ Runs a Selenium Grid Standalone with a VNC Server to allow you to visually see the browser being automated.

--- a/StandaloneOperaDebug/README.md
+++ b/StandaloneOperaDebug/README.md
@@ -1,0 +1,62 @@
+# Selenium Grid Standalone - Opera Debug
+
+_This image is only intended for development purposes!_ Runs a Selenium Grid Standalone with a VNC Server to allow you to visually see the browser being automated.
+
+
+## Dockerfile
+
+[`selenium/standalone-oepra-debug` Dockerfile](https://github.com/SeleniumHQ/docker-selenium/blob/master/StandaloneOperaDebug/Dockerfile)
+
+## How to use this image
+
+
+```
+$ docker run -d -p 4444:4444 -p 5900:5900 -v /dev/shm:/dev/shm selenium/standalone-opera-debug
+```
+
+You can acquire the port that the VNC server is exposed to by running:
+(Assuming that we mapped the ports like this: 49338:5900)
+``` bash
+$ docker port <container-name|container-id> 5900
+#=> 0.0.0.0:49338
+```
+
+In case you have [RealVNC](https://www.realvnc.com/) binary `vnc` in your path, you can always take a look, view only to avoid messing around your tests with an unintended mouse click or keyboard interrupt:
+``` bash
+$ ./bin/vncview 127.0.0.1:49338
+```
+
+If you are running Boot2Docker on Mac then you already have a [VNC client](http://www.davidtheexpert.com/post.php?id=5) built-in. You can connect by entering `vnc://<boot2docker-ip>:49160` in Safari or [Alfred](http://www.alfredapp.com/)
+
+## What is Selenium?
+_Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
+
+Selenium has the support of some of the largest browser vendors who have taken (or are taking) steps to make Selenium a native part of their browser. It is also the core technology in countless other browser automation tools, APIs and frameworks.
+
+See the Selenium [site](http://docs.seleniumhq.org/) for documation on usage within your test code.
+
+## License
+
+View [license information](https://github.com/SeleniumHQ/docker-selenium/blob/master/LICENSE.md) for the software contained in this image.
+
+## Getting Help
+
+### User Group
+
+The first place where people ask for help about Selenium is the [Official User Group](https://groups.google.com/forum/#!forum/selenium-users). Here, you'll find that most of the time, someone already found the problem you are facing right now, and usually reached the solution for which you are looking.
+
+_Note: Please make sure to search the group before asking for something. Your question likely won't get answered if it was previously answered in another discussion!_
+
+### Chat Room
+
+The best place to ask for help is the user group (because they also keep the information accessible for others to read in the future). However, if you have a very important (or too simple) issue that needs a solution ASAP, you can always enter the IRC chat room. You might just find someone ready to help on `#selenium` at [Freenode](https://freenode.net/) or [SeleniumHQ Slack](https://seleniumhq.herokuapp.com/)
+
+### Issues
+
+If you have any problems with or questions about this image, please contact us through a [Github issue](https://github.com/SeleniumHQ/docker-selenium/issues). If you have any problems with or questions about Selenium, please contact us through Selenium's [Bug Tracker](https://github.com/SeleniumHQ/selenium/issues).
+
+## Contributing
+
+There are many ways to [contribute](http://docs.seleniumhq.org/about/getting-involved.jsp) whether by answering user questions, additional docs, or pull request we look forward to hearing from you.
+
+If you do supply a patch we will need you to [sign the CLA](https://spreadsheets.google.com/spreadsheet/viewform?hl=en_US&formkey=dFFjXzBzM1VwekFlOWFWMjFFRjJMRFE6MQ#gid=0). We are part of [SFC](http://www.sfconservancy.org/)

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -60,3 +60,10 @@ class FirefoxTests(SeleniumGenericTests):
         self.driver.get('https://the-internet.herokuapp.com')
         self.driver.maximize_window()
         self.assertTrue(self.driver.title == 'The Internet')
+
+
+class OperaTests(SeleniumGenericTests):
+    def setUp(self):
+        self.driver = webdriver.Remote(
+            desired_capabilities=DesiredCapabilities.OPERA
+        )

--- a/tests/test.py
+++ b/tests/test.py
@@ -57,11 +57,11 @@ TEST_NAME_MAP = {
     'StandaloneFirefox': 'FirefoxTests',
     'StandaloneFirefoxDebug': 'FirefoxTests',
 
-    # Firefox Images
-    'NodeOpera': 'OperaTests'
-    'NodeOperaDebug': 'FirefoxTests',
-    'StandaloneOpera': 'FirefoxTests',
-    'StandaloneOperaDebug': 'FirefoxTests',
+    # Opera Images
+    'NodeOpera': 'OperaTests',
+    'NodeOperaDebug': 'OperaTests',
+    'StandaloneOpera': 'OperaTests',
+    'StandaloneOperaDebug': 'OperaTests'
 }
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -39,6 +39,9 @@ IMAGE_NAME_MAP = {
 
     # Opera Images
     'NodeOpera': 'node-opera',
+    'NodeOperaDebug': 'node-opera-debug',
+    'StandaloneOpera': 'standalone-opera',
+    'StandaloneOperaDebug': 'standalone-opera-debug'
 }
 
 TEST_NAME_MAP = {
@@ -55,7 +58,10 @@ TEST_NAME_MAP = {
     'StandaloneFirefoxDebug': 'FirefoxTests',
 
     # Firefox Images
-    'NodeOpera': 'OperaTests',
+    'NodeOpera': 'OperaTests'
+    'NodeOperaDebug': 'FirefoxTests',
+    'StandaloneOpera': 'FirefoxTests',
+    'StandaloneOperaDebug': 'FirefoxTests',
 }
 
 

--- a/tests/test.py
+++ b/tests/test.py
@@ -36,6 +36,9 @@ IMAGE_NAME_MAP = {
     'NodeFirefoxDebug': 'node-firefox-debug',
     'StandaloneFirefox': 'standalone-firefox',
     'StandaloneFirefoxDebug': 'standalone-firefox-debug',
+
+    # Opera Images
+    'NodeOpera': 'node-opera',
 }
 
 TEST_NAME_MAP = {
@@ -50,6 +53,9 @@ TEST_NAME_MAP = {
     'NodeFirefoxDebug': 'FirefoxTests',
     'StandaloneFirefox': 'FirefoxTests',
     'StandaloneFirefoxDebug': 'FirefoxTests',
+
+    # Firefox Images
+    'NodeOpera': 'OperaTests',
 }
 
 


### PR DESCRIPTION
I would like to use opera node in selenium docker hub. I think that it can be useful also for others, so I created PR to be able to make these changes official and not only for private usage.

I don't have any experience with automation which is created in SeleniumHQ so I tried to make changes in all required other files too, not only created NodeOpera directory.

I tested creation of opera selenium image and it was correctly connected to running selenium docker hub.
I'll provide screenshots and some details about scripts.


- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
