### PR TITLE
Helm: ability to specify image pull secrets (#1619)

### DIFF
--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.7.0
+
+### Added
+- Added ability to specify image pull secrets
+
 ## :heavy_check_mark: 0.6.0
 
 ### Added

--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.7.0
+
+### Added
+- Added ability to specify image pull secrets
+
 ## :heavy_check_mark: 0.6.1
 
 ### Changed

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.6.0
+version: 0.7.0
 appVersion: 4.3.0-20220628

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,5 +2,5 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.6.1
+version: 0.7.0
 appVersion: 4.3.0-20220628

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -49,10 +49,11 @@ helm uninstall selenium-grid
 
 For now, global configuration supported is:
 
-| Parameter                           | Default                            | Description                           |
-| ----------------------------------- | ---------------------------------- | ------------------------------------- |
-| `global.seleniumGrid.imageTag`      | `4.3.0-20220628`                   | Image tag for all selenium components |
-| `global.seleniumGrid.nodesImageTag` | `4.3.0-20220628`                   | Image tag for browser's nodes         |
+| Parameter                             | Default                            | Description                           |
+| -----------------------------------   | ---------------------------------- | ------------------------------------- |
+| `global.seleniumGrid.imageTag`        | `4.3.0-20220628`                   | Image tag for all selenium components |
+| `global.seleniumGrid.nodesImageTag`   | `4.3.0-20220628`                   | Image tag for browser's nodes         |
+| `global.seleniumGrid.imagePullSecret` | `""`                               | Pull secret to be used for all images |
 
 This table contains the configuration parameters of the chart and their default values:
 
@@ -71,6 +72,7 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.imageName`                  | `selenium/node-chrome`             | Image of chrome nodes                                                                                                      |
 | `chromeNode.imageTag`                   | `4.3.0-20220628`                   | Image of chrome nodes                                                                                                      |
 | `chromeNode.imagePullPolicy`            | `IfNotPresent`                     | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
+| `chromeNode.imagePullSecret`            | `""`                               | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)               |
 | `chromeNode.ports`                      | `[5553]`                           | Port list to enable on container                                                                                           |
 | `chromeNode.seleniumPort`               | `5900`                             | Selenium port (spec.ports[0].targetPort in kubernetes service)                                                             |
 | `chromeNode.seleniumServicePort`        | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
@@ -93,6 +95,7 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.imageName`                 | `selenium/node-firefox`            | Image of firefox nodes                                                                                                     |
 | `firefoxNode.imageTag`                  | `4.3.0-20220628`                   | Image of firefox nodes                                                                                                     |
 | `firefoxNode.imagePullPolicy`           | `IfNotPresent`                     | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
+| `firefoxNode.imagePullSecret`           | `""`                               | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)               |
 | `firefoxNode.ports`                     | `[5553]`                           | Port list to enable on container                                                                                           |
 | `firefoxNode.seleniumPort`              | `5900`                             | Selenium port (spec.ports[0].targetPort in kubernetes service)                                                             |
 | `firefoxNode.seleniumServicePort`       | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
@@ -115,6 +118,7 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.imageName`                    | `selenium/node-edge`               | Image of edge nodes                                                                                                        |
 | `edgeNode.imageTag`                     | `4.3.0-20220628`                   | Image of edge nodes                                                                                                        |
 | `edgeNode.imagePullPolicy`              | `IfNotPresent`                     | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
+| `edgeNode.imagePullSecret`              | `""`                               | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)               |
 | `edgeNode.ports`                        | `[5553]`                           | Port list to enable on container                                                                                           |
 | `edgeNode.seleniumPort`                 | `5900`                             | Selenium port (spec.ports[0].targetPort in kubernetes service)                                                             |
 | `edgeNode.seleniumServicePort`          | `6900`                             | Selenium port exposed in service (spec.ports[0].port in kubernetes service)                                                |
@@ -144,6 +148,7 @@ You can configure the Selenium Hub with this values:
 | `hub.imageName`                 | `selenium/hub`    | Selenium Hub image name                                                                                                          |
 | `hub.imageTag`                  | `nil`             | Selenium Hub image tag (this overwrites `.global.seleniumGrid.imageTag` value)                                                   |
 | `hub.imagePullPolicy`           | `IfNotPresent`    | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
+| `hub.imagePullSecret`           | `""`              | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)                     |
 | `hub.annotations`               | `{}`              | Custom annotations for Selenium Hub pod                                                                                          |
 | `hub.labels`                    | `{}`              | Custom labels for Selenium Hub pod                                                                                               |
 | `hub.publishPort`               | `4442`            | Port where events are published                                                                                                  |
@@ -169,6 +174,7 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.router.imageName`                 | `selenium/router`         | Router image name                                                                                                                |
 | `components.router.imageTag`                  | `nil`                     | Router image tag (this overwrites `.global.seleniumGrid.imageTag` value)                                                         |
 | `components.router.imagePullPolicy`           | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
