### PR TITLE
fix for setting x11vnc -viewonly

### DIFF
--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -23,7 +23,7 @@ if [ "${START_XVFB}" = true ] ; then
 
   if [ ! -z $VNC_VIEW_ONLY ]; then
       echo "Starting VNC server with viewonly option"
-      X11VNC_OPTS=${X11VNC_OPTS} -viewonly
+      X11VNC_OPTS="${X11VNC_OPTS} -viewonly"
   fi
 
   for i in $(seq 1 10)


### PR DESCRIPTION
Due to the bug in the code x11vnc's parameter '-viewonly' is
set only under the certain condition, that some other parameter
already initialized variable $X11VNC_OPTS.
This fix solves this problem.

Fixes #1424

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
