### PR TITLE
Enable autorestart for vnc and other video-related services

### DIFF
--- a/NodeBase/selenium.conf
+++ b/NodeBase/selenium.conf
@@ -6,9 +6,7 @@
 priority=0
 command=/opt/bin/start-xvfb.sh
 autostart=true
-autorestart=false
-startsecs=0
-startretries=0
+autorestart=true
 
 ;Logs
 redirect_stderr=false
@@ -25,9 +23,7 @@ stderr_capture_maxbytes=50MB
 priority=5
 command=/opt/bin/start-vnc.sh
 autostart=true
-autorestart=false
-startsecs=0
-startretries=0
+autorestart=true
 
 ;Logs
 redirect_stderr=false
@@ -44,9 +40,7 @@ stderr_capture_maxbytes=50MB
 priority=10
 command=/opt/bin/start-novnc.sh
 autostart=true
-autorestart=false
-startsecs=0
-startretries=0
+autorestart=true
 
 ;Logs
 redirect_stderr=false

--- a/Video/supervisord.conf
+++ b/Video/supervisord.conf
@@ -15,9 +15,7 @@ minprocs=200                                  ; (min. avail process descriptors;
 priority=0
 command=/opt/bin/video.sh
 autostart=true
-autorestart=false
-startsecs=0
-startretries=0
+autorestart=true
 stopsignal=INT
 
 ;Logs (all activity redirected to stdout so it can be seen through "docker logs"
@@ -29,9 +27,7 @@ stdout_logfile_maxbytes=0
 priority=5
 command=python3 /opt/bin/video_ready.py
 autostart=true
-autorestart=false
-startsecs=0
-startretries=0
+autorestart=true
 stopsignal=INT
 
 ;Logs (all activity redirected to stdout so it can be seen through "docker logs"


### PR DESCRIPTION
### Description
Enabled autorestart in vnc-related supervisor services.

### Motivation and Context
When a VNC process crashes there is no way to restart it, and it breaks video capabilities. I don't see any downside of enabling it, as there is also a circuitbreaker which stops restarts after 3 tries.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

[![asciicast](https://asciinema.org/a/qh8aIFvxT1XWDWwqDZD7Buc0l.svg)](https://asciinema.org/a/qh8aIFvxT1XWDWwqDZD7Buc0l)