### PR TITLE
1335: video_ready_port should be an int

### DIFF
--- a/Video/video_ready.py
+++ b/Video/video_ready.py
@@ -3,7 +3,7 @@ from os import environ
 import json
 import psutil
 
-video_ready_port = environ.get('VIDEO_READY_PORT', 9000)
+video_ready_port = int(environ.get('VIDEO_READY_PORT', 9000))
 
 class Handler(BaseHTTPRequestHandler):
 


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->
When setting VIDEO_READY_PORT `environ.get()` returns a string but an int is required
### Description
<!--- Describe your changes in detail -->
wrap `int(environ.get('VIDEO_READY_PORT', 9000))` in an `int()
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
