### PR TITLE
Add pod priority class to helm chart and icon

### DIFF
--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.6.2
+
+### Added
+- Pod PriorityClasses
+
 ## :heavy_check_mark: 0.6.1
 
 ### Changed

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,5 +2,6 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.6.1
+version: 0.6.2
 appVersion: 4.3.0-20220628
+icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -76,10 +76,11 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.seleniumServicePort`        | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
 | `chromeNode.annotations`                | `{}`                               | Annotations for chrome-node pods                                                                                           |
 | `chromeNode.labels`                     | `{}`                               | Labels for chrome-node pods                                                                                                |
-| `chromeNode.resources`                  | `See values.yaml`                  | Resources for chrome-node container                                                                                        |
-| `chromeNode.tolerations`                | `[]`                               | Tolerations for chrome-node container                                                                                      |
-| `chromeNode.nodeSelector`               | `{}`                               | Node Selector for chrome-node container                                                                                    |
+| `chromeNode.resources`                  | `See values.yaml`                  | Resources for chrome-node pods                                                                                             |
+| `chromeNode.tolerations`                | `[]`                               | Tolerations for chrome-node pods                                                                                           |
+| `chromeNode.nodeSelector`               | `{}`                               | Node Selector for chrome-node pods                                                                                         |
 | `chromeNode.hostAliases`                | `nil`                              | Custom host aliases for chrome nodes                                                                                       |
+| `chromeNode.priorityClassName`          | `""`                               | Priority class name for chrome-node pods                                                                                   |
 | `chromeNode.extraEnvironmentVariables`  | `nil`                              | Custom environment variables for chrome nodes                                                                              |
 | `chromeNode.extraEnvFrom`               | `nil`                              | Custom environment taken from `configMap` or `secret` variables for chrome nodes                                           |
 | `chromeNode.service.enabled`            | `true`                             | Create a service for node                                                                                                  |
@@ -98,10 +99,11 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.seleniumServicePort`       | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
 | `firefoxNode.annotations`               | `{}`                               | Annotations for firefox-node pods                                                                                          |
 | `firefoxNode.labels`                    | `{}`                               | Labels for firefox-node pods                                                                                               |
-| `firefoxNode.resources`                 | `See values.yaml`                  | Resources for firefox-node container                                                                                       |
-| `firefoxNode.tolerations`               | `[]`                               | Tolerations for firefox-node container                                                                                     |
-| `firefoxNode.nodeSelector`              | `{}`                               | Node Selector for firefox-node container                                                                                   |
+| `firefoxNode.resources`                 | `See values.yaml`                  | Resources for firefox-node pods                                                                                            |
+| `firefoxNode.tolerations`               | `[]`                               | Tolerations for firefox-node pods                                                                                          |
+| `firefoxNode.nodeSelector`              | `{}`                               | Node Selector for firefox-node pods                                                                                        |
 | `firefoxNode.hostAliases`               | `nil`                              | Custom host aliases for firefox nodes                                                                                      |
+| `firefoxNode.priorityClassName`         | `""`                               | Priority class name for firefox-node pods                                                                                  |
 | `firefoxNode.extraEnvironmentVariables` | `nil`                              | Custom environment variables for firefox nodes                                                                             |
 | `firefoxNode.extraEnvFrom`              | `nil`                              | Custom environment variables taken from `configMap` or `secret` for firefox nodes                                          |
 | `firefoxNode.service.enabled`           | `true`                             | Create a service for node                                                                                                  |
