### PR TITLE
Support for browsers to play video streams

### DIFF
--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -6,6 +6,7 @@ USER root
 RUN apt-get update -qqy \
   && apt-get -qqy install \
     xvfb \
+    pulseaudio \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #==============================

--- a/NodeBase/start-selenium-node.sh
+++ b/NodeBase/start-selenium-node.sh
@@ -7,6 +7,16 @@ if [ ! -e /opt/selenium/config.json ]; then
   exit 1
 fi
 
+# Start the pulseaudio server
+pulseaudio -D --exit-idle-time=-1
+
+# Load the virtual sink and set it as default
+pacmd load-module module-virtual-sink sink_name=v1
+pacmd set-default-sink v1
+
+# set the monitor of v1 sink to be the default source
+pacmd set-default-source v1.monitor
+
 # In the long term the idea is to remove $HUB_PORT_4444_TCP_ADDR and $HUB_PORT_4444_TCP_PORT and only work with
 # $HUB_HOST and $HUB_PORT
 if [ ! -z "$HUB_HOST" ]; then

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -6,7 +6,7 @@ USER root
 ARG FIREFOX_VERSION=latest
 RUN FIREFOX_DOWNLOAD_URL=$(if [ $FIREFOX_VERSION = "latest" ] || [ $FIREFOX_VERSION = "nightly-latest" ] || [ $FIREFOX_VERSION = "devedition-latest" ]; then echo "https://download.mozilla.org/?product=firefox-$FIREFOX_VERSION-ssl&os=linux64&lang=en-US"; else echo "https://download-installer.cdn.mozilla.net/pub/firefox/releases/$FIREFOX_VERSION/linux-x86_64/en-US/firefox-$FIREFOX_VERSION.tar.bz2"; fi) \
   && apt-get update -qqy \
-  && apt-get -qqy --no-install-recommends install firefox \
+  && apt-get -qqy --no-install-recommends install firefox libavcodec-extra \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
   && wget --no-verbose -O /tmp/firefox.tar.bz2 $FIREFOX_DOWNLOAD_URL \
   && apt-get -y purge firefox \

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -1,5 +1,8 @@
 import unittest
 from selenium import webdriver
+from selenium.webdriver.common.by import By
+from selenium.webdriver.support.ui import WebDriverWait
+from selenium.webdriver.support import expected_conditions as EC
 from selenium.webdriver.common.desired_capabilities import DesiredCapabilities
 
 
@@ -38,6 +41,20 @@ class SeleniumGenericTests(unittest.TestCase):
         driver.get('http://admin:admin@the-internet.herokuapp.com/basic_auth')
         page_message = driver.find_element_by_css_selector('.example p').text
         self.assertTrue(page_message == 'Congratulations! You must have the proper credentials.')
+
+    def test_play_video(self):
+        driver = self.driver
+        driver.get('https://hls-js.netlify.com/demo/')
+        wait = WebDriverWait(driver, 30)
+        video = wait.until(
+            EC.element_to_be_clickable((By.TAG_NAME, 'video'))
+        )
+        video.click()
+        wait.until(
+            lambda d: d.find_element_by_tag_name('video').get_property('currentTime')
+        )
+        paused = video.get_property('paused')
+        self.assertFalse(paused)
 
     def tearDown(self):
         self.driver.quit()


### PR DESCRIPTION
### Description
This pull request provides the following changes:

1) Install the missing video codecs for the Firefox browser.
2) Configure a dummy output for PulseAudio for all images to allow the consumption of sound data.
3) Add a new test to play video and validate the resulting images.

### Motivation and Context
These important changes allow browsers to reproduce and test sites with embedded video without memory leaks.

We, at [System73](https://system73.com), have been using Selenium to test our software for several years. We needed to implement these changes for Selenium nodes to work with video and now we are sharing them with the community.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.