### PR TITLE
Added information to the README about docker-seleniarm community repo

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,20 @@ and made the source code freely available under the [Apache License 2.0](LICENSE
 ![Build & test](https://github.com/SeleniumHQ/docker-selenium/workflows/Build%20&%20test/badge.svg?branch=trunk)
 ![Deployments](https://github.com/SeleniumHQ/docker-selenium/workflows/Deploys/badge.svg)
 
+## Images published to Docker Hub registry
+
+These images are published to the Docker Hub registry at [Selenium Docker Hub](https://hub.docker.com/u/selenium).
+
+## Experimental Mult-Arch aarch64/armhf/amd64 Images
+
+For experimental docker container images, which run on platforms such as the Mac M1 or Raspberry Pi, see the community repository hosted at [seleniumhq-community/docker-seleniarm](https://github.com/seleniumhq-community/docker-seleniarm).  These images are built for three separate architectures:  linux/arm64 (aarch64), linux/arm/v7 (armhf), and linux/amd64. 
+
+Furthermore, these experimental container images are published on [Seleniarm Docker Hub](https://hub.docker.com/u/seleniarm) registry.
+
+See [Issue #1076](https://github.com/SeleniumHQ/docker-selenium/issues/1076) for more information on these images.
+
+If you're working on an Intel or AMD64 architecture, we recommend using the container images in _this_ repository (SeleniumHQ/docker-selenium) instead of the experimental ones.
+
 # Selenium Grid 4
 
 Docker images for Grid 4 come with a handful of tags to simplify its usage, have a look at them in one of 


### PR DESCRIPTION
Added information to the README about the location of the multi-arch container images GitHub repo and Docker Hub organization. 

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description

Updated the README to do two things:

- Point to the location of the stable Selenium x86_64 container images on Docker Hub.
- Point to the location of the docker-seleniarm community repository for mult-arch images and the images on Docker Hub.

### Motivation and Context

- See #1076 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [ X ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

