### PR TITLE
Set autorestart of fluxbox to unexpected to prevent restart loop

### DIFF
--- a/NodeDebug/selenium-debug.conf
+++ b/NodeDebug/selenium-debug.conf
@@ -6,7 +6,7 @@
 priority=5
 command=/opt/bin/start-fluxbox.sh
 autostart=true
-autorestart=true
+autorestart=unexpected
 startsecs=0
 startretries=0
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 



<!--- Provide a general summary of your changes in the Title above -->

### Description
Prevent restart loop of fluxbox when using selenium container without XVFB. Fixes #945 

Container log looks know like this:
```
2019-12-18 09:57:52,148 INFO Included extra file "/etc/supervisor/conf.d/selenium-debug.conf" during parsing
2019-12-18 09:57:52,148 INFO Included extra file "/etc/supervisor/conf.d/selenium.conf" during parsing
2019-12-18 09:57:52,150 INFO supervisord started with pid 8
2019-12-18 09:57:53,152 INFO spawned: 'xvfb' with pid 11
2019-12-18 09:57:53,153 INFO spawned: 'fluxbox' with pid 12
2019-12-18 09:57:53,154 INFO spawned: 'vnc' with pid 13
2019-12-18 09:57:53,155 INFO spawned: 'selenium-standalone' with pid 14
2019-12-18 09:57:53,156 INFO success: xvfb entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2019-12-18 09:57:53,157 INFO success: fluxbox entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2019-12-18 09:57:53,157 INFO success: vnc entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2019-12-18 09:57:53,157 INFO success: selenium-standalone entered RUNNING state, process has stayed up for > than 0 seconds (startsecs)
2019-12-18 09:57:53,157 INFO exited: xvfb (exit status 0; expected)
2019-12-18 09:57:53,158 INFO exited: fluxbox (exit status 0; expected)
2019-12-18 09:57:53,160 INFO exited: vnc (exit status 0; expected)
09:57:53.345 INFO [GridLauncherV3.parse] - Selenium server version: 3.141.59, revision: e82be7d358
09:57:53.414 INFO [GridLauncherV3.lambda$buildLaunchers$3] - Launching a standalone Selenium Server on port 4444
2019-12-18 09:57:53.450:INFO::main: Logging initialized @286ms to org.seleniumhq.jetty9.util.log.StdErrLog
09:57:53.622 INFO [WebDriverServlet.<init>] - Initialising WebDriverServlet
09:57:53.704 INFO [SeleniumServer.boot] - Selenium Server is up and running on port 4444
```
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
