### PR TITLE
Add ability to mount extra volumes into nodes pods

### DIFF
--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.5.0
+
+### Added
+- Added ability to mount arbitrary volumes into browser nodes
+
 ## :heavy_check_mark: 0.4.2
 
 ### Changed
@@ -11,7 +16,6 @@ All notable changes to this helm chart will be documented in this file.
 
 ### Changed
 - Update image tag to 4.2.1-20220608
-
 
 ## :heavy_check_mark: 0.4.0
 

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.4.2
+version: 0.5.0
 appVersion: 4.2.2-20220609

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -85,6 +85,8 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.service.type`               | `ClusterIP`                        | Service type                                                                                                               |
 | `chromeNode.service.annotations`        | `{}`                               | Custom annotations for service                                                                                             |
 | `chromeNode.dshmVolumeSizeLimit`        | `1Gi`                              | Size limit for DSH volume mounted in container (if not set, default is "1Gi")                                              |
+| `chromeNode.extraVolumeMounts`          | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
+| `chromeNode.extraVolumes`               | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `firefoxNode.enabled`                   | `true`                             | Enable firefox nodes                                                                                                       |
 | `firefoxNode.replicas`                  | `1`                                | Number of firefox nodes                                                                                                    |
 | `firefoxNode.imageName`                 | `selenium/node-firefox`            | Image of firefox nodes                                                                                                     |
@@ -104,6 +106,8 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.service.type`              | `ClusterIP`                        | Service type                                                                                                               |
 | `firefoxNode.service.annotations`       | `{}`                               | Custom annotations for service                                                                                             |
 | `firefoxNode.dshmVolumeSizeLimit`       | `1Gi`                              | Size limit for DSH volume mounted in container (if not set, default is "1Gi")                                              |
+| `firefoxNode.extraVolumeMounts`         | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
+| `firefoxNode.extraVolumes`              | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `edgeNode.enabled`                      | `true`                             | Enable edge nodes                                                                                                          |
 | `edgeNode.replicas`                     | `1`                                | Number of edge nodes                                                                                                       |
 | `edgeNode.imageName`                    | `selenium/node-edge`               | Image of edge nodes                                                                                                        |
@@ -123,6 +127,8 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.service.type`                 | `ClusterIP`                        | Service type                                                                                                               |
 | `edgeNode.service.annotations`          | `{}`                               | Custom annotations for service                                                                                             |
 | `edgeNode.dshmVolumeSizeLimit`          | `1Gi`                              | Size limit for DSH volume mounted in container (if not set, default is "1Gi")                                              |
+| `edgeNode.extraVolumeMounts`            | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
+| `edgeNode.extraVolumes`                 | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `customLabels`                          | `{}`                               | Custom labels for k8s resources                                                                                            |
 
 

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -52,6 +52,9 @@ spec:
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm
+          {{- if .Values.chromeNode.extraVolumeMounts }}
+            {{- toYaml .Values.chromeNode.extraVolumeMounts | nindent 12 }}
+          {{- end }}
         {{- with .Values.chromeNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
@@ -67,4 +70,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ default "1Gi" .Values.chromeNode.dshmVolumeSizeLimit }}
+      {{- if .Values.chromeNode.extraVolumes }}
+        {{ toYaml .Values.chromeNode.extraVolumes | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -52,6 +52,9 @@ spec:
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm
+          {{- if .Values.edgeNode.extraVolumeMounts }}
+            {{- toYaml .Values.edgeNode.extraVolumeMounts | nindent 12 }}
+          {{- end }}
         {{- with .Values.edgeNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
@@ -67,4 +70,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ default "1Gi" .Values.edgeNode.dshmVolumeSizeLimit }}
+      {{- if .Values.edgeNode.extraVolumes }}
+        {{ toYaml .Values.edgeNode.extraVolumes | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -52,6 +52,9 @@ spec:
           volumeMounts:
             - name: dshm
               mountPath: /dev/shm
+          {{- if .Values.firefoxNode.extraVolumeMounts }}
+            {{- toYaml .Values.firefoxNode.extraVolumeMounts | nindent 12 }}
+          {{- end }}
         {{- with .Values.firefoxNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
@@ -67,4 +70,7 @@ spec:
           emptyDir:
             medium: Memory
             sizeLimit: {{ default "1Gi" .Values.firefoxNode.dshmVolumeSizeLimit }}
+      {{- if .Values.firefoxNode.extraVolumes }}
+        {{ toYaml .Values.firefoxNode.extraVolumes | nindent 8 }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -311,6 +311,17 @@ chromeNode:
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
   dshmVolumeSizeLimit: 1Gi
 
+  extraVolumeMounts: []
+  # - name: my-extra-volume
+  #   mountPath: /home/seluser/Downloads
+
+  extraVolumes: []
+  # - name: my-extra-volume
+  #   emptyDir: {}
+  # - name: my-extra-volume-from-pvc
+  #   persistentVolumeClaim:
+  #     claimName: my-pv-claim
+
 # Configuration for firefox nodes
 firefoxNode:
   # Enable firefox nodes
@@ -372,6 +383,17 @@ firefoxNode:
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
   dshmVolumeSizeLimit: 1Gi
 
+  extraVolumeMounts: []
+  # - name: my-extra-volume
+  #   mountPath: /home/seluser/Downloads
+
+  extraVolumes: []
+  # - name: my-extra-volume
+  #   emptyDir: {}
+  # - name: my-extra-volume-from-pvc
+  #   persistentVolumeClaim:
+  #     claimName: my-pv-claim
+
 # Configuration for edge nodes
 edgeNode:
   # Enable edge nodes
@@ -432,6 +454,17 @@ edgeNode:
       hello: world
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
   dshmVolumeSizeLimit: 1Gi
+
+  extraVolumeMounts: []
+  # - name: my-extra-volume
+  #   mountPath: /home/seluser/Downloads
+
+  extraVolumes: []
+  # - name: my-extra-volume
+  #   emptyDir: {}
+  # - name: my-extra-volume-from-pvc
+  #   persistentVolumeClaim:
+  #     claimName: my-pv-claim
 
 # Custom labels for k8s resources
 customLabels: {}


### PR DESCRIPTION
### Description
Added ability to mount arbitrary extra volumes into Chrome, Firefox and Edge nodes.

### Motivation and Context
I was testing some of my applications and in parallel decided to run Selenium Hub in my Kubernetes cluster.
Selenium test code downloads files from web-app and shared caller-script had to check files integrity.
It was easy, when I was running simple selenium containers on my localhost and mounting the required Dir into the container.
In the case of Kubernetes same problem is solved using Volumes and VolumeMounts.

My change is strictly following Kubernetes mounts and volumes definitions and accepts exactly the same format as it is described in Kubernetes docs.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
