### PR TITLE
Support for Selenium nodes with Opera browser

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -8,19 +8,23 @@ MAJOR := $(word 1,$(subst ., ,$(VERSION)))
 MINOR := $(word 2,$(subst ., ,$(VERSION)))
 MAJOR_MINOR_PATCH := $(word 1,$(subst -, ,$(VERSION)))
 
-all: hub chrome firefox chrome_debug firefox_debug standalone_chrome standalone_firefox standalone_chrome_debug standalone_firefox_debug
+all: hub chrome firefox opera chrome_debug firefox_debug opera_debug standalone_chrome standalone_firefox standalone_opera standalone_chrome_debug standalone_firefox_debug standalone_opera_debug
 
 generate_all:	\
 	generate_hub \
 	generate_nodebase \
 	generate_chrome \
 	generate_firefox \
+	generate_opera \
 	generate_chrome_debug \
 	generate_firefox_debug \
+	generate_opera_debug \
 	generate_standalone_firefox \
 	generate_standalone_chrome \
+	generate_standalone_opera \
 	generate_standalone_firefox_debug \
-	generate_standalone_chrome_debug
+	generate_standalone_chrome_debug \
+	generate_standalone_opera_debug
 
 build: all
 
@@ -53,6 +57,12 @@ generate_firefox:
 firefox: nodebase generate_firefox
 	cd ./NodeFirefox && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox:$(VERSION) .
 
+generate_opera:
+	cd ./NodeOpera && ./generate.sh $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+opera: nodebase generate_opera
+	cd ./NodeOpera && docker build $(BUILD_ARGS) -t $(NAME)/node-opera:$(VERSION) .
+
 generate_standalone_firefox:
 	cd ./Standalone && ./generate.sh StandaloneFirefox node-firefox Firefox $(VERSION) $(NAMESPACE) $(AUTHORS)
 
@@ -77,6 +87,18 @@ generate_standalone_chrome_debug:
 standalone_chrome_debug: chrome_debug generate_standalone_chrome_debug
 	cd ./StandaloneChromeDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-chrome-debug:$(VERSION) .
 
+generate_standalone_opera:
+	cd ./Standalone && ./generate.sh StandaloneOpera node-opera Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+standalone_opera: opera generate_standalone_opera
+	cd ./StandaloneOpera && docker build $(BUILD_ARGS) -t $(NAME)/standalone-opera:$(VERSION) .
+
+generate_standalone_opera_debug:
+	cd ./StandaloneDebug && ./generate.sh StandaloneOperaDebug node-opera-debug Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+standalone_opera_debug: opera_debug generate_standalone_opera_debug
+	cd ./StandaloneOperaDebug && docker build $(BUILD_ARGS) -t $(NAME)/standalone-opera-debug:$(VERSION) .
+
 generate_chrome_debug:
 	cd ./NodeDebug && ./generate.sh NodeChromeDebug node-chrome Chrome $(VERSION) $(NAMESPACE) $(AUTHORS)
 
@@ -88,6 +110,12 @@ generate_firefox_debug:
 
 firefox_debug: generate_firefox_debug firefox
 	cd ./NodeFirefoxDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-firefox-debug:$(VERSION) .
+
+generate_opera_debug:
+	cd ./NodeDebug && ./generate.sh NodeOperaDebug node-opera Opera $(VERSION) $(NAMESPACE) $(AUTHORS)
+
+opera_debug: generate_opera_debug opera
+	cd ./NodeOperaDebug && docker build $(BUILD_ARGS) -t $(NAME)/node-opera-debug:$(VERSION) .
 
 tag_latest:
 	docker tag $(NAME)/base:$(VERSION) $(NAME)/base:latest
@@ -209,12 +237,16 @@ release: tag_major_minor
 
 test: test_chrome \
  test_firefox \
+ test_opera \
  test_chrome_debug \
  test_firefox_debug \
+ test_opera_debug \
  test_chrome_standalone \
  test_firefox_standalone \
+ test_opera_standalone \
  test_chrome_standalone_debug \
- test_firefox_standalone_debug
+ test_firefox_standalone_debug \
+ test_opera_standalone_debug
 
 
 test_chrome:
@@ -241,6 +273,18 @@ test_firefox_standalone:
 test_firefox_standalone_debug:
 	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh StandaloneFirefoxDebug
 
