### PR TITLE
Issue-1398: set umask when launching browsers

### DIFF
--- a/NodeChrome/wrap_chrome_binary
+++ b/NodeChrome/wrap_chrome_binary
@@ -6,6 +6,7 @@ mv "$WRAPPER_PATH" "$BASE_PATH"
 
 cat > "$WRAPPER_PATH" <<_EOF
 #!/bin/bash
+umask 002
 # Note: exec -a below is a bashism.
 exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
 _EOF

--- a/NodeChrome/wrap_chrome_binary
+++ b/NodeChrome/wrap_chrome_binary
@@ -6,7 +6,10 @@ mv "$WRAPPER_PATH" "$BASE_PATH"
 
 cat > "$WRAPPER_PATH" <<_EOF
 #!/bin/bash
+
+# umask 002 ensures default permissions of files are 664 (rw-rw-r--) and directories are 775 (rwxrwxr-x).
 umask 002
+
 # Note: exec -a below is a bashism.
 exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
 _EOF

--- a/NodeEdge/wrap_edge_binary
+++ b/NodeEdge/wrap_edge_binary
@@ -6,7 +6,7 @@ mv "$WRAPPER_PATH" "$BASE_PATH"
 
 cat > "$WRAPPER_PATH" <<_EOF
 #!/bin/bash
-
+umask 002
 # Note: exec -a below is a bashism.
 exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
 _EOF

--- a/NodeEdge/wrap_edge_binary
+++ b/NodeEdge/wrap_edge_binary
@@ -6,7 +6,10 @@ mv "$WRAPPER_PATH" "$BASE_PATH"
 
 cat > "$WRAPPER_PATH" <<_EOF
 #!/bin/bash
+
+# umask 002 ensures default permissions of files are 664 (rw-rw-r--) and directories are 775 (rwxrwxr-x).
 umask 002
+
 # Note: exec -a below is a bashism.
 exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"
 _EOF


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.

Set umask to 002 before launching browsers. This will cause downloaded files to 664 (-rw-rw-r)
https://github.com/SeleniumHQ/docker-selenium/issues/1398

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Allows changing downloaded files when run in an environment where the userids don't map

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
