### PR TITLE
Document VNC password in Standalone*Debug/README.md

### DIFF
--- a/StandaloneChromeDebug/README.md
+++ b/StandaloneChromeDebug/README.md
@@ -28,6 +28,14 @@ $ ./bin/vncview 127.0.0.1:49338
 
 If you are running Boot2Docker on Mac then you already have a [VNC client](http://www.davidtheexpert.com/post.php?id=5) built-in. You can connect by entering `vnc://<boot2docker-ip>:49160` in Safari or [Alfred](http://www.alfredapp.com/)
 
+When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
+
+``` dockerfile
+FROM selenium/node-chrome-debug-debug:3.141.59-zirconium
+
+RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
+```
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/StandaloneDebug/README.template.md
+++ b/StandaloneDebug/README.template.md
@@ -28,6 +28,14 @@ $ ./bin/vncview 127.0.0.1:49338
 
 If you are running Boot2Docker on Mac then you already have a [VNC client](http://www.davidtheexpert.com/post.php?id=5) built-in. You can connect by entering `vnc://<boot2docker-ip>:49160` in Safari or [Alfred](http://www.alfredapp.com/)
 
+When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
+
+``` dockerfile
+FROM selenium/##BASE##-debug:3.141.59-zirconium
+
+RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
+```
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 

--- a/StandaloneFirefoxDebug/README.md
+++ b/StandaloneFirefoxDebug/README.md
@@ -28,6 +28,14 @@ $ ./bin/vncview 127.0.0.1:49338
 
 If you are running Boot2Docker on Mac then you already have a [VNC client](http://www.davidtheexpert.com/post.php?id=5) built-in. You can connect by entering `vnc://<boot2docker-ip>:49160` in Safari or [Alfred](http://www.alfredapp.com/)
 
+When you are prompted for the password it is __secret__. If you wish to change this then you should either change it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a docker image that derives from the posted ones which reconfigures it:
+
+``` dockerfile
+FROM selenium/node-firefox-debug-debug:3.141.59-zirconium
+
+RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
+```
+
 ## What is Selenium?
 _Selenium automates browsers._ That's it! What you do with that power is entirely up to you. Primarily, it is for automating web applications for testing purposes, but is certainly not limited to just that. Boring web-based administration tasks can (and should!) also be automated as well.
 


### PR DESCRIPTION
### Description
Default VNC password `secret` and how to change it does appear in main README and some other places, but was missing from a few per-directory READMEs.

### Motivation and Context
Similar to #682 it wasn't clear to me what's the VNC password because I went directly to the sub-directory I wanted (StandaloneChromeDebug) which seemed to be a complete doc but didn't mention the password.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

READMEs only. If you're asking from SemVer perspective, this fits "bug fix" but perhaps doesn't deserve a release at all?

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
  > FYI, that document is pretty irrelevant for this repo.
- [ ] ~~My change requires a change to the documentation.~~ no code changes
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I've re-run `make generate_all`.
FYI, StandaloneOpera/README.md, StandaloneOperaDebug/README.md, and several other files in opera directories are currently missing from git. Apparently intentional (#995)?