### PR TITLE
Use a numeric USER instruction in Dockerfiles

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -41,11 +41,15 @@ RUN echo "${TZ}" > /etc/timezone \
   && dpkg-reconfigure --frontend noninteractive tzdata
 
 #========================================
-# Add normal user with passwordless sudo
+# Add normal user and group with passwordless sudo
 #========================================
-RUN useradd seluser \
-         --shell /bin/bash  \
+RUN groupadd seluser \
+         --gid 1201 \
+  && useradd seluser \
          --create-home \
+         --gid 1201 \
+         --shell /bin/bash \
+         --uid 1200 \
   && usermod -a -G sudo seluser \
   && echo 'ALL ALL = (ALL) NOPASSWD: ALL' >> /etc/sudoers \
   && echo 'seluser:secret' | chpasswd
@@ -75,7 +79,7 @@ RUN  mkdir -p /opt/selenium /var/run/supervisor /var/log/supervisor \
 #===================================================
 # Run the following commands as non-privileged user
 #===================================================
-USER seluser
+USER 1200:1201
 
 
 CMD ["/opt/bin/entry_point.sh"]

--- a/Hub/Dockerfile
+++ b/Hub/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/base:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #========================
 # Selenium Configuration

--- a/Hub/Dockerfile.txt
+++ b/Hub/Dockerfile.txt
@@ -1,4 +1,4 @@
-USER seluser
+USER 1200
 
 #========================
 # Selenium Configuration

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -75,7 +75,7 @@ RUN apt-get -qqy update \
 # Run the following commands as non-privileged user
 #===================================================
 
-USER seluser
+USER 1200
 
 #==============================
 # Scripts to run Selenium Node and XVFB

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -68,7 +68,7 @@ RUN apt-get -qqy update \
 # Run the following commands as non-privileged user
 #===================================================
 
-USER seluser
+USER 1200
 
 #==============================
 # Scripts to run Selenium Node and XVFB

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -32,7 +32,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 COPY wrap_chrome_binary /opt/bin/wrap_chrome_binary
 RUN /opt/bin/wrap_chrome_binary
 
-USER seluser
+USER 1200
 
 #============================================
 # Chrome webdriver

--- a/NodeChrome/Dockerfile.txt
+++ b/NodeChrome/Dockerfile.txt
@@ -25,7 +25,7 @@ RUN wget -q -O - https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key
 COPY wrap_chrome_binary /opt/bin/wrap_chrome_binary
 RUN /opt/bin/wrap_chrome_binary
 
-USER seluser
+USER 1200
 
 #============================================
 # Chrome webdriver

--- a/NodeChromeDebug/Dockerfile
+++ b/NodeChromeDebug/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qqy \
     fluxbox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-USER seluser
+USER 1200
 
 #==============================
 # Generating the VNC password as seluser

--- a/NodeDebug/Dockerfile.txt
+++ b/NodeDebug/Dockerfile.txt
@@ -17,7 +17,7 @@ RUN apt-get update -qqy \
     fluxbox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-USER seluser