+| `components.router.imagePullSecret`           | `""`                      | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)                     |
 | `components.router.annotations`               | `{}`                      | Custom annotations for router pod                                                                                                |
 | `components.router.port`                      | `4444`                    | Router port                                                                                                                      |
 | `components.router.livenessProbe`             | `See values.yaml`         | Liveness probe settings                                                                                                          |
@@ -179,6 +185,7 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.distributor.imageName`            | `selenium/distributor`    | Distributor image name                                                                                                           |
 | `components.distributor.imageTag`             | `nil`                     | Distributor image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                   |
 | `components.distributor.imagePullPolicy`      | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
+| `components.distributor.imagePullSecret`      | `""`                      | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)                     |
 | `components.distributor.annotations`          | `{}`                      | Custom annotations for Distributor pod                                                                                           |
 | `components.distributor.port`                 | `5553`                    | Distributor port                                                                                                                 |
 | `components.distributor.resources`            | `{}`                      | Resources for Distributor container                                                                                              |
@@ -187,6 +194,7 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.eventBus.imageName`               | `selenium/event-bus`      | Event Bus image name                                                                                                             |
 | `components.eventBus.imageTag`                | `nil`                     | Event Bus image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                     |
 | `components.eventBus.imagePullPolicy`         | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
+| `components.eventBus.imagePullSecret`         | `""`                      | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)                     |
 | `components.eventBus.annotations`             | `{}`                      | Custom annotations for Event Bus pod                                                                                             |
 | `components.eventBus.port`                    | `5557`                    | Event Bus port                                                                                                                   |
 | `components.eventBus.publishPort`             | `4442`                    | Port where events are published                                                                                                  |
@@ -197,6 +205,7 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.sessionMap.imageName`             | `selenium/sessions`       | Session Map image name                                                                                                           |
 | `components.sessionMap.imageTag`              | `nil`                     | Session Map image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                   |
 | `components.sessionMap.imagePullPolicy`       | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
+| `components.sessionMap.imagePullSecret`       | `""`                      | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)                     |
 | `components.sessionMap.annotations`           | `{}`                      | Custom annotations for Session Map pod                                                                                           |
 | `components.sessionMap.resources`             | `{}`                      | Resources for event-bus container                                                                                                |
 | `components.sessionMap.serviceType`           | `ClusterIP`               | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |
@@ -204,6 +213,7 @@ If you implement selenium-grid with separate components (`isolateComponents: tru
 | `components.sessionQueue.imageName`           | `selenium/session-queue`  | Session Queue image name                                                                                                         |
 | `components.sessionQueue.imageTag`            | `nil`                     | Session Queue image tag  (this overwrites `.global.seleniumGrid.imageTag` value)                                                 |
 | `components.sessionQueue.imagePullPolicy`     | `IfNotPresent`            | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                                   |
+| `components.sessionQueue.imagePullSecret`     | `""`                      | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry)                     |
 | `components.sessionQueue.annotations`         | `{}`                      | Custom annotations for Session Queue pod                                                                                         |
 | `components.sessionQueue.resources`           | `{}`                      | Resources for event-bus container                                                                                                |
 | `components.sessionQueue.serviceType`         | `ClusterIP`               | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types) |

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -61,6 +61,10 @@ spec:
         {{- with .Values.chromeNode.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.chromeNode.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.chromeNode.imagePullSecret }}
