### PR TITLE
Trigger chart release only on changes in the charts directory

### DIFF
--- a/.github/workflows/helm-chart-release.yml
+++ b/.github/workflows/helm-chart-release.yml
@@ -4,6 +4,8 @@ on:
   push:
     branches:
       - trunk
+    paths:
+      - 'charts/**'
 
 jobs:
   release:


### PR DESCRIPTION
### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
I would like to suggest triggering chart-releaser action only on changes in the charts directory.
I don't see any other logic that triggers chart publishing on any push to the trunk that also updates Chart.yaml with a new version automatically.
So IMHO, Chart version is updated and pushed to trunk manually (PR merged), so the chart needs release only when anything in the charts dir changes.

Feel free to discard, if that logic doesn't fit your workflow :)

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
