### PR TITLE
helm: add lifecycle preStop hook & startupProbe, fix port number

### DIFF
--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -73,7 +73,7 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.imageTag`                   | `4.3.0-20220726`                   | Image of chrome nodes                                                                                                      |
 | `chromeNode.imagePullPolicy`            | `IfNotPresent`                     | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
 | `chromeNode.imagePullSecret`            | `""`                               | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)               |
-| `chromeNode.ports`                      | `[5553]`                           | Port list to enable on container                                                                                           |
+| `chromeNode.ports`                      | `[5555]`                           | Port list to enable on container                                                                                           |
 | `chromeNode.seleniumPort`               | `5900`                             | Selenium port (spec.ports[0].targetPort in kubernetes service)                                                             |
 | `chromeNode.seleniumServicePort`        | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
 | `chromeNode.annotations`                | `{}`                               | Annotations for chrome-node pods                                                                                           |
@@ -89,6 +89,9 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.service.type`               | `ClusterIP`                        | Service type                                                                                                               |
 | `chromeNode.service.annotations`        | `{}`                               | Custom annotations for service                                                                                             |
 | `chromeNode.dshmVolumeSizeLimit`        | `1Gi`                              | Size limit for DSH volume mounted in container (if not set, default is "1Gi")                                              |
+| `chromeNode.startupProbe`               | `{}`                               | Probe to check pod is started successfully                                                                                 |
+| `chromeNode.terminationGracePeriodSeconds` | `30`                            | Time to graceful terminate container (default: 30s)                                                                        |
+| `chromeNode.lifecycle`                  | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `chromeNode.extraVolumeMounts`          | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `chromeNode.extraVolumes`               | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `firefoxNode.enabled`                   | `true`                             | Enable firefox nodes                                                                                                       |
@@ -97,7 +100,7 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.imageTag`                  | `4.3.0-20220726`                   | Image of firefox nodes                                                                                                     |
 | `firefoxNode.imagePullPolicy`           | `IfNotPresent`                     | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
 | `firefoxNode.imagePullSecret`           | `""`                               | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)               |
-| `firefoxNode.ports`                     | `[5553]`                           | Port list to enable on container                                                                                           |
+| `firefoxNode.ports`                     | `[5555]`                           | Port list to enable on container                                                                                           |
 | `firefoxNode.seleniumPort`              | `5900`                             | Selenium port (spec.ports[0].targetPort in kubernetes service)                                                             |
 | `firefoxNode.seleniumServicePort`       | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
 | `firefoxNode.annotations`               | `{}`                               | Annotations for firefox-node pods                                                                                          |
@@ -113,6 +116,9 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.service.type`              | `ClusterIP`                        | Service type                                                                                                               |
 | `firefoxNode.service.annotations`       | `{}`                               | Custom annotations for service                                                                                             |
 | `firefoxNode.dshmVolumeSizeLimit`       | `1Gi`                              | Size limit for DSH volume mounted in container (if not set, default is "1Gi")                                              |
+| `firefoxNode.startupProbe`              | `{}`                               | Probe to check pod is started successfully                                                                                 |
+| `firefoxNode.terminationGracePeriodSeconds` | `30`                            | Time to graceful terminate container (default: 30s)                                                                       |
+| `firefoxNode.lifecycle`                 | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `firefoxNode.extraVolumeMounts`         | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `firefoxNode.extraVolumes`              | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `edgeNode.enabled`                      | `true`                             | Enable edge nodes                                                                                                          |
@@ -121,7 +127,7 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.imageTag`                     | `4.3.0-20220726`                   | Image of edge nodes                                                                                                        |
 | `edgeNode.imagePullPolicy`              | `IfNotPresent`                     | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
 | `edgeNode.imagePullSecret`              | `""`                               | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)               |
-| `edgeNode.ports`                        | `[5553]`                           | Port list to enable on container                                                                                           |
+| `edgeNode.ports`                        | `[5555]`                           | Port list to enable on container                                                                                           |
 | `edgeNode.seleniumPort`                 | `5900`                             | Selenium port (spec.ports[0].targetPort in kubernetes service)                                                             |
 | `edgeNode.seleniumServicePort`          | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
 | `edgeNode.annotations`                  | `{}`                               | Annotations for edge-node pods                                                                                             |
@@ -137,6 +143,9 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.service.type`                 | `ClusterIP`                        | Service type                                                                                                               |
 | `edgeNode.service.annotations`          | `{}`                               | Custom annotations for service                                                                                             |
 | `edgeNode.dshmVolumeSizeLimit`          | `1Gi`                              | Size limit for DSH volume mounted in container (if not set, default is "1Gi")                                              |
+| `edgeNode.startupProbe`                 | `{}`                               | Probe to check pod is started successfully                                                                                 |
+| `edgeNode.terminationGracePeriodSeconds` | `30`                            | Time to graceful terminate container (default: 30s)                                                                        |
+| `edgeNode.lifecycle`                    | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `edgeNode.extraVolumeMounts`            | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `edgeNode.extraVolumes`                 | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `customLabels`                          | `{}`                               | Custom labels for k8s resources                                                                                            |

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -61,6 +61,12 @@ spec:
         {{- with .Values.chromeNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.chromeNode.lifecycle }}
