### PR TITLE
Exiting container when Standalone or Node exits

### DIFF
--- a/.github/workflows/k8s-deploy-test.yml
+++ b/.github/workflows/k8s-deploy-test.yml
@@ -20,8 +20,8 @@ jobs:
       - name: Setup Minikube
         uses: manusa/actions-setup-minikube@v2.3.0
         with:
-          minikube version: "v1.13.1"
-          kubernetes version: "v1.19.2"
+          minikube version: 'v1.24.0'
+          kubernetes version: 'v1.23.0'
           github token: ${{ secrets.GITHUB_TOKEN }}
           driver: none
       - name: Interact with Minikube

--- a/.github/workflows/k8s-deploy-test.yml
+++ b/.github/workflows/k8s-deploy-test.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v1
       - name: Setup Minikube
-        uses: manusa/actions-setup-minikube@v2.3.0
+        uses: manusa/actions-setup-minikube@v2.4.3
         with:
           minikube version: 'v1.24.0'
           kubernetes version: 'v1.23.0'

--- a/.github/workflows/k8s-deploy-test.yml
+++ b/.github/workflows/k8s-deploy-test.yml
@@ -1,12 +1,7 @@
 name: "Test Selenium Grid 4 deployment on Minikube Cluster"
 
 on:
-  push:
-    branches:
-      - trunk
-  pull_request:
-    branches:
-      - trunk
+  workflow_dispatch:
 
 jobs:
   deploy:

--- a/NodeBase/selenium.conf
+++ b/NodeBase/selenium.conf
@@ -61,7 +61,8 @@ stderr_capture_maxbytes=50MB
 
 [program:selenium-node]
 priority=15
-command=/opt/bin/start-selenium-node.sh
+command=bash -c "/opt/bin/start-selenium-node.sh && kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`"
+stopasgroup = true
 autostart=true
 autorestart=false
 startsecs=0

--- a/Standalone/selenium.conf
+++ b/Standalone/selenium.conf
@@ -61,7 +61,8 @@ stderr_capture_maxbytes=50MB
 
 [program:selenium-standalone]
 priority=15
-command=/opt/bin/start-selenium-standalone.sh
+command=bash -c "/opt/bin/start-selenium-standalone.sh && kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`"
+stopasgroup = true
 autostart=true
 autorestart=false
 startsecs=0


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->
This will exit the NodeChrome/NodeFirefox/NodeEdge/StandaloneChrome/StandaloneFirefox/StandaloneEdge container(s) when the Selenium Server process exits.

### Description
<!--- Describe your changes in detail -->
The behaviour we have always had is one where supervisor controls all processes and keeps the container running. This is great because it has improved maintainability and readability. However, when the most important process, the Selenium Server, exits... the container has no purpose anymore. Users need to stop/kill the container themselves.

This change will make the container exit when the Selenium Server process exits.


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
In some environments like Kubernetes, it is useful to know when the Selenium Server is not running anymore to stop the pod. This was not possible because the container was still running. Now, since the container exits, the pod can be removed as well.

Used the solution proposed here https://github.com/Supervisor/supervisor/issues/712#issuecomment-396553685

Fixes #1435 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
