### PR TITLE
Add ingress resource, use ClusterIP by default

### DIFF
--- a/chart/selenium-grid/Chart.yaml
+++ b/chart/selenium-grid/Chart.yaml
@@ -1,0 +1,6 @@
+apiVersion: v2
+name: selenium-grid
+description: A Helm chart for creating a Selenium grid server in Kubernetes
+type: application
+version: 0.4.0
+appVersion: 4.1.4-20220427

--- a/chart/selenium-grid/templates/ingress.yaml
+++ b/chart/selenium-grid/templates/ingress.yaml
@@ -1,0 +1,61 @@
+{{- if .Values.ingress.enabled }}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+{{- if semverCompare ">=1.19-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1
+{{- else if semverCompare ">=1.14-0" .Capabilities.KubeVersion.GitVersion -}}
+apiVersion: networking.k8s.io/v1beta1
+{{- else -}}
+apiVersion: extensions/v1beta1
+{{- end }}
+kind: Ingress
+metadata:
+  name: selenium-ingress
+  labels:
+    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.ingress.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ . | quote }}
+        {{- end }}
+      secretName: {{ .secretName }}
+    {{- end }}
+  {{- end }}
+  rules:
+      {{- if $.Values.ingress.hostname }}
+    - host: {{ .Values.ingress.hostname }}
+      http:
+      {{- else }}
+    - http:
+      {{- end }}
+        paths:
+          - path: /
+            pathType: Prefix
+            backend:
+              service:
+                {{- if $.Values.isolateComponents }}
+                name: {{ template "seleniumGrid.router.fullname" $ }}
+                port:
+                  number: {{ $.Values.components.router.port }}
+                {{- else }}
+                name: {{ template "seleniumGrid.hub.fullname" $ }}
+                port:
+                  number: {{ $.Values.hub.port }}
+                {{- end }}
+{{- end }}

--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,14 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.4.0
+
+### Added
+- Expose the Hub or the Router by default with ingress resource.
+
+### Changed
+- Set the default serviceType of the Hub and the Router to ClusterIP
+
 ## :heavy_check_mark: 0.3.1
 
 ### Added

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -24,6 +24,9 @@ helm install selenium-grid docker-selenium/selenium-grid --set isolateComponents
 
 # Or install specified version
 helm install selenium-grid docker-selenium/selenium-grid --version 0.3.1