+    {{- end }}
     {{- with .Values.chromeNode.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -52,6 +52,10 @@ spec:
         {{- with .Values.components.distributor.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.components.distributor.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.components.distributor.imagePullSecret }}
+    {{- end }}
     {{- with .Values.components.distributor.nodeSelector }}
       nodeSelector: {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -68,6 +68,10 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.edgeNode.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.edgeNode.imagePullSecret }}
+    {{- end }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -52,4 +52,8 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.components.eventBus.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.components.eventBus.imagePullSecret }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -68,6 +68,10 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.firefoxNode.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.firefoxNode.imagePullSecret }}
+    {{- end }}
       volumes:
         - name: dshm
           emptyDir:

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -77,4 +77,8 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.hub.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.hub.imagePullSecret }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -83,4 +83,8 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.components.router.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.components.router.imagePullSecret }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -50,4 +50,8 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.components.sessionMap.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.components.sessionMap.imagePullSecret }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/session-queuer-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queuer-deployment.yaml
@@ -50,4 +50,8 @@ spec:
       tolerations:
         {{ toYaml . | nindent 6 }}
     {{- end }}
+    {{- if or .Values.global.seleniumGrid.imagePullSecret .Values.components.sessionQueue.imagePullSecret }}
+      imagePullSecrets:
+        - name: {{ default .Values.global.seleniumGrid.imagePullSecret .Values.components.sessionQueue.imagePullSecret }}
+    {{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -4,6 +4,8 @@ global:
     imageTag: 4.3.0-20220628
     # Image tag for browser's nodes
     nodesImageTag: 4.3.0-20220628
+    # Pull secret for all components, can be overridden individually
+    imagePullSecret: ""
 
 # Deploy Router, Distributor, EventBus, SessionMap and Nodes separately
 isolateComponents: false
@@ -40,6 +42,9 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
+    # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+    imagePullSecret: ""
+
     # Custom annotations for router pod
     annotations: {}
     # Router port
@@ -82,6 +87,9 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
+    # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+    imagePullSecret: ""
+
     # Custom annotations for Distributor pod
     annotations: {}
     # Distributor port
@@ -106,6 +114,9 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
+    # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+    imagePullSecret: ""
+
     # Custom annotations for Event Bus pod
     annotations: {}
     # Event Bus port
@@ -134,6 +145,9 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
+    # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+    imagePullSecret: ""
+
     # Custom annotations for Session Map pod
     annotations: {}
     port: 5556
@@ -157,6 +171,9 @@ components:
 
     # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
     imagePullPolicy: IfNotPresent
+    # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+    imagePullSecret: ""
+
     # Custom annotations for Session Queue pod
     annotations: {}
     port: 5559
@@ -196,6 +213,9 @@ hub:
   imageTag: 4.3.0-20220628
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
+  # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  imagePullSecret: ""
+
   # Custom annotations for Selenium Hub pod
   annotations: {}
   # Custom labels for Selenium Hub pod
@@ -262,6 +282,9 @@ chromeNode:
   # imageTag: 4.3.0-20220628
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
+  # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  imagePullSecret: ""
+
   # Port list to enable on container
   ports:
     - 5553
@@ -343,6 +366,9 @@ firefoxNode:
   # imageTag: 4.3.0-20220628
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
+  # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  imagePullSecret: ""
+
   # Port list to enable on container
   ports:
     - 5553
@@ -424,6 +450,9 @@ edgeNode:
   # imageTag: 4.3.0-20220628
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
+  # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
+  imagePullSecret: ""
+
   ports:
     - 5553
   # Selenium port (spec.ports[0].targetPort in kubernetes service)


### PR DESCRIPTION
### Description
Added global value `global.seleniumGrid.imagePullSecret`
Added per component override `component.imagePullSecret`

Updated readme
Bumped chart version to 0.7.0

### Motivation and Context
Allows users to deploy images from a private repository rather than dockerhub.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [X] My change requires a change to the documentation.
- [X] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