@@ -120,12 +122,13 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.seleniumServicePort`          | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
 | `edgeNode.annotations`                  | `{}`                               | Annotations for edge-node pods                                                                                             |
 | `edgeNode.labels`                       | `{}`                               | Labels for edge-node pods                                                                                                  |
-| `edgeNode.resources`                    | `See values.yaml`                  | Resources for edge-node container                                                                                          |
-| `edgeNode.tolerations`                  | `[]`                               | Tolerations for edge-node container                                                                                        |
-| `edgeNode.nodeSelector`                 | `{}`                               | Node Selector for edge-node container                                                                                      |
+| `edgeNode.resources`                    | `See values.yaml`                  | Resources for edge-node pods                                                                                               |
+| `edgeNode.tolerations`                  | `[]`                               | Tolerations for edge-node pods                                                                                             |
+| `edgeNode.nodeSelector`                 | `{}`                               | Node Selector for edge-node pods                                                                                           |
 | `edgeNode.hostAliases`                  | `nil`                              | Custom host aliases for edge nodes                                                                                         |
-| `edgeNode.extraEnvironmentVariables`    | `nil`                              | Custom environment variables for edge nodes                                                                                |
-| `edgeNode.extraEnvFrom`                 | `nil`                              | Custom environment taken from `configMap` or `secret` variables for edge nodes                                             |
+| `edgeNode.priorityClassName`            | `""`                               | Priority class name for edge-node pods                                                                                     |
+| `edgeNode.extraEnvironmentVariables`    | `nil`                              | Custom environment variables for firefox nodes                                                                             |
+| `edgeNode.extraEnvFrom`                 | `nil`                              | Custom environment taken from `configMap` or `secret` variables for firefox nodes                                          |
 | `edgeNode.service.enabled`              | `true`                             | Create a service for node                                                                                                  |
 | `edgeNode.service.type`                 | `ClusterIP`                        | Service type                                                                                                               |
 | `edgeNode.service.annotations`          | `{}`                               | Custom annotations for service                                                                                             |
@@ -151,8 +154,9 @@ You can configure the Selenium Hub with this values:
 | `hub.port`                      | `4444`            | Selenium Hub port                                                                                                                |
 | `hub.livenessProbe`             | `See values.yaml` | Liveness probe settings                                                                                                          |
 | `hub.readinessProbe`            | `See values.yaml` | Readiness probe settings                                                                                                         |
-| `hub.tolerations`               | `[]`              | Tolerations for selenium-hub container                                                                                           |
-| `hub.nodeSelector`              | `{}`              | Node Selector for selenium-hub container                                                                                         |
+| `hub.tolerations`               | `[]`              | Tolerations for selenium-hub pods                                                                                                |
+| `hub.nodeSelector`              | `{}`              | Node Selector for selenium-hub pods                                                                                              |
+| `hub.priorityClassName`         | `""`              | Priority class name for selenium-hub pods                                                                                        |
 | `hub.extraEnvironmentVariables` | `nil`             | Custom environment variables for selenium-hub                                                                                    |
 | `hub.extraEnvFrom`              | `nil`             | Custom environment variables for selenium taken from `configMap` or `secret`-hub                                                 |
 | `hub.resources`                 | `{}`              | Resources for selenium-hub container                                                                                             |
@@ -176,6 +180,9 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.router.resources`                 | `{}`                      | Resources for router container                                                                                                   |
 | `components.router.serviceType`               | `NodePort`                | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | `components.router.serviceAnnotations`        | `{}`                      | Custom annotations for router service                                                                                            |
+| `components.router.tolerations`               | `[]`                      | Tolerations for router pods                                                                                                      |
+| `components.router.nodeSelector`              | `{}`                      | Node Selector for router pods                                                                                                    |
+| `components.router.priorityClassName`         | `""`                      | Priority class name for router pods                                                                                              |
 | `components.distributor.imageName`            | `selenium/distributor`    | Distributor image name                                                                                                           |
 | `components.distributor.imageTag`             | `nil`                     | Distributor image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                   |
 | `components.distributor.imagePullPolicy`      | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