+test_opera:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh NodeOpera
+
+test_opera_debug:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh NodeOperaDebug
+
+test_opera_standalone:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh StandaloneOpera
+
+test_opera_standalone_debug:
+	VERSION=$(VERSION) NAMESPACE=$(NAMESPACE) ./tests/bootstrap.sh StandaloneOperaDebug
+
 
 .PHONY: \
 	all \
@@ -251,17 +295,23 @@ test_firefox_standalone_debug:
 	ci \
 	firefox \
 	firefox_debug \
+	opera \
+	opera_debug \
 	generate_all \
 	generate_hub \
 	generate_nodebase \
 	generate_chrome \
 	generate_firefox \
+	generage_opera \
 	generate_chrome_debug \
 	generate_firefox_debug \
+	generate_opera_debug \
 	generate_standalone_chrome \
 	generate_standalone_firefox \
+	generate_standalone_opera \
 	generate_standalone_chrome_debug \
 	generate_standalone_firefox_debug \
+	generate_standalone_opera_debug \
 	hub \
 	nodebase \
 	release \

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -1,0 +1,58 @@
+USER root
+
+
+#============================================
+# Opera
+#============================================
+# can specify versions by OPERA_VERSION;
+#  e.g. opera-stable=60.0.3255.109
+#       opera-beta=60.0.3255.103
+#       opera-developer=62.0.3323.0
+#       opera=12.16.1860
+#       opera-next=12.16.1860
+#       latest (equivalent to opera-stable)
+#       opera-beta  (pull latest beta)
+#============================================
+ARG OPERA_VERSION="opera-stable"
+RUN wget -q -O - https://deb.opera.com/archive.key | apt-key add - \
+  && echo "deb https://deb.opera.com/opera-stable/ stable non-free" >> /etc/apt/sources.list.d/opera-stable.list \
+  && apt-get update -qqy \
+  && apt-get -qqy install \
+    ${OPERA_VERSION:-opera-stable} \
+  && dpkg-divert --divert /usr/lib/x86_64-linux-gnu/opera/libffmpeg.so.orig \
+     --package ${OPERA_VERSION:-opera-stable} --rename --add \
+     /usr/lib/x86_64-linux-gnu/opera/libffmpeg.so \
+  && ln -sf /usr/lib/chromium-browser/libffmpeg.so /usr/lib/x86_64-linux-gnu/opera/libffmpeg.so \
+  && rm /etc/apt/sources.list.d/opera-stable.list \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
+#=================================
+# Opera Launch Script Wrapper
+#=================================
+COPY wrap_opera_binary /opt/bin/wrap_opera_binary
+RUN /opt/bin/wrap_opera_binary
+
+USER seluser
+
+#=====================
+# Opera webdriver
+#=====================
+# can specify versions by OPERA_DRIVER_VERSION
+# Latest released version will be used by default
+#=====================
+ARG OPERA_DRIVER_VERSION
+RUN LATEST_VERSION=$(curl -s https://api.github.com/repos/operasoftware/operachromiumdriver/releases/latest | jq .name -r) \
+  && [ -z "$OPERA_DRIVER_VERSION" ] && OPERA_DRIVER_VERSION=$LATEST_VERSION \
+  && echo "Using operadriver version: "$OPERA_DRIVER_VERSION \
+  && wget --no-verbose -O /tmp/operadriver_linux64.zip https://github.com/operasoftware/operachromiumdriver/releases/download/v.${OPERA_DRIVER_VERSION}/operadriver_linux64.zip \
+  && rm -rf /opt/selenium/operadriver \
+  && unzip /tmp/operadriver_linux64.zip -d /tmp/ \
+  && mv /tmp/operadriver_linux64/operadriver /opt/selenium/operadriver-${OPERA_DRIVER_VERSION} \
+  && rm -rf /tmp/operadriver_linux64* \
+  && chmod 755 /opt/selenium/operadriver-${OPERA_DRIVER_VERSION} \
+  && sudo ln -fs /opt/selenium/operadriver-${OPERA_DRIVER_VERSION} /usr/bin/operadriver
+
+COPY generate_config /opt/bin/generate_config
+
+# Generating a default config during build time
+RUN /opt/bin/generate_config > /opt/selenium/config.json

--- a/NodeOpera/README-short.txt
+++ b/NodeOpera/README-short.txt
@@ -1,0 +1,1 @@
+Selenium Node configured to run Chromium based versions of Opera

--- a/NodeOpera/generate.sh
+++ b/NodeOpera/generate.sh
@@ -1,0 +1,13 @@
+#!/bin/bash
+VERSION=$1
+NAMESPACE=$2
+AUTHORS=$3
+
+echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" > ./Dockerfile
+echo "# NOTE: DO *NOT* EDIT THIS FILE.  IT IS GENERATED." >> ./Dockerfile
+echo "# PLEASE UPDATE Dockerfile.txt INSTEAD OF THIS FILE" >> ./Dockerfile
+echo "# !!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!!" >> ./Dockerfile
+echo FROM ${NAMESPACE}/node-base:${VERSION} >> ./Dockerfile
+echo LABEL authors="$AUTHORS" >> ./Dockerfile
+echo "" >> ./Dockerfile
+cat ./Dockerfile.txt >> ./Dockerfile

--- a/NodeOpera/generate_config
+++ b/NodeOpera/generate_config
@@ -1,0 +1,27 @@
+#!/bin/bash
+
+OPERA_VERSION=$(opera -version)
+
+cat <<_EOF
+{
+  "capabilities": [
+    {
+      "version": "$OPERA_VERSION",
+      "browserName": "operablink",
+      "maxInstances": $NODE_MAX_INSTANCES,
+      "seleniumProtocol": "WebDriver",
+      "applicationName": "$NODE_APPLICATION_NAME"
+    }
+  ],
+  "proxy": "org.openqa.grid.selenium.proxy.DefaultRemoteProxy",
+  "maxSession": $NODE_MAX_SESSION,
+  "host": "$NODE_HOST",
+  "port": $NODE_PORT,
+  "register": true,
+  "registerCycle": $NODE_REGISTER_CYCLE,
+  "nodePolling": $NODE_POLLING,
+  "unregisterIfStillDownAfter": $NODE_UNREGISTER_IF_STILL_DOWN_AFTER,
+  "downPollingLimit": $NODE_DOWN_POLLING_LIMIT,
+  "debug": $GRID_DEBUG
+}
+_EOF

--- a/NodeOpera/wrap_opera_binary
+++ b/NodeOpera/wrap_opera_binary
@@ -1,0 +1,13 @@
+#!/bin/bash
+
+WRAPPER_PATH=$(readlink -f /usr/lib/*-linux-gnu/opera/opera)
+BASE_PATH="$WRAPPER_PATH-base"
+mv "$WRAPPER_PATH" "$BASE_PATH"
+
+cat > "$WRAPPER_PATH" <<_EOF
+#!/bin/bash
+
+# Note: exec -a below is a bashism.
+exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
+_EOF
+chmod +x "$WRAPPER_PATH"

--- a/NodeOperaDebug/README-short.txt
+++ b/NodeOperaDebug/README-short.txt
@@ -1,0 +1,1 @@
+_This image is only intended for development purposes!_ Runs a Selenium Grid Node with a VNC Server to allow you to visually see the browser being automated.

--- a/StandaloneOpera/README-short.txt
+++ b/StandaloneOpera/README-short.txt
@@ -1,0 +1,1 @@
+Selenium Standalone configured to run Opera

--- a/StandaloneOpera/selenium.conf
+++ b/StandaloneOpera/selenium.conf
@@ -1,0 +1,36 @@
+; Documentation of this file format -> http://supervisord.org/configuration.html
+
+; Priority 0 - xvfb, 5 - fluxbox (debug images), 10 - x11vnc (debug images), 15 - selenium-node
+
+[program:xvfb]
+priority=0
+command=/opt/bin/start-xvfb.sh
+autostart=true
+autorestart=false
+startsecs=0
+startretries=0
+
+;Logs
+redirect_stderr=false
+stdout_logfile=/var/log/supervisor/xvfb-stdout.log
+stderr_logfile=/var/log/supervisor/xvfb-stderr.log
+stdout_logfile_maxbytes=50MB
+stderr_logfile_maxbytes=50MB
+stdout_logfile_backups=5
+stderr_logfile_backups=5
+stdout_capture_maxbytes=50MB
+stderr_capture_maxbytes=50MB
+
+
+[program:selenium-standalone]
+priority=15
+command=/opt/bin/start-selenium-standalone.sh
+autostart=true
+autorestart=false
+startsecs=0
+startretries=0
+
+;Logs (all Hub activity redirected to stdout so it can be seen through "docker logs"
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/StandaloneOperaDebug/README-short.txt
+++ b/StandaloneOperaDebug/README-short.txt
@@ -1,0 +1,1 @@
+_This image is only intended for development purposes!_ Runs a Selenium Grid Standalone with a VNC Server to allow you to visually see the browser being automated.

--- a/StandaloneOperaDebug/selenium.conf
+++ b/StandaloneOperaDebug/selenium.conf
@@ -1,0 +1,36 @@
+; Documentation of this file format -> http://supervisord.org/configuration.html
+
+; Priority 0 - xvfb, 5 - fluxbox (debug images), 10 - x11vnc (debug images), 15 - selenium-node
+
+[program:xvfb]
+priority=0
+command=/opt/bin/start-xvfb.sh
+autostart=true
+autorestart=false
+startsecs=0
+startretries=0
+
+;Logs
+redirect_stderr=false
+stdout_logfile=/var/log/supervisor/xvfb-stdout.log
+stderr_logfile=/var/log/supervisor/xvfb-stderr.log
+stdout_logfile_maxbytes=50MB
+stderr_logfile_maxbytes=50MB
+stdout_logfile_backups=5
+stderr_logfile_backups=5
+stdout_capture_maxbytes=50MB
+stderr_capture_maxbytes=50MB
+
+
+[program:selenium-standalone]
+priority=15
+command=/opt/bin/start-selenium-standalone.sh
+autostart=true
+autorestart=false
+startsecs=0
+startretries=0
+
+;Logs (all Hub activity redirected to stdout so it can be seen through "docker logs"
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0

--- a/StandaloneOperaDebug/start-selenium-standalone.sh
+++ b/StandaloneOperaDebug/start-selenium-standalone.sh
@@ -1,0 +1,6 @@
+#!/usr/bin/env bash
+#
+# IMPORTANT: Change this file only in directory StandaloneDebug!
+
+java ${JAVA_OPTS} -jar /opt/selenium/selenium-server-standalone.jar \
+    ${SE_OPTS}

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -60,3 +60,12 @@ class FirefoxTests(SeleniumGenericTests):
         self.driver.get('https://the-internet.herokuapp.com')
         self.driver.maximize_window()
         self.assertTrue(self.driver.title == 'The Internet')
+
+
+class OperaTests(SeleniumGenericTests):
+    def setUp(self):
+        capabilities = DesiredCapabilities.CHROME
+        capabilities['browserName'] = 'operablink'
+        self.driver = webdriver.Remote(
+            desired_capabilities=capabilities
+        )

--- a/tests/test.py
+++ b/tests/test.py
@@ -36,6 +36,12 @@ IMAGE_NAME_MAP = {
     'NodeFirefoxDebug': 'node-firefox-debug',
     'StandaloneFirefox': 'standalone-firefox',
     'StandaloneFirefoxDebug': 'standalone-firefox-debug',
+
+    # Opera Images
+    'NodeOpera': 'node-opera',
+    'NodeOperaDebug': 'node-opera-debug',
+    'StandaloneOpera': 'standalone-opera',
+    'StandaloneOperaDebug': 'standalone-opera-debug',
 }
 
 TEST_NAME_MAP = {
@@ -50,6 +56,12 @@ TEST_NAME_MAP = {
     'NodeFirefoxDebug': 'FirefoxTests',
     'StandaloneFirefox': 'FirefoxTests',
     'StandaloneFirefoxDebug': 'FirefoxTests',
+
+    # Opera Images
+    'NodeOpera': 'OperaTests',
+    'NodeOperaDebug': 'OperaTests',
+    'StandaloneOpera': 'OperaTests',
+    'StandaloneOperaDebug': 'OperaTests',
 }
 
 


### PR DESCRIPTION
### Description
This pull request provides the following changes:

1) Add the necessary files to build all types of Selenium nodes with the Opera browser. 
2) Enable existing tests for the resulting Docker Images
3) Update the README.md file to describe the usage of the 

### Motivation and Context
These changes will allow us to use Opera as a new browser to test with Selenium.

We, at [System73](https://system73.com), have been using Selenium to test our software for several years. We needed to implement these changes for Selenium nodes to work with Opera and now we are sharing them with the community.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.