### PR TITLE
Improve documentation on starting up grid

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,11 +36,13 @@ $ docker run -d -p 4444:4444 -p 7900:7900 --shm-size 2g selenium/standalone-fire
 $ docker run -d -p 4444:4444 -p 7900:7900 -v /dev/shm:/dev/shm selenium/standalone-firefox:4.0.0-beta-3-prerelease-20210422
 ```
 
-2. Point your WebDriver tests to http://localhost:4444/wd/hub
+2. Point your WebDriver tests to http://localhost:4444 *
 
 3. That's it! 
 
 4. (Optional) To see what is happening inside the container, head to http://localhost:7900 (password is `secret`).
+
+* Grid 3 used "/wd/hub", while it should also work, it is no longer required
 
 More details about visualising the container activity, check the [Debugging](#debugging) section.
 

--- a/docker-compose-v3-full-grid-swarm.yml
+++ b/docker-compose-v3-full-grid-swarm.yml
@@ -1,0 +1,62 @@
+# To start Docker in Swarm mode, you need to run `docker swarm init`
+# To deploy the Grid, `docker stack deploy -c docker-compose-v3-swarm.yml grid`
+# Stop with `docker stack rm grid`
+# Stop swarm mode `docker swarm leave --force`
+
+version: '3.7'
+
+services:
+  chrome:
+    image: selenium/node-chrome:4.0.0-beta-3-prerelease-20210422
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    deploy:
+      replicas: 1
+    entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
+
+  edge:
+    image: selenium/node-edge:4.0.0-beta-3-prerelease-20210422
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    deploy:
+      replicas: 1
+    entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
+
+  firefox:
+    image: selenium/node-firefox:4.0.0-beta-3-prerelease-20210422
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    deploy:
+      replicas: 1
+    entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
+
+  opera:
+    image: selenium/node-opera:4.0.0-beta-3-prerelease-20210422
+    volumes:
+      - /dev/shm:/dev/shm
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+    deploy:
+      replicas: 1
+    entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
+
+  selenium-hub:
+    image: selenium/hub:4.0.0-beta-3-prerelease-20210422
+    ports:
+      - "4442:4442"
+      - "4443:4443"
+      - "4444:4444"


### PR DESCRIPTION
### Description
Selenium Grid 4 no longer needs "/wd/hub" endpoint
Add skeleton file for full grid in Docker Swarm

### Motivation and Context
Improving documentation and making things clear

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