+USER 1200
 
 #==============================
 # Generating the VNC password as seluser

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -37,7 +37,7 @@ RUN GK_VERSION=$(if [ ${GECKODRIVER_VERSION:-latest} = "latest" ]; then echo "0.
   && chmod 755 /opt/geckodriver-$GK_VERSION \
   && ln -fs /opt/geckodriver-$GK_VERSION /usr/bin/geckodriver
 
-USER seluser
+USER 1200
 
 COPY generate_config /opt/bin/generate_config
 

--- a/NodeFirefox/Dockerfile.txt
+++ b/NodeFirefox/Dockerfile.txt
@@ -30,7 +30,7 @@ RUN GK_VERSION=$(if [ ${GECKODRIVER_VERSION:-latest} = "latest" ]; then echo "0.
   && chmod 755 /opt/geckodriver-$GK_VERSION \
   && ln -fs /opt/geckodriver-$GK_VERSION /usr/bin/geckodriver
 
-USER seluser
+USER 1200
 
 COPY generate_config /opt/bin/generate_config
 

--- a/NodeFirefoxDebug/Dockerfile
+++ b/NodeFirefoxDebug/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qqy \
     fluxbox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-USER seluser
+USER 1200
 
 #==============================
 # Generating the VNC password as seluser

--- a/NodeOpera/Dockerfile
+++ b/NodeOpera/Dockerfile
@@ -39,7 +39,7 @@ RUN wget -q -O - https://deb.opera.com/archive.key | apt-key add - \
 COPY wrap_opera_binary /opt/bin/wrap_opera_binary
 RUN /opt/bin/wrap_opera_binary
 
-USER seluser
+USER 1200
 
 #=====================
 # Opera webdriver

--- a/NodeOpera/Dockerfile.txt
+++ b/NodeOpera/Dockerfile.txt
@@ -32,7 +32,7 @@ RUN wget -q -O - https://deb.opera.com/archive.key | apt-key add - \
 COPY wrap_opera_binary /opt/bin/wrap_opera_binary
 RUN /opt/bin/wrap_opera_binary
 
-USER seluser
+USER 1200
 
 #=====================
 # Opera webdriver

--- a/NodeOperaDebug/Dockerfile
+++ b/NodeOperaDebug/Dockerfile
@@ -24,7 +24,7 @@ RUN apt-get update -qqy \
     fluxbox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
-USER seluser
+USER 1200
 
 #==============================
 # Generating the VNC password as seluser

--- a/Standalone/Dockerfile.txt
+++ b/Standalone/Dockerfile.txt
@@ -1,4 +1,4 @@
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone

--- a/StandaloneChrome/Dockerfile
+++ b/StandaloneChrome/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/node-chrome:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone

--- a/StandaloneChromeDebug/Dockerfile
+++ b/StandaloneChromeDebug/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/node-chrome-debug:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone

--- a/StandaloneFirefox/Dockerfile
+++ b/StandaloneFirefox/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/node-firefox:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone

--- a/StandaloneFirefoxDebug/Dockerfile
+++ b/StandaloneFirefoxDebug/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/node-firefox-debug:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone

--- a/StandaloneOpera/Dockerfile
+++ b/StandaloneOpera/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/node-opera:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone

--- a/StandaloneOperaDebug/Dockerfile
+++ b/StandaloneOperaDebug/Dockerfile
@@ -5,7 +5,7 @@
 FROM selenium/node-opera-debug:3.141.59-20200525
 LABEL authors=SeleniumHQ
 
-USER seluser
+USER 1200
 
 #====================================
 # Scripts to run Selenium Standalone


### PR DESCRIPTION
### Description
By using a numeric `USER` instruction in Dockerfiles, the images are now able to pass a strict [Kubernetes `securityContext` configuration](https://kubernetes.io/docs/reference/generated/kubernetes-api/v1.18/#securitycontext-v1-core). Specifically, `runAsNonRoot`, which requires a _numeric_ user/group ID. It is also a [Docker best practice](https://docs.docker.com/develop/develop-images/dockerfile_best-practices/#user). The values of 1200 and 1201 are arbitrary.

### Motivation and Context
While running a Selenium grid cluster in Kubernetes, I noticed I was unable to run the images with `runAsNonRoot: true` due to the following error:

> CreateContainerConfigError: container has runAsNonRoot and image has non-numeric user (seluser), cannot verify user is non-root

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.


Here's an example of the k8s config that runs successfully _after_ this patch:

```yaml
apiVersion: apps/v1
kind: Deployment
spec:
  template:
    spec:
      containers:
      - name: hub
        image: selenium/hub:local
        securityContext:
          allowPrivilegeEscalation: false
          capabilities:
            drop:
            - ALL
          privileged: false
          readOnlyRootFilesystem: false
          runAsNonRoot: true
```

I can run `VERSION=local make build` locally successfully. Let me know if there's anything I can change or if this can be tested somehow.

Thanks,
Steve
