### PR TITLE
Upgrade Ubuntu and JRE

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -1,12 +1,12 @@
-FROM ubuntu:bionic-20191029
+FROM ubuntu:focal
 LABEL authors="Selenium <selenium-developers@googlegroups.com>"
 
 #================================================
 # Customize sources for apt-get
 #================================================
-RUN  echo "deb http://archive.ubuntu.com/ubuntu bionic main universe\n" > /etc/apt/sources.list \
-  && echo "deb http://archive.ubuntu.com/ubuntu bionic-updates main universe\n" >> /etc/apt/sources.list \
-  && echo "deb http://security.ubuntu.com/ubuntu bionic-security main universe\n" >> /etc/apt/sources.list
+RUN  echo "deb http://archive.ubuntu.com/ubuntu focal main universe\n" > /etc/apt/sources.list \
+  && echo "deb http://archive.ubuntu.com/ubuntu focal-updates main universe\n" >> /etc/apt/sources.list \
+  && echo "deb http://security.ubuntu.com/ubuntu focal-security main universe\n" >> /etc/apt/sources.list
 
 # No interactive frontend during docker build
 ENV DEBIAN_FRONTEND=noninteractive \

--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -20,7 +20,7 @@ RUN apt-get -qqy update \
   && apt-get -qqy --no-install-recommends install \
     bzip2 \
     ca-certificates \
-    openjdk-8-jre-headless \
+    openjdk-14-jre-headless \
     tzdata \
     sudo \
     unzip \
@@ -29,8 +29,7 @@ RUN apt-get -qqy update \
     curl \
     supervisor \
     gnupg2 \
-  && rm -rf /var/lib/apt/lists/* /var/cache/apt/* \
-  && sed -i 's/securerandom\.source=file:\/dev\/random/securerandom\.source=file:\/dev\/urandom/' ./usr/lib/jvm/java-8-openjdk-amd64/jre/lib/security/java.security
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #===================
 # Timezone settings


### PR DESCRIPTION
### Description
This PR upgrades Ubuntu from 18.04 LTS (Bionic Beaver) to 20.04 LTS (Focal Fossa). Additionally, the OpenJDK Java runtime is upgraded from 8 to 14.

### Motivation and Context
I have a Selenium grid running a Kubernetes cluster. Since I build these images myself, I decided to try upgrading. Initially, I used the following process in my pipeline:

```
    # Clone the Selenium repo containing all the Dockerfiles.
    - git clone https://github.com/SeleniumHQ/docker-selenium.git docker-selenium

    # A few changes are made to the base image (e.g. upgrading Ubuntu and Java versions).
    - sed -i '1s/^FROM.*/FROM ubuntu:focal/'                       docker-selenium/Base/Dockerfile
    - sed -i '7,9s/bionic/focal/'                                  docker-selenium/Base/Dockerfile
    - sed -i '23s/openjdk-8-jre-headless/openjdk-14-jre-headless/' docker-selenium/Base/Dockerfile
    - sed -i '32s/ .$//; 33d'                                      docker-selenium/Base/Dockerfile

    # Use the provided Makefile to build select images.
    - cd docker-selenium && make hub chrome firefox opera
```

It's been running well in my environment, so here's a PR to contribute my changes upstream!

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