+          lifecycle: {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.chromeNode.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+        {{- end }}
     {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.chromeNode.imagePullSecret }}
       imagePullSecrets:
         - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.chromeNode.imagePullSecret }}
@@ -75,6 +81,7 @@ spec:
     {{- with .Values.chromeNode.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.chromeNode.terminationGracePeriodSeconds }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -61,6 +61,12 @@ spec:
         {{- with .Values.edgeNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.edgeNode.lifecycle }}
+          lifecycle: {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.edgeNode.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+        {{- end }}
     {{- with .Values.edgeNode.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -75,6 +81,7 @@ spec:
     {{- with .Values.edgeNode.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.edgeNode.terminationGracePeriodSeconds }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -61,6 +61,12 @@ spec:
         {{- with .Values.firefoxNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
+        {{- with .Values.firefoxNode.lifecycle }}
+          lifecycle: {{- toYaml . | nindent 12 }}
+        {{- end }}
+        {{- with .Values.firefoxNode.startupProbe }}
+          startupProbe: {{- toYaml . | nindent 12 }}
+        {{- end }}
     {{- with .Values.firefoxNode.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}
@@ -75,6 +81,7 @@ spec:
     {{- with .Values.firefoxNode.priorityClassName }}
       priorityClassName: {{ . }}
     {{- end }}
+      terminationGracePeriodSeconds: {{ .Values.firefoxNode.terminationGracePeriodSeconds }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -303,7 +303,7 @@ chromeNode:
 
   # Port list to enable on container
   ports:
-    - 5553
+    - 5555
   # Selenium port (spec.ports[0].targetPort in kubernetes service)
   seleniumPort: 5900
   # Selenium port exposed in service (spec.ports[0].port in kubernetes service)
@@ -361,6 +361,26 @@ chromeNode:
   # Priority class name for chrome-node pods
   priorityClassName: ""
 
+  # Wait for pod startup
+  startupProbe: {}
+    # httpGet:
+    #   path: /status
+    #   port: 5555
+    # failureThreshold: 120
+    # periodSeconds: 5
+  # Time to wait for pod termination
+  terminationGracePeriodSeconds: 30
+  # Allow pod correctly shutdown
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - bash
+    #       - -c
+    #       - |
+    #         curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
+    #         while curl 127.0.0.1:5555/status; do sleep 1; done
+
   extraVolumeMounts: []
   # - name: my-extra-volume
   #   mountPath: /home/seluser/Downloads
@@ -389,7 +409,7 @@ firefoxNode:
 
   # Port list to enable on container
   ports:
-    - 5553
+    - 5555
   # Selenium port (spec.ports[0].targetPort in kubernetes service)
   seleniumPort: 5900
   # Selenium port exposed in service (spec.ports[0].port in kubernetes service)
@@ -447,6 +467,26 @@ firefoxNode:
   # Priority class name for firefox-node pods
   priorityClassName: ""
 
+  # Wait for pod startup
+  startupProbe: {}
+    # httpGet:
+    #   path: /status
+    #   port: 5555
+    # failureThreshold: 120
+    # periodSeconds: 5
+  # Time to wait for pod termination
+  terminationGracePeriodSeconds: 30
+  # Allow pod correctly shutdown
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - bash
+    #       - -c
+    #       - |
+    #         curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
+    #         while curl 127.0.0.1:5555/status; do sleep 1; done
+
   extraVolumeMounts: []
   # - name: my-extra-volume
   #   mountPath: /home/seluser/Downloads
@@ -474,7 +514,7 @@ edgeNode:
   imagePullSecret: ""
 
   ports:
-    - 5553
+    - 5555
   # Selenium port (spec.ports[0].targetPort in kubernetes service)
   seleniumPort: 5900
   # Selenium port exposed in service (spec.ports[0].port in kubernetes service)
@@ -532,6 +572,26 @@ edgeNode:
   dshmVolumeSizeLimit: 1Gi
   # Priority class name for edge-node pods
   priorityClassName: ""
+
+  # Wait for pod startup
+  startupProbe: {}
+    # httpGet:
+    #   path: /status
+    #   port: 5555
+    # failureThreshold: 120
+    # periodSeconds: 5
+  # Time to wait for pod termination
+  terminationGracePeriodSeconds: 30
+  # Allow pod correctly shutdown
+  lifecycle: {}
+    # preStop:
+    #   exec:
+    #     command:
+    #       - bash
+    #       - -c
+    #       - |
+    #         curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
+    #         while curl 127.0.0.1:5555/status; do sleep 1; done
 
   extraVolumeMounts: []
   # - name: my-extra-volume


### PR DESCRIPTION
### Summary:
* Allow define lifecycle hooks & add a working example
* Allow override termination gracePeriod
* Allow defining startupProbe
* Fix port number in values


### Motivation and Context
Without a lifecycle preStop hook autoscaling is a huge problem (pod will die - test will fail), so just add instrumentation to define one and change the termination grace period.

startupProbe - just for observability purposes, the pod will be shown as ready only when it ready to work

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

https://github.com/SeleniumHQ/docker-selenium/pull/1592