### PR TITLE
Always use updated version of specific ubuntu release

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -1,4 +1,4 @@
-FROM ubuntu:bionic-20190612
+FROM ubuntu:bionic
 LABEL authors="Selenium <selenium-developers@googlegroups.com>"
 
 #================================================


### PR DESCRIPTION
By always using latest version of ubuntu release we don't need to update packages inside the images

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->


- [ X] By placing an `X` in the preceding checkbox, I verify that I have signed the [Contributor License Agreement](https://github.com/SeleniumHQ/docker-selenium/blob/master/CONTRIBUTING.md#contributing-code-to-selenium)
