### PR TITLE
Feature: Dockerfile delete not needed mkdir

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -51,11 +51,6 @@ RUN useradd seluser \
   && echo 'seluser:secret' | chpasswd
 ENV HOME=/home/seluser
 
-#=======================================
-# Create shared / common bin directory
-#=======================================
-RUN  mkdir -p /opt/bin 
-
 #======================================
 # Add Grid check script
 #======================================


### PR DESCRIPTION
The COPY command create the folder /opt/bin/ if not exists.
So there is no need to create the folder manual. Deleting the line reduce the
docker image by one layer and save disk space.
Tested with docker and podman.

- [X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
