### PR TITLE
Add example of multiple nodes on same VM

### DIFF
--- a/README.md
+++ b/README.md
@@ -110,7 +110,8 @@ $ docker network rm grid
 
 #### Using different machines/VMs
 The Hub and Nodes will be created on different machines/VMs, they need to know each other's IPs to
-communicate properly.
+communicate properly. If more than one node will be running on the same Machine/VM, they must be
+configured to expose different ports.
 
 Hub - Machine/VM 1
 ``` bash
@@ -148,6 +149,18 @@ $ docker run -d -p 5555:5555 \
     -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
     -e SE_NODE_HOST=<ip-from-machine-4> \
     selenium/node-firefox:4.1.1-20220121
+```
+
+Node Chrome - Machine/VM 4
+``` bash
+$ docker run -d -p 5556:5556 \
+    --shm-size="2g" \
+    -e SE_EVENT_BUS_HOST=<ip-from-machine-1> \
+    -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
+    -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
+    -e SE_NODE_HOST=<ip-from-machine-4> \
+    -e SE_NODE_PORT=5556 \
+    selenium/node-chrome:4.1.1-20220121
 ```
 
 #### Docker Compose


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
It's not clear from the documentation that the container will be listening on a port other than 5555 when the SE_NODE_PORT parameter is provided. This PR adds an example of the case where there are two nodes running on the same machine/VM, and shows the correct port mapping and environment variable configuration

### Motivation and Context
This behavior is different than in Selenium3, where the container was always listening on 5555, so the port mapping always pointed there.  TBH, I'm not 100% sure if this was an intended change or not... but if not, please let me know and I will ~close~ update this PR and open a bug report.
Note that this is also different behavior than the VNC port for the container, which always listens on 5900. 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
