### PR TITLE
Fixed parsing problem with msedgedriver version in release notes

### DIFF
--- a/generate_release_notes.sh
+++ b/generate_release_notes.sh
@@ -14,7 +14,7 @@ git --no-pager log "${LATEST_TAG}...${HEAD_BRANCH}" --pretty=format:"* [\`%h\`](
 CHROME_VERSION=$(docker run --rm selenium/node-chrome:${TAG_VERSION} google-chrome --version | awk '{print $3}')
 EDGE_VERSION=$(docker run --rm selenium/node-edge:${TAG_VERSION} microsoft-edge --version | awk '{print $3}')
 CHROMEDRIVER_VERSION=$(docker run --rm selenium/node-chrome:${TAG_VERSION} chromedriver --version | awk '{print $2}')
-EDGEDRIVER_VERSION=$(docker run --rm selenium/node-edge:${TAG_VERSION} msedgedriver --version | awk '{print $2}')
+EDGEDRIVER_VERSION=$(docker run --rm selenium/node-edge:${TAG_VERSION} msedgedriver --version | awk '{print $4}')
 FIREFOX_VERSION=$(docker run --rm selenium/node-firefox:${TAG_VERSION} firefox --version | awk '{print $3}')
 GECKODRIVER_VERSION=$(docker run --rm selenium/node-firefox:${TAG_VERSION} geckodriver --version | awk 'NR==1{print $2}')
 FFMPEG_VERSION=$(docker run --entrypoint="" --rm selenium/video:ffmpeg-4.3.1-${BUILD_DATE} ffmpeg -version | awk '{print $3}' | head -n 1)

--- a/tag_and_push_browser_images.sh
+++ b/tag_and_push_browser_images.sh
@@ -69,7 +69,7 @@ edge)
   EDGE_SHORT_VERSION="$(short_version ${EDGE_VERSION})"
   echo "Short Edge version -> "${EDGE_SHORT_VERSION}
 
-  EDGEDRIVER_VERSION=$(docker run --rm selenium/node-edge:${TAG_VERSION} msedgedriver --version | awk '{print $2}')
+  EDGEDRIVER_VERSION=$(docker run --rm selenium/node-edge:${TAG_VERSION} msedgedriver --version | awk '{print $4}')
   echo "EdgeDriver version -> "${EDGEDRIVER_VERSION}
   EDGEDRIVER_SHORT_VERSION="$(short_version ${EDGEDRIVER_VERSION})"
   echo "Short EdgeDriver version -> "${EDGEDRIVER_SHORT_VERSION}


### PR DESCRIPTION
Fixed parsing problem with msedgedriver version in release notes generator script and docker image tagging script.

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

Fixes #1641 where the msedgedriver version was not parsed correctly in release notes and when pushing tags to Docker Hub.

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

msedgedriver version output looks like this:
```
$ docker run --rm selenium/node-edge:4.4.0-20220815 msedgedriver --version
Microsoft Edge WebDriver 104.0.1293.54 (cf00dc8720d894eb5f0a1b840990bb9ecf8b3589)
```

When trying to parse the version, we were pulling from the second column.  At some point, Microsoft must have changed the location of the version number to the 4th column.  Using the 4th column, we get the version:

```
docker run --rm selenium/node-edge:4.4.0-20220815 msedgedriver --version | awk '{print $4}'
104.0.1293.54
```


### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

This ensures release notes have the correct version, and that the Docker Hub tags have the correct driver version applied to them.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [X] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
