### PR TITLE
Using xvfb-run to expose display via tcp

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,7 +1,7 @@
 NAME := $(or $(NAME),$(NAME),selenium)
 CURRENT_DATE := $(shell date '+%Y%m%d')
 BUILD_DATE := $(or $(BUILD_DATE),$(BUILD_DATE),$(CURRENT_DATE))
-VERSION := $(or $(VERSION),$(VERSION),4.0.0-alpha-6)
+VERSION := $(or $(VERSION),$(VERSION),4.0.0-alpha-7)
 TAG_VERSION := $(VERSION)-$(BUILD_DATE)
 NAMESPACE := $(or $(NAMESPACE),$(NAMESPACE),$(NAME))
 AUTHORS := $(or $(AUTHORS),$(AUTHORS),SeleniumHQ)

--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -117,8 +117,7 @@ RUN sudo chmod -R 777 ${HOME} \
 #==============================
 # Scripts to run fluxbox and x11vnc
 #==============================
-COPY start-fluxbox.sh \
-      start-vnc.sh \
+COPY start-vnc.sh \
       /opt/bin/
 
 #============================
@@ -129,6 +128,7 @@ ENV SCREEN_HEIGHT 1020
 ENV SCREEN_DEPTH 24
 ENV SCREEN_DPI 96
 ENV DISPLAY :99.0
+ENV DISPLAY_NUM 99
 ENV START_XVFB true
 
 #========================

--- a/NodeBase/selenium.conf
+++ b/NodeBase/selenium.conf
@@ -21,25 +21,6 @@ stderr_logfile_backups=5
 stdout_capture_maxbytes=50MB
 stderr_capture_maxbytes=50MB
 
-[program:fluxbox]
-priority=5
-command=/opt/bin/start-fluxbox.sh
-autostart=true
-autorestart=unexpected
-startsecs=0
-startretries=0
-
-;Logs
-redirect_stderr=false
-stdout_logfile=/var/log/supervisor/fluxbox-stdout.log
-stderr_logfile=/var/log/supervisor/fluxbox-stderr.log
-stdout_logfile_maxbytes=50MB
-stderr_logfile_maxbytes=50MB
-stdout_logfile_backups=5
-stderr_logfile_backups=5
-stdout_capture_maxbytes=50MB
-stderr_capture_maxbytes=50MB
-
 [program:vnc]
 priority=10
 command=/opt/bin/start-vnc.sh

--- a/NodeBase/start-fluxbox.sh
+++ b/NodeBase/start-fluxbox.sh
@@ -1,9 +1,0 @@
-#!/usr/bin/env bash
-#
-# IMPORTANT: Change this file only in directory NodeDebug!
-
-if [ "${START_XVFB}" = true ] ; then
-  fluxbox -display ${DISPLAY}
-else
-  echo "Fluxbox won't start because Xvfb is configured to not start."
-fi

--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 #
-# IMPORTANT: Change this file only in directory NodeDebug!
+# IMPORTANT: Change this file only in directory NodeBase!
 
 if [ "${START_XVFB}" = true ] ; then
   if [ ! -z $VNC_NO_PASSWORD ]; then
@@ -20,8 +20,7 @@ if [ "${START_XVFB}" = true ] ; then
     echo "Waiting for Xvfb..."
   done
 
-  # -noxrecord fixes https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=859213 in x11vnc 0.9.13-2
-  x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -display ${DISPLAY} -noxrecord
+  x11vnc ${X11VNC_OPTS} -forever -shared -rfbport 5900 -rfbportv6 5900 -display ${DISPLAY}
 else
   echo "Vnc won't start because Xvfb is configured to not start."
 fi

--- a/NodeBase/start-xvfb.sh
+++ b/NodeBase/start-xvfb.sh
@@ -5,7 +5,14 @@ if [ "${START_XVFB}" = true ] ; then
 
   rm -f /tmp/.X*lock
 
-  /usr/bin/Xvfb ${DISPLAY} -screen 0 ${GEOMETRY} -dpi ${SCREEN_DPI} -ac +extension RANDR
+  # Command reference
+  # http://manpages.ubuntu.com/manpages/bionic/man1/xvfb-run.1.html
+  # http://manpages.ubuntu.com/manpages/bionic/man1/Xvfb.1.html
+  # http://manpages.ubuntu.com/manpages/bionic/man1/Xserver.1.html
+  /usr/bin/xvfb-run --server-num=${DISPLAY_NUM} \
+    --listen-tcp \
+    --server-args="-screen 0 ${GEOMETRY} -dpi ${SCREEN_DPI} -listen tcp -noreset -ac +extension RANDR" \
+    /usr/bin/fluxbox -display ${DISPLAY}
 else
-  echo "Xvfb won't start. Chrome/Firefox can only run in headless mode. Remember to set the 'headless' flag in your test."
+  echo "Xvfb and Fluxbox won't start. Chrome/Firefox/Opera can only run in headless mode. Remember to set the 'headless' flag in your test."
 fi

--- a/Standalone/selenium.conf
+++ b/Standalone/selenium.conf
@@ -21,25 +21,6 @@ stderr_logfile_backups=5
 stdout_capture_maxbytes=50MB
 stderr_capture_maxbytes=50MB
 
-[program:fluxbox]
-priority=5
-command=/opt/bin/start-fluxbox.sh
-autostart=true
-autorestart=unexpected
-startsecs=0
-startretries=0
-
-;Logs
-redirect_stderr=false
-stdout_logfile=/var/log/supervisor/fluxbox-stdout.log
-stderr_logfile=/var/log/supervisor/fluxbox-stderr.log
-stdout_logfile_maxbytes=50MB
-stderr_logfile_maxbytes=50MB
-stdout_logfile_backups=5
-stderr_logfile_backups=5
-stdout_capture_maxbytes=50MB
-stderr_capture_maxbytes=50MB
-
 [program:vnc]
 priority=10
 command=/opt/bin/start-vnc.sh


### PR DESCRIPTION
This will allow another container to attach
itself to the exposed display, and potentially
record the stream.

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This changes slighlty how `xvfb` is started, and allows exposing the display via tcp.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
If the display can be accessed via tcp, we can potentially have another container running with `ffmpeg` and record the display.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