+
+# In both cases grid exposed by default using ingress. You may want to set hostname for the grid. Default hostname is selenium-grid.local.
+helm install selenium-grid --set ingress.hostname=selenium-grid.k8s.local docker-selenium/chart/selenium-grid/.
 ```
 
 ## Updating Selenium-Grid release
@@ -57,6 +60,11 @@ This table contains the configuration parameters of the chart and their default 
 | --------------------------------------- | ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------- |
 | `isolateComponents`                     | `false`                            | Deploy Router, Distributor, EventBus, SessionMap and Nodes separately                                                      |
 | `busConfigMap.name`                     | `selenium-event-bus-config`        | Name of the configmap that contains SE_EVENT_BUS_HOST, SE_EVENT_BUS_PUBLISH_PORT and SE_EVENT_BUS_SUBSCRIBE_PORT variables |
+| `ingress.enabled`                       | `true`                             | Enable or disable ingress resource                                                                                         |
+| `ingress.className`                     | `""`                               | Name of ingress class to select which controller will implement ingress resource                                           |
+| `ingress.annotations`                   | `{}`                               | Custom annotations for ingress resource                                                                                    |
+| `ingress.hostname`                      | `selenium-grid.local`              | Default host for the ingress resource                                                                                      |
+| `ingress.tls`                           | `[]`                               | TLS backend configuration for ingress resource                                                                             |
 | `busConfigMap.annotations`              | `{}`                               | Custom annotations for configmap                                                                                           |
 | `chromeNode.enabled`                    | `true`                             | Enable chrome nodes                                                                                                        |
 | `chromeNode.replicas`                   | `1`                                | Number of chrome nodes                                                                                                     |

--- a/charts/selenium-grid/templates/NOTES.txt
+++ b/charts/selenium-grid/templates/NOTES.txt
@@ -1,13 +1,24 @@
-Selenium Grid Server deployed succesfully.
+Selenium Grid Server deployed successfully.
 
 {{- $svcName := ternary (include "seleniumGrid.router.fullname" . ) (include "seleniumGrid.hub.fullname" . ) .Values.isolateComponents }}
+{{- $appName := ternary "selenium-router" "selenium-hub" .Values.isolateComponents }}
+{{- $serviceType := ternary .Values.components.router.serviceType .Values.hub.serviceType .Values.isolateComponents }}
+{{- $port := ternary .Values.components.router.port .Values.hub.port .Values.isolateComponents }}
+{{- $localUrl := ternary "http://localhost:PORT" "http://localhost:PORT/wd/hub" .Values.isolateComponents }}
 
-1. To access Selenium from outside of Kubernetes, run these commands:
-
-    {{- $appName := ternary "selenium-router" "selenium-hub" .Values.isolateComponents }}
-    {{- $serviceType := ternary .Values.components.router.serviceType .Values.hub.serviceType .Values.isolateComponents }}
-    {{- $port := ternary .Values.components.router.port .Values.hub.port .Values.isolateComponents }}
-    {{- $localUrl := ternary "http://localhost:PORT" "http://localhost:PORT/wd/hub" .Values.isolateComponents }}
+{{- if .Values.ingress.enabled }}
+    {{- if .Values.ingress.hostname }}
+1. Ingress is enabled, and it exposes the Grid Hub or Grid Router with the hostname you supplied.
+    To access Selenium from outside of Kubernetes, simply open http://{{ .Values.ingress.hostname }}.
+    {{- else}}
+1. Ingress is enabled, but hostname doesn't set. All inbound HTTP traffic will be routed to the Grid by matching any host.
+    Please keep in mind that it is rarely necessary, and in most cases, you shall provide `ingress.hostname` in values.yaml.
+    To access Selenium from outside of Kubernetes:
+        - open IP of the any node with Ingress, or
+        - any hostname pointing to the node with Ingress
+    {{- end}}
+{{- else}}
+1. Ingress is disabled. To access Selenium from outside of Kubernetes, simply run these commands:
     {{- if contains "NodePort" $serviceType }}
     export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" svc {{ $svcName }})
     export NODE_IP=$(kubectl get nodes -n {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
@@ -22,6 +33,7 @@ Selenium Grid Server deployed succesfully.
     echo "Point your WebDriver tests to {{ $localUrl | replace "PORT" (toString $port) }}"
     kubectl -n {{ .Release.Namespace }} port-forward $POD_NAME {{ $port }}:{{ $port }}
     {{- end }}
+{{- end}}
 
-2. Within Kubernetes cluster, you can use following Service endpoint:  
+2. Within Kubernetes cluster, you can use following Service endpoint:
         http://{{ $svcName }}.{{ .Release.Namespace }}.svc:{{ $port }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -8,6 +8,19 @@ global:
 # Deploy Router, Distributor, EventBus, SessionMap and Nodes separately
 isolateComponents: false
 
+# Configure the ingress resource to access the Grid installation.
+ingress:
+  # Enable or disable ingress resource
+  enabled: true
+  # Name of ingress class to select which controller will implement ingress resource
+  className: ""
+  # Custom annotations for ingress resource
+  annotations: {}
+  # Default host for the ingress resource
+  hostname: selenium-grid.local
+  # TLS backend configuration for ingress resource
+  tls: []
+
 # ConfigMap that contains SE_EVENT_BUS_HOST, SE_EVENT_BUS_PUBLISH_PORT and SE_EVENT_BUS_SUBSCRIBE_PORT variables
 busConfigMap:
   # Name of the configmap
@@ -52,7 +65,7 @@ components:
     # Resources for router container
     resources: {}
     # Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
-    serviceType: NodePort
+    serviceType: ClusterIP
     # Custom annotations for router service
     serviceAnnotations: {}
     # Tolerations for router container
@@ -229,7 +242,7 @@ hub:
   # Resources for selenium-hub container
   resources: {}
   # Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
-  serviceType: NodePort
+  serviceType: ClusterIP
   # Custom annotations for Selenium Hub service
   serviceAnnotations: {}
   # Tolerations for selenium-hub container


### PR DESCRIPTION
### Description

Set ClusterIP service type for Hub and Router components, NodePort could be set explicitly, but the default is ClusterIP.

Add enabled by default ingress resource, which exposes either Hub or Router service.
In the case of LoadBalancer or NodePort set explicitly, you shall turn off ingress explicitly as well.
To turn off: `--set ingress.enabled=false`

End-user shall supply the hostname for the ingress. There is an option to use an empty host instead.
Be aware of the consequences of accepting traffic from all hosts.

### Motivation and Context
See issue #1546.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
