### PR TITLE
Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - trunk
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     # Skip job based on the commit message, only works in push to branches for now

--- a/.github/workflows/test-video.yml
+++ b/.github/workflows/test-video.yml
@@ -8,6 +8,9 @@ on:
     branches:
       - trunk
 
+permissions:
+  contents: read
+
 jobs:
   build-and-test:
     # Skip job based on the commit message, only works in push to branches for now


### PR DESCRIPTION
- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

Signed-off-by: naveensrinivasan <172697+naveensrinivasan@users.noreply.github.com>