@@ -184,6 +191,9 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.distributor.resources`            | `{}`                      | Resources for Distributor container                                                                                              |
 | `components.distributor.serviceType`          | `ClusterIP`               | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | `components.distributor.serviceAnnotations`   | `{}`                      | Custom annotations for Distributor service                                                                                       |
+| `components.distributor.tolerations`          | `[]`                      | Tolerations for Distributor pods                                                                                                 |
+| `components.distributor.nodeSelector`         | `{}`                      | Node Selector for Distributor pods                                                                                               |
+| `components.distributor.priorityClassName`    | `""`                      | Priority class name for Distributor pods                                                                                         |
 | `components.eventBus.imageName`               | `selenium/event-bus`      | Event Bus image name                                                                                                             |
 | `components.eventBus.imageTag`                | `nil`                     | Event Bus image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                     |
 | `components.eventBus.imagePullPolicy`         | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
@@ -194,6 +204,9 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.eventBus.resources`               | `{}`                      | Resources for event-bus container                                                                                                |
 | `components.eventBus.serviceType`             | `ClusterIP`               | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | `components.eventBus.serviceAnnotations`      | `{}`                      | Custom annotations for Event Bus service                                                                                         |
+| `components.eventBus.tolerations`             | `[]`                      | Tolerations for Event Bus pods                                                                                                   |
+| `components.eventBus.nodeSelector`            | `{}`                      | Node Selector for Event Bus pods                                                                                                 |
+| `components.eventBus.priorityClassName`       | `""`                      | Priority class name for Event Bus pods                                                                                           |
 | `components.sessionMap.imageName`             | `selenium/sessions`       | Session Map image name                                                                                                           |
 | `components.sessionMap.imageTag`              | `nil`                     | Session Map image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                   |
 | `components.sessionMap.imagePullPolicy`       | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
@@ -201,6 +214,9 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.sessionMap.resources`             | `{}`                      | Resources for event-bus container                                                                                                |
 | `components.sessionMap.serviceType`           | `ClusterIP`               | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | `components.sessionMap.serviceAnnotations`    | `{}`                      | Custom annotations for Session Map service                                                                                       |
+| `components.sessionMap.tolerations`           | `[]`                      | Tolerations for Session Map pods                                                                                                 |
+| `components.sessionMap.nodeSelector`          | `{}`                      | Node Selector for Session Map pods                                                                                               |
+| `components.sessionMap.priorityClassName`     | `""`                      | Priority class name for Session Map pods                                                                                         |
 | `components.sessionQueue.imageName`           | `selenium/session-queue`  | Session Queue image name                                                                                                         |
 | `components.sessionQueue.imageTag`            | `nil`                     | Session Queue image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                 |
 | `components.sessionQueue.imagePullPolicy`     | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
@@ -208,6 +224,9 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.sessionQueue.resources`           | `{}`                      | Resources for event-bus container                                                                                                |
 | `components.sessionQueue.serviceType`         | `ClusterIP`               | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
 | `components.sessionQueue.serviceAnnotations`  | `{}`                      | Custom annotations for Session Queue service                                                                                     |
+| `components.sessionQueue.tolerations`         | `[]`                      | Tolerations for Session Queue pods                                                                                               |
+| `components.sessionQueue.nodeSelector`        | `{}`                      | Node Selector for Session Queue pods                                                                                             |
+| `components.sessionQueue.priorityClassName`   | `""`                      | Priority class name for Session Queue pods                                                                                       |
 | `components.extraEnvironmentVariables`        | `nil`                     | Custom environment variables for all components                                                                                  |
 | `components.extraEnvFrom`                     | `nil`                     | Custom environment variables taken from `configMap` or `secret` for all components                                               |
 

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -68,6 +68,9 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.chromeNode.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -59,4 +59,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.components.distributor.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -68,6 +68,9 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.edgeNode.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -38,10 +38,10 @@ spec:
         {{- with .Values.components.extraEnvironmentVariables }}
           env: {{- tpl (toYaml .) $ | nindent 12 }}
         {{- end }}
+        {{- with .Values.components.extraEnvFrom }}
           envFrom:
