### PR TITLE
Fix make fails in minimal alpine-bash + make

### DIFF
--- a/NodeBase/generate.sh
+++ b/NodeBase/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION=$1
 NAMESPACE=$2
 AUTHORS=$3

--- a/NodeChrome/generate.sh
+++ b/NodeChrome/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION=$1
 NAMESPACE=$2
 AUTHORS=$3

--- a/NodeFirefox/generate.sh
+++ b/NodeFirefox/generate.sh
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/usr/bin/env bash
 VERSION=$1
 NAMESPACE=$2
 AUTHORS=$3


### PR DESCRIPTION
By default `make generate_all` (in minimal alpine-bash with make Docker container) fails:
```
bash-5.0# make generate_all
cd ./Hub && ./generate.sh 3.141.59-titanium selenium SeleniumHQ
cd ./NodeBase && ./generate.sh 3.141.59-titanium selenium SeleniumHQ
/bin/sh: ./generate.sh: not found
make: *** [Makefile:39: generate_nodebase] Error 127
```

While the complete/standard call hides the problem a bit, when executing it step-by-step it is more obvious:
```
bash-5.0# cd NodeBase/
bash-5.0# ./generate.sh 3.141.59-titanium selenium SeleniumHQ
bash: ./generate.sh: /bin/bash: bad interpreter: No such file or directory
```

=> The fix is replacing the shebang according to some other "generate.sh" scripts, cf. https://github.com/SeleniumHQ/docker-selenium/commit/73c67d61165ce36ed88aa4d771a031356855a223

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
