### PR TITLE
Add configurable docker env variables to support disabling novnc and changing ports

### DIFF
--- a/NodeBase/Dockerfile.txt
+++ b/NodeBase/Dockerfile.txt
@@ -160,6 +160,7 @@ ENV SCREEN_DPI 96
 ENV DISPLAY :99.0
 ENV DISPLAY_NUM 99
 ENV START_XVFB true
+ENV START_NO_VNC true
 
 #========================
 # Selenium Configuration

--- a/NodeBase/start-novnc.sh
+++ b/NodeBase/start-novnc.sh
@@ -3,7 +3,11 @@
 # IMPORTANT: Change this file only in directory NodeBase!
 
 if [ "${START_XVFB}" = true ] ; then
-  /opt/bin/noVNC/utils/launch.sh --listen 7900 --vnc localhost:5900
+  if [ "${START_NO_VNC}" = true ] ; then
+    /opt/bin/noVNC/utils/launch.sh --listen ${NO_VNC_PORT:-7900} --vnc localhost:${VNC_PORT:-5900}
+  else
+    echo "noVNC won't start because START_NO_VNC is false."
+  fi
 else
   echo "noVNC won't start because Xvfb is configured to not start."
 fi

--- a/README.md
+++ b/README.md
@@ -625,6 +625,7 @@ their browser. This might come handy if you cannot install a VNC client on your 
 noVNC, so you will need to connect to that port with your browser.
 
 Similarly to the previous section, feel free to map port 7900 to any free external port that you wish.
+You can also override it with the `NO_VNC_PORT` environment variable in case you want to use `--net=host`.
 
 Here is an example with the standalone images, the same concept applies to the node images.
 ``` bash


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail --> 
Adds env variables to allow for configuring the novnc script, and the ports being used. 


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
It may be desirable to disable the novnc script after starting xvfm service if net=host. The listening port was hardcoded and not configurable, so this adds an env variable that can be 
set to update that. Also the vnc port is already configurable so this ensures that if the vnc_port is set, it will update the value in the start_no_vnc script as well. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