-            {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
+        {{- end }}
         {{- with .Values.components.eventBus.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -52,4 +52,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.components.eventBus.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -68,6 +68,9 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.firefoxNode.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -63,10 +63,10 @@ spec:
         {{- with .Values.hub.extraEnvironmentVariables }}
           env: {{- tpl (toYaml .) $ | nindent 12 }}
         {{- end }}
+        {{- with .Values.hub.extraEnvFrom }}
           envFrom:
-            {{- with .Values.hub.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
+        {{- end }}
         {{- with .Values.hub.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -77,4 +77,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.hub.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -83,4 +83,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.components.router.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -44,10 +44,10 @@ spec:
           {{- with .Values.components.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
+          {{- with .Values.components.extraEnvFrom }}
           envFrom:
-            {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-            {{- end }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.components.router.port }}
               protocol: TCP

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -50,4 +50,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.components.sessionMap.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/session-queuer-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queuer-deployment.yaml
@@ -50,4 +50,7 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- with .Values.components.sessionQueue.priorityClassName }}
+      priorityClassName: {{ . }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -72,6 +72,8 @@ components:
     tolerations: []
     # Node selector for router container
     nodeSelector: {}
+    # Priority class name for router pods
+    priorityClassName: ""
 
   # Configuration for distributor component
   distributor:
@@ -96,6 +98,8 @@ components:
     tolerations: []
     # Node selector for Distributor container
     nodeSelector: {}
+    # Priority class name for Distributor pods
+    priorityClassName: ""
 
   # Configuration for Event Bus component
   eventBus:
@@ -124,6 +128,8 @@ components:
     tolerations: []
     # Node selector for Event Bus container
     nodeSelector: {}
+    # Priority class name for Event Bus pods
+    priorityClassName: ""
 
   # Configuration for Session Map component
   sessionMap:
@@ -147,6 +153,8 @@ components:
     tolerations: []
     # Node selector for Session Map container
     nodeSelector: {}
+    # Priority class name for Session Map pods
+    priorityClassName: ""
 
   # Configuration for Session Queue component
   sessionQueue:
@@ -170,6 +178,8 @@ components:
     tolerations: []
     # Node selector for Session Queue container
     nodeSelector: {}
+    # Priority class name for Session Queue pods
+    priorityClassName: ""
 
   # Custom environment variables for all components
   extraEnvironmentVariables:
@@ -249,6 +259,8 @@ hub:
   tolerations: []
   # Node selector for selenium-hub container
   nodeSelector: {}
+  # Priority class name for selenium-hub pods
+  priorityClassName: ""
 
 # Configuration for chrome nodes
 chromeNode:
@@ -319,6 +331,8 @@ chromeNode:
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
   dshmVolumeSizeLimit: 1Gi
+  # Priority class name for chrome-node pods
+  priorityClassName: ""
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -400,6 +414,8 @@ firefoxNode:
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
   dshmVolumeSizeLimit: 1Gi
+  # Priority class name for firefox-node pods
+  priorityClassName: ""
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -481,6 +497,8 @@ edgeNode:
       hello: world
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
   dshmVolumeSizeLimit: 1Gi
+  # Priority class name for edge-node pods
+  priorityClassName: ""
 
   extraVolumeMounts: []
   # - name: my-extra-volume

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -40,7 +40,7 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
-    # Custom annotations for router pod
+    # Custom annotations for router pods
     annotations: {}
     # Router port
     port: 4444
@@ -68,9 +68,9 @@ components:
     serviceType: ClusterIP
     # Custom annotations for router service
     serviceAnnotations: {}
-    # Tolerations for router container
+    # Tolerations for router pods
     tolerations: []
-    # Node selector for router container
+    # Node selector for router pods
     nodeSelector: {}
     # Priority class name for router pods
     priorityClassName: ""
@@ -84,7 +84,7 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
-    # Custom annotations for Distributor pod
+    # Custom annotations for Distributor pods
     annotations: {}
     # Distributor port
     port: 5553
@@ -94,9 +94,9 @@ components:
     serviceType: ClusterIP
     # Custom annotations for Distributor service
     serviceAnnotations: {}
-    # Tolerations for Distributor container
+    # Tolerations for Distributor pods
     tolerations: []
-    # Node selector for Distributor container
+    # Node selector for Distributor pods
     nodeSelector: {}
     # Priority class name for Distributor pods
     priorityClassName: ""
@@ -110,7 +110,7 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
-    # Custom annotations for Event Bus pod
+    # Custom annotations for Event Bus pods
     annotations: {}
     # Event Bus port
     port: 5557
@@ -124,9 +124,9 @@ components:
     serviceType: ClusterIP
     # Custom annotations for Event Bus service
     serviceAnnotations: {}
-    # Tolerations for Event Bus container
+    # Tolerations for Event Bus pods
     tolerations: []
-    # Node selector for Event Bus container
+    # Node selector for Event Bus pods
     nodeSelector: {}
     # Priority class name for Event Bus pods
     priorityClassName: ""
@@ -140,7 +140,7 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
-    # Custom annotations for Session Map pod
+    # Custom annotations for Session Map pods
     annotations: {}
     port: 5556
     # Resources for Session Map container
@@ -149,9 +149,9 @@ components:
     serviceType: ClusterIP
     # Custom annotations for Session Map service
     serviceAnnotations: {}
-    # Tolerations for Session Map container
+    # Tolerations for Session Map pods
     tolerations: []
-    # Node selector for Session Map container
+    # Node selector for Session Map pods
     nodeSelector: {}
     # Priority class name for Session Map pods
     priorityClassName: ""
@@ -165,7 +165,7 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
-    # Custom annotations for Session Queue pod
+    # Custom annotations for Session Queue pods
     annotations: {}
     port: 5559
     # Resources for Session Queue container
@@ -174,9 +174,9 @@ components:
     serviceType: ClusterIP
     # Custom annotations for Session Queue service
     serviceAnnotations: {}
-    # Tolerations for Session Queue container
+    # Tolerations for Session Queue pods
     tolerations: []
-    # Node selector for Session Queue container
+    # Node selector for Session Queue pods
     nodeSelector: {}
     # Priority class name for Session Queue pods
     priorityClassName: ""
@@ -206,9 +206,9 @@ hub:
   imageTag: 4.3.0-20220628
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
-  # Custom annotations for Selenium Hub pod
+  # Custom annotations for Selenium Hub pods
   annotations: {}
-  # Custom labels for Selenium Hub pod
+  # Custom labels for Selenium Hub pods
   labels: {}
   # Port where events are published
   publishPort: 4442
@@ -255,9 +255,9 @@ hub:
   serviceType: ClusterIP
   # Custom annotations for Selenium Hub service
   serviceAnnotations: {}
-  # Tolerations for selenium-hub container
+  # Tolerations for selenium-hub pods
   tolerations: []
-  # Node selector for selenium-hub container
+  # Node selector for selenium-hub pods
   nodeSelector: {}
   # Priority class name for selenium-hub pods
   priorityClassName: ""
@@ -293,9 +293,9 @@ chromeNode:
     limits:
       memory: "1Gi"
       cpu: "1"
-  # Tolerations for chrome-node container
+  # Tolerations for chrome-node pods
   tolerations: []
-  # Node selector for chrome-node container
+  # Node selector for chrome-node pods
   nodeSelector: {}
   # Custom host aliases for chrome nodes
   hostAliases:
@@ -368,9 +368,9 @@ firefoxNode:
   annotations: {}
   # Labels for firefox-node pods
   labels: {}
-  # Tolerations for firefox-node container
+  # Tolerations for firefox-node pods
   tolerations: []
-  # Node selector for firefox-node container
+  # Node selector for firefox-node pods
   nodeSelector: {}
   # Resources for firefox-node container
   resources:
@@ -450,9 +450,9 @@ edgeNode:
   annotations: {}
   # Labels for edge-node pods
   labels: {}
-  # Tolerations for edge-node container
+  # Tolerations for edge-node pods
   tolerations: []
-  # Node selector for edge-node container
+  # Node selector for edge-node pods
   nodeSelector: {}
   # Resources for edge-node container
   resources:


### PR DESCRIPTION
### Description
Add `priorityClassName` option for each deployment and add an icon to the Helm chart.

### Motivation and Context
We have had some issues with pods getting preempted in the middle of running a test which causes a test failure. Setting a higher priority for pods should reduce the chance of this happening. 

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.