### PR TITLE
Upgrade base ubuntu image to ubuntu:bionic-20190612

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20181204
+FROM ubuntu:bionic-20190612
 LABEL authors="Selenium <selenium-developers@googlegroups.com>"
 
 #================================================


### PR DESCRIPTION
Upgrading to `ubuntu:bionic-20190612` makes 5MB reduction
<img width="217" alt="スクリーンショット 2019-06-23 17 51 34" src="https://user-images.githubusercontent.com/8651308/59973925-851d1780-95e0-11e9-8104-0702d97813b4.png">
<img width="210" alt="スクリーンショット 2019-06-23 17 52 17" src="https://user-images.githubusercontent.com/8651308/59973927-86e6db00-95e0-11e9-9ca8-745dc9fec668.png">

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
