### PR TITLE
Added supervisorctl (ported from /etc/supervisor/supervisord.conf

### DIFF
--- a/Base/supervisord.conf
+++ b/Base/supervisord.conf
@@ -11,5 +11,18 @@ nodaemon=true                                 ; (start in foreground if true;def
 minfds=1024                                   ; (min. avail startup file descriptors;default 1024)
 minprocs=200                                  ; (min. avail process descriptors;default 200)
 
+[unix_http_server]
+file=/var/run/supervisor.sock                 ; (the path to the socket file)
+chmod=0700
+
+; the below section must remain in the config file for RPC
+; (supervisorctl/web interface) to work, additional interfaces may be
+; added by defining them in separate rpcinterface: sections
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock     ; use a unix:// URL  for a unix socket
+
 [include]
 files = /etc/supervisor/conf.d/*.conf

--- a/Base/supervisord.conf
+++ b/Base/supervisord.conf
@@ -12,7 +12,7 @@ minfds=1024                                   ; (min. avail startup file descrip
 minprocs=200                                  ; (min. avail process descriptors;default 200)
 
 [unix_http_server]
-file=/var/run/supervisor.sock                 ; (the path to the socket file)
+file=/tmp/supervisor.sock                     ; (the path to the socket file)
 chmod=0700
 
 ; the below section must remain in the config file for RPC
@@ -22,7 +22,7 @@ chmod=0700
 supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
 
 [supervisorctl]
-serverurl=unix:///var/run/supervisor.sock     ; use a unix:// URL  for a unix socket
+serverurl=unix:///tmp/supervisor.sock         ; use a unix:// URL  for a unix socket
 
 [include]
 files = /etc/supervisor/conf.d/*.conf


### PR DESCRIPTION
### Description
Adds supervisord control socket so supervisorctl is available for use inside of the container. 
### Motivation and Context
It would be quite useful to be able to restart each supervisor service separately (for example vnc server gets stuck or something like that). It has been discussed with @diemol in [slack](https://seleniumhq.slack.com/archives/C0ABCS03F/p1655884428185359?thread_ts=1655831925.904899&cid=C0ABCS03F)

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
