### PR TITLE
[helm] add support of loadBalancerIP for hub and router services

### DIFF
--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 All notable changes to this helm chart will be documented in this file.
 
-## :heavy_check_mark: 0.7.1
+## :heavy_check_mark: 0.8.0
 
 ### Added
 - Added support of loadBalancerIP for hub and router services

--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.7.1
+
+### Added
+- Added support of loadBalancerIP for hub and router services
+
 ## :heavy_check_mark: 0.7.0
 
 ### Added

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.7.1
+version: 0.8.0
 appVersion: 4.3.0-20220706
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.7.0
+version: 0.7.1
 appVersion: 4.3.0-20220706
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -166,6 +166,7 @@ You can configure the Selenium Hub with this values:
 | `hub.extraEnvFrom`              | `nil`             | Custom environment variables for selenium taken from `configMap` or `secret`-hub                                                 |
 | `hub.resources`                 | `{}`              | Resources for selenium-hub container                                                                                             |
 | `hub.serviceType`               | `NodePort`        | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
+| `hub.loadBalancerIP`            | `nil`             | Set specific loadBalancerIP when serviceType is LoadBalancer (see https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) |
 | `hub.serviceAnnotations`        | `{}`              | Custom annotations for Selenium Hub service                                                                                      |
 
 
@@ -185,6 +186,7 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.router.readinessProbe`            | `See values.yaml`         | Readiness probe settings                                                                                                         |
 | `components.router.resources`                 | `{}`                      | Resources for router container                                                                                                   |
 | `components.router.serviceType`               | `NodePort`                | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
+| `components.router.loadBalancerIP`            | `nil`                     | Set specific loadBalancerIP when serviceType is LoadBalancer (see https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer) |
 | `components.router.serviceAnnotations`        | `{}`                      | Custom annotations for router service                                                                                            |
 | `components.router.tolerations`               | `[]`                      | Tolerations for router pods                                                                                                      |
 | `components.router.nodeSelector`              | `{}`                      | Node Selector for router pods                                                                                                    |

--- a/charts/selenium-grid/templates/hub-service.yaml
+++ b/charts/selenium-grid/templates/hub-service.yaml
@@ -17,6 +17,9 @@ spec:
   selector:
     app: selenium-hub
   type: {{ .Values.hub.serviceType }}
+  {{- if and (eq .Values.hub.serviceType "LoadBalancer") ( .Values.hub.loadBalancerIP ) }}
+  loadBalancerIP: {{ .Values.hub.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: http-hub
       protocol: TCP

--- a/charts/selenium-grid/templates/router-service.yaml
+++ b/charts/selenium-grid/templates/router-service.yaml
@@ -17,6 +17,9 @@ spec:
   selector:
     app: selenium-router
   type: {{ .Values.components.router.serviceType }}
+  {{- if and (eq .Values.components.router.serviceType "LoadBalancer") (.Values.components.router.loadBalancerIP) }}
+  loadBalancerIP: {{ .Values.components.router.loadBalancerIP }}
+  {{- end }}
   ports:
     - name: tcp-router
       protocol: TCP

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -71,6 +71,8 @@ components:
     resources: {}
     # Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
     serviceType: ClusterIP
+    # Set specific loadBalancerIP when serviceType is LoadBalancer (see https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
+    loadBalancerIP: ""
     # Custom annotations for router service
     serviceAnnotations: {}
     # Tolerations for router pods
@@ -273,6 +275,8 @@ hub:
   resources: {}
   # Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)
   serviceType: ClusterIP
+  # Set specific loadBalancerIP when serviceType is LoadBalancer (see https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer)
+  loadBalancerIP: ""
   # Custom annotations for Selenium Hub service
   serviceAnnotations: {}
   # Tolerations for selenium-hub pods


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Templates under  `charts/selenium-grid/templates/hub-service.yaml` and `charts/selenium-grid/templates/router-service.yaml` are updated to support loadBalancerIP value
Values under `charts/selenium-grid/values.yaml` is updated to support loadBalancerIP value
Readme under `charts/selenium-grid/README.md` is updated to describe new values

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
This PR adds support to the `loadBalancerIP` parameter when the service type is [LoadBalancer](https://kubernetes.io/docs/concepts/services-networking/service/#loadbalancer). This allows using of a specific IP for some cloud providers and on-premises

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
