### PR TITLE
Autoscaling selenium grid on kubernetes with video recording

### DIFF
--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -53,6 +53,15 @@ RUN apt-get update -qqy \
     fluxbox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
+#=========
+# ffmpeg
+# A fast, lightweight and responsive window manager
+#=========
+RUN apt-get update -qqy \
+  && apt-get -qqy install \
+    ffmpeg \
+  && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
+
 #================
 # Font libraries
 #================
@@ -109,6 +118,13 @@ RUN  wget -nv -O noVNC.zip \
   && rm -rf websockify-${WEBSOCKIFY_SHA}/tests \
   && mv websockify-${WEBSOCKIFY_SHA} /opt/bin/noVNC/utils/websockify
 
+#===================================================
+# Install aws cli
+#===================================================
+RUN wget -O awscliv2.zip "https://awscli.amazonaws.com/awscli-exe-linux-x86_64.zip"\
+  && unzip awscliv2.zip \
+  && sudo ./aws/install
+
 #=========================================================================================================================================
 # Run this command for executable file permissions for /dev/shm when this is a "child" container running in Docker Desktop and WSL2 distro
 #=========================================================================================================================================
@@ -125,6 +141,8 @@ USER 1200
 #==============================
 COPY start-selenium-node.sh \
       start-xvfb.sh \
+      start-video-recorder.sh \
+      start-s3-uploader.sh \
       /opt/bin/
 
 #==============================
@@ -180,8 +198,13 @@ ENV GENERATE_CONFIG true
 # Drain the Node after N sessions. 
 # A value higher than zero enables the feature
 ENV SE_DRAIN_AFTER_SESSION_COUNT 0
-
-
+ENV DISPLAY_CONTAINER_NAME ""
+ENV SE_SCREEN_WIDTH 1360
+ENV SE_SCREEN_HEIGHT 1020
+ENV SE_FRAME_RATE 15
+ENV SE_CODEC libx264
+ENV SE_PRESET "-preset ultrafast"
+ENV FILE_NAME video.mp4
 
 #========================
 # Selenium Configuration

--- a/NodeBase/selenium.conf
+++ b/NodeBase/selenium.conf
@@ -53,8 +53,20 @@ stderr_logfile_backups=5
 stdout_capture_maxbytes=50MB
 stderr_capture_maxbytes=50MB
 
-[program:selenium-node]
+[program:video-recorder]
 priority=15
+command=/opt/bin/start-video-recorder.sh
+autostart=true
+autorestart=true
+stopsignal=INT
+
+;Logs (all activity redirected to stdout so it can be seen through "docker logs"
+redirect_stderr=true
+stdout_logfile=/dev/stdout
+stdout_logfile_maxbytes=0
+
+[program:selenium-node]
+priority=20
 command=bash -c "/opt/bin/start-selenium-node.sh && kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`"
 stopasgroup = true
 autostart=true

--- a/NodeBase/start-s3-uploader.sh
+++ b/NodeBase/start-s3-uploader.sh
@@ -1,7 +1,9 @@
 #!/usr/bin/env bash
 
-
-echo "s3 videos bucket ${S3_VIDEOS_BUCKET}"
-echo "video file name ${VIDEO_FILE_NAME}"
-
-aws s3 cp ${VIDEO_FILE_NAME} ${S3_VIDEOS_BUCKET}
+if [ ${UPLOAD_TO_S3} = "true" ];
+then
+  echo 'Uploading $1 to S3 videos bucket ${S3_VIDEOS_BUCKET}'
+  aws s3 cp $1 ${S3_VIDEOS_BUCKET}
+else
+  echo 'Uploading to s3 disabled'
+fi

--- a/NodeBase/start-s3-uploader.sh
+++ b/NodeBase/start-s3-uploader.sh
@@ -2,8 +2,8 @@
 
 if [ ${UPLOAD_TO_S3} = "true" ];
 then
-  echo 'Uploading $1 to S3 videos bucket ${S3_VIDEOS_BUCKET}'
+  echo "Uploading $1 to S3 videos bucket ${S3_VIDEOS_BUCKET}"
   aws s3 cp $1 ${S3_VIDEOS_BUCKET}
 else
-  echo 'Uploading to s3 disabled'
+  echo "Uploading to s3 disabled"
 fi

--- a/NodeBase/start-s3-uploader.sh
+++ b/NodeBase/start-s3-uploader.sh
@@ -1,43 +1,7 @@
 #!/usr/bin/env bash
 
-last_session_id=${LAST_SESSION_ID}
-full_log_name=${FULL_LOG_NAME}
-console_log_name="/tmp/$last_session_id-console.log"
-text_log_name="/tmp/$last_session_id-text.log"
-network_log_name="/tmp/$last_session_id-network.log"
-video_file_name=${VIDEO_FILE_NAME}
 
-echo "session id $last_session_id"
-echo "full log name $full_log_name"
-echo "console log name $console_log_name"
-echo "text log name $text_log_name"
-echo "network log name $network_log_name"
-echo "pod name ${POD_NAME}"
 echo "s3 videos bucket ${S3_VIDEOS_BUCKET}"
-echo "s3 logs bucket ${S3_LOGS_BUCKET}"
-echo "s3 fulllogs bucket ${S3_FULL_LOGS_BUCKET}"
-echo "video file name $video_file_name"
+echo "video file name ${VIDEO_FILE_NAME}"
 
-aws s3 cp $video_file_name ${S3_VIDEOS_BUCKET}
-
-if [[ ${POD_NAME} =~ "chrome" || ${POD_NAME} =~ "edge" ]];
-then
-    echo 'Chrome/Edge browser'
-    sed -rn '/Runtime.consoleAPICalled/,/^}*$/p' $full_log_name > $console_log_name
-    sed -rn '/\['$last_session_id'\]/,/^}*$/p' $full_log_name > $text_log_name
-    sed -rn '/Network./,/^}*$/p' $full_log_name > $network_log_name
-    aws s3 cp $full_log_name ${S3_FULL_LOGS_BUCKET}
-    aws s3 cp $console_log_name ${S3_LOGS_BUCKET}
-    aws s3 cp $text_log_name ${S3_LOGS_BUCKET}
-    aws s3 cp $network_log_name ${S3_LOGS_BUCKET}
-elif [[ ${POD_NAME} =~ "firefox" ]];
-then
-    echo 'Firefox browser'
-    grep 'console.' $full_log_name | grep -v 'webdriver::server' | grep -v 'Marionette' > $console_log_name
-    grep 'webdriver::server' $full_log_name > $text_log_name
-    aws s3 cp $full_log_name ${S3_FULL_LOGS_BUCKET}
-    aws s3 cp $console_log_name ${S3_LOGS_BUCKET}
-    aws s3 cp $text_log_name ${S3_LOGS_BUCKET}
-else
-    echo 'Unknown browser'
-fi
+aws s3 cp ${VIDEO_FILE_NAME} ${S3_VIDEOS_BUCKET}

--- a/NodeBase/start-s3-uploader.sh
+++ b/NodeBase/start-s3-uploader.sh
@@ -1,8 +1,9 @@
 #!/usr/bin/env bash
 
-if [ ${UPLOAD_TO_S3} = "true" ];
+if [ "${UPLOAD_TO_S3}" = "true" ];
 then
   echo "Uploading $1 to S3 videos bucket ${S3_VIDEOS_BUCKET}"
+  export 
   aws s3 cp $1 ${S3_VIDEOS_BUCKET}
 else
   echo "Uploading to s3 disabled"

--- a/NodeBase/start-s3-uploader.sh
+++ b/NodeBase/start-s3-uploader.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+
+last_session_id=${LAST_SESSION_ID}
+full_log_name=${FULL_LOG_NAME}
+console_log_name="/tmp/$last_session_id-console.log"
+text_log_name="/tmp/$last_session_id-text.log"
+network_log_name="/tmp/$last_session_id-network.log"
+video_file_name=${VIDEO_FILE_NAME}
+
+echo "session id $last_session_id"
+echo "full log name $full_log_name"
+echo "console log name $console_log_name"
+echo "text log name $text_log_name"
+echo "network log name $network_log_name"
+echo "pod name ${POD_NAME}"
+echo "s3 videos bucket ${S3_VIDEOS_BUCKET}"
+echo "s3 logs bucket ${S3_LOGS_BUCKET}"
+echo "s3 fulllogs bucket ${S3_FULL_LOGS_BUCKET}"
+echo "video file name $video_file_name"
+
+aws s3 cp $video_file_name ${S3_VIDEOS_BUCKET}
+
+if [[ ${POD_NAME} =~ "chrome" || ${POD_NAME} =~ "edge" ]];
+then
+    echo 'Chrome/Edge browser'
+    sed -rn '/Runtime.consoleAPICalled/,/^}*$/p' $full_log_name > $console_log_name
+    sed -rn '/\['$last_session_id'\]/,/^}*$/p' $full_log_name > $text_log_name
+    sed -rn '/Network./,/^}*$/p' $full_log_name > $network_log_name
+    aws s3 cp $full_log_name ${S3_FULL_LOGS_BUCKET}
+    aws s3 cp $console_log_name ${S3_LOGS_BUCKET}
+    aws s3 cp $text_log_name ${S3_LOGS_BUCKET}
+    aws s3 cp $network_log_name ${S3_LOGS_BUCKET}
+elif [[ ${POD_NAME} =~ "firefox" ]];
+then
+    echo 'Firefox browser'
+    grep 'console.' $full_log_name | grep -v 'webdriver::server' | grep -v 'Marionette' > $console_log_name
+    grep 'webdriver::server' $full_log_name > $text_log_name
+    aws s3 cp $full_log_name ${S3_FULL_LOGS_BUCKET}
+    aws s3 cp $console_log_name ${S3_LOGS_BUCKET}
+    aws s3 cp $text_log_name ${S3_LOGS_BUCKET}
+else
+    echo 'Unknown browser'
+fi

--- a/NodeBase/start-video-recorder.sh
+++ b/NodeBase/start-video-recorder.sh
@@ -1,0 +1,64 @@
+#!/usr/bin/env bash
+
+VIDEO_SIZE="${SE_SCREEN_WIDTH}""x""${SE_SCREEN_HEIGHT}"
+DISPLAY_CONTAINER_NAME=${DISPLAY_CONTAINER_NAME}
+DISPLAY_NUM=${DISPLAY_NUM}
+FILE_NAME=${FILE_NAME}
+FRAME_RATE=${FRAME_RATE:-$SE_FRAME_RATE}
+CODEC=${CODEC:-$SE_CODEC}
+PRESET=${PRESET:-$SE_PRESET}
+
+return_code=1
+max_attempts=50
+attempts=0
+echo 'Checking if the display is open...'
+until [ $return_code -eq 0 -o $attempts -eq $max_attempts ]; do
+	xset -display :${DISPLAY_NUM} b off > /dev/null 2>&1
+	return_code=$?
+	if [ $return_code -ne 0 ]; then
+		echo 'Waiting before next display check...'
+		sleep 0.5
+	fi
+	attempts=$((attempts+1))
+done
+
+recording_started="false"
+last_session_id=""
+video_file_name=""
+while true;
+do
+	session_id=$(curl -s --request GET 'http://localhost:5555/status' | jq -r '.[]?.node?.slots | .[0]?.session?.sessionId')
+	echo $session_id
+	if [ $session_id != "null" -a $session_id != "" ] && [ $recording_started = "false" ];
+	then
+		echo 'Starting to record video'
+		video_file_name="/tmp/$session_id.mp4"
+		ffmpeg -nostdin -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY_CONTAINER_NAME}:${DISPLAY_NUM}.0 -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p $video_file_name &
+		last_session_id=$session_id
+		recording_started="true"
+		echo 'Video recording started'
+	elif [ $session_id = "null" -o $session_id = "" ] && [ $recording_started = "true" ];
+	then
+		echo 'Stopping to record video'
+		pkill --signal INT ffmpeg
+		full_log_name="/tmp/$last_session_id:${POD_NAME}.log"
+		mv ${LOG_FILE_NAME} $full_log_name
+		export LAST_SESSION_ID=$last_session_id
+		export FULL_LOG_NAME=$full_log_name
+		export VIDEO_FILE_NAME=$video_file_name
+		if [ ${UPLOAD_TO_S3} = "true" ];
+		then
+			./opt/bin/start-s3-uploader.sh &
+		else
+			echo 'Uploading to s3 disabled'
+		fi
+		recording_started="false"
+		echo 'Video recording stopped'
+	elif [ $recording_started = "true" ];
+	then
+		echo 'Video recording in progress'
+	else
+		echo 'No session in progress'
+	fi
+	sleep 1
+done

--- a/NodeBase/start-video-recorder.sh
+++ b/NodeBase/start-video-recorder.sh
@@ -1,64 +1,61 @@
 #!/usr/bin/env bash
 
-VIDEO_SIZE="${SE_SCREEN_WIDTH}""x""${SE_SCREEN_HEIGHT}"
-DISPLAY_CONTAINER_NAME=${DISPLAY_CONTAINER_NAME}
-DISPLAY_NUM=${DISPLAY_NUM}
-FILE_NAME=${FILE_NAME}
-FRAME_RATE=${FRAME_RATE:-$SE_FRAME_RATE}
-CODEC=${CODEC:-$SE_CODEC}
-PRESET=${PRESET:-$SE_PRESET}
+if [ ${RECORD_VIDEO} = "true" ];
+then 
+	VIDEO_SIZE="${SE_SCREEN_WIDTH}""x""${SE_SCREEN_HEIGHT}"
+	DISPLAY_CONTAINER_NAME=${DISPLAY_CONTAINER_NAME}
+	DISPLAY_NUM=${DISPLAY_NUM}
+	FILE_NAME=${FILE_NAME}
+	FRAME_RATE=${FRAME_RATE:-$SE_FRAME_RATE}
+	CODEC=${CODEC:-$SE_CODEC}
+	PRESET=${PRESET:-$SE_PRESET}
 
-return_code=1
-max_attempts=50
-attempts=0
-echo 'Checking if the display is open...'
-until [ $return_code -eq 0 -o $attempts -eq $max_attempts ]; do
-	xset -display :${DISPLAY_NUM} b off > /dev/null 2>&1
-	return_code=$?
-	if [ $return_code -ne 0 ]; then
-		echo 'Waiting before next display check...'
-		sleep 0.5
-	fi
-	attempts=$((attempts+1))
-done
-
-recording_started="false"
-last_session_id=""
-video_file_name=""
-while true;
-do
-	session_id=$(curl -s --request GET 'http://localhost:5555/status' | jq -r '.[]?.node?.slots | .[0]?.session?.sessionId')
-	echo $session_id
-	if [ $session_id != "null" -a $session_id != "" ] && [ $recording_started = "false" ];
-	then
-		echo 'Starting to record video'
-		video_file_name="/tmp/$session_id.mp4"
-		ffmpeg -nostdin -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY_CONTAINER_NAME}:${DISPLAY_NUM}.0 -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p $video_file_name &
-		last_session_id=$session_id
-		recording_started="true"
-		echo 'Video recording started'
-	elif [ $session_id = "null" -o $session_id = "" ] && [ $recording_started = "true" ];
-	then
-		echo 'Stopping to record video'
-		pkill --signal INT ffmpeg
-		full_log_name="/tmp/$last_session_id:${POD_NAME}.log"
-		mv ${LOG_FILE_NAME} $full_log_name
-		export LAST_SESSION_ID=$last_session_id
-		export FULL_LOG_NAME=$full_log_name
-		export VIDEO_FILE_NAME=$video_file_name
-		if [ ${UPLOAD_TO_S3} = "true" ];
-		then
-			./opt/bin/start-s3-uploader.sh &
-		else
-			echo 'Uploading to s3 disabled'
+	return_code=1
+	max_attempts=50
+	attempts=0
+	echo 'Checking if the display is open...'
+	until [ $return_code -eq 0 -o $attempts -eq $max_attempts ]; do
+		xset -display :${DISPLAY_NUM} b off > /dev/null 2>&1
+		return_code=$?
+		if [ $return_code -ne 0 ]; then
+			echo 'Waiting before next display check...'
+			sleep 0.5
 		fi
-		recording_started="false"
-		echo 'Video recording stopped'
-	elif [ $recording_started = "true" ];
-	then
-		echo 'Video recording in progress'
-	else
-		echo 'No session in progress'
-	fi
-	sleep 1
-done
+		attempts=$((attempts+1))
+	done
+
+	recording_started="false"
+	video_file_name=""
+	while true;
+	do
+		session_id=$(curl -s --request GET 'http://localhost:5555/status' | jq -r '.[]?.node?.slots | .[0]?.session?.sessionId')
+		echo $session_id
+		if [ $session_id != "null" -a $session_id != "" ] && [ $recording_started = "false" ];
+		then
+			echo 'Starting to record video'
+			video_file_name="${VIDEO_LOCATION}/$session_id.mp4"
+			ffmpeg -nostdin -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY_CONTAINER_NAME}:${DISPLAY_NUM}.0 -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p $video_file_name &
+			recording_started="true"
+			echo 'Video recording started'
+		elif [ $session_id = "null" -o $session_id = "" ] && [ $recording_started = "true" ];
+		then
+			echo 'Stopping to record video'
+			pkill --signal INT ffmpeg
+			export VIDEO_FILE_NAME=$video_file_name
+			if [ ${UPLOAD_TO_S3} = "true" ];
+			then
+				./opt/bin/start-s3-uploader.sh &
+			else
+				echo 'Uploading to s3 disabled'
+			fi
+			recording_started="false"
+			echo 'Video recording stopped'
+		elif [ $recording_started = "true" ];
+		then
+			echo 'Video recording in progress'
+		else
+			echo 'No session in progress'
+		fi
+		sleep 1
+	done
+fi

--- a/NodeBase/start-video-recorder.sh
+++ b/NodeBase/start-video-recorder.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 
-if [ ${RECORD_VIDEO} = "true" ];
+if [ "${RECORD_VIDEO}" = "true" ];
 then 
 	VIDEO_SIZE="${SE_SCREEN_WIDTH}""x""${SE_SCREEN_HEIGHT}"
 	DISPLAY_CONTAINER_NAME=${DISPLAY_CONTAINER_NAME}

--- a/NodeBase/start-video-recorder.sh
+++ b/NodeBase/start-video-recorder.sh
@@ -32,23 +32,23 @@ then
 		echo $session_id
 		if [ $session_id != "null" -a $session_id != "" ] && [ $recording_started = "false" ];
 		then
-			echo 'Starting to record video'
+			echo "Starting to record video"
 			video_file_name="${VIDEO_LOCATION}/$session_id.mp4"
 			ffmpeg -nostdin -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY_CONTAINER_NAME}:${DISPLAY_NUM}.0 -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p $video_file_name &
 			recording_started="true"
-			echo 'Video recording started'
+			echo "Video recording started"
 		elif [ $session_id = "null" -o $session_id = "" ] && [ $recording_started = "true" ];
 		then
-			echo 'Stopping to record video'
+			echo "Stopping to record video"
 			pkill --signal INT ffmpeg
     	./opt/bin/start-s3-uploader.sh $video_file_name &
 			recording_started="false"
-			echo 'Video recording stopped'
+			echo "Video recording stopped"
 		elif [ $recording_started = "true" ];
 		then
-			echo 'Video recording in progress'
+			echo "Video recording in progress"
 		else
-			echo 'No session in progress'
+			echo "No session in progress"
 		fi
 		sleep 1
 	done

--- a/NodeBase/start-video-recorder.sh
+++ b/NodeBase/start-video-recorder.sh
@@ -41,13 +41,7 @@ then
 		then
 			echo 'Stopping to record video'
 			pkill --signal INT ffmpeg
-			export VIDEO_FILE_NAME=$video_file_name
-			if [ ${UPLOAD_TO_S3} = "true" ];
-			then
-				./opt/bin/start-s3-uploader.sh &
-			else
-				echo 'Uploading to s3 disabled'
-			fi
+    	./opt/bin/start-s3-uploader.sh $video_file_name &
 			recording_started="false"
 			echo 'Video recording stopped'
 		elif [ $recording_started = "true" ];

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -66,6 +66,7 @@ This table contains the configuration parameters of the chart and their default 
 | `ingress.annotations`                   | `{}`                               | Custom annotations for ingress resource                                                                                    |
 | `ingress.hostname`                      | `selenium-grid.local`              | Default host for the ingress resource                                                                                      |
 | `ingress.tls`                           | `[]`                               | TLS backend configuration for ingress resource                                                                             |
+| `ingress.path`                          | `/`                                | Default path for ingress resource                                                                             |
 | `busConfigMap.annotations`              | `{}`                               | Custom annotations for configmap                                                                                           |
 | `chromeNode.enabled`                    | `true`                             | Enable chrome nodes                                                                                                        |
 | `chromeNode.replicas`                   | `1`                                | Number of chrome nodes                                                                                                     |
@@ -94,6 +95,12 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.lifecycle`                  | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `chromeNode.extraVolumeMounts`          | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `chromeNode.extraVolumes`               | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `chromeNode.hpa.url`                    | `http://selenium-hub.default:4444/graphql` | Graphql Url of the hub or the router |
+| `chromeNode.hpa.browserName`            | `chrome`                           | BrowserName from the capability |
+| `chromeNode.hpa.browserVersion`         | ``                                 | BrowserVersion from the capability |
+| `chromeNode.maxReplicaCount`            | `8`                                | Max number of replicas that this browsernode can auto scale up to |
+| `chromeNode.automountServiceAccountToken`| `false`                           | Determines automounting of service account token |
+| `chromeNode.serviceAccount`             | ``                                 | Service account for chrome container |
 | `firefoxNode.enabled`                   | `true`                             | Enable firefox nodes                                                                                                       |
 | `firefoxNode.replicas`                  | `1`                                | Number of firefox nodes                                                                                                    |
 | `firefoxNode.imageName`                 | `selenium/node-firefox`            | Image of firefox nodes                                                                                                     |
@@ -121,6 +128,12 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.lifecycle`                 | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `firefoxNode.extraVolumeMounts`         | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `firefoxNode.extraVolumes`              | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `firefoxNode.hpa.url`                   | `http://selenium-hub.default:4444/graphql` | Graphql Url of the hub or the router |
+| `firefoxNode.hpa.browserName`           | `firefox`                          | BrowserName from the capability |
+| `firefoxNode.hpa.browserVersion`        | ``                                 | BrowserVersion from the capability |
+| `firefoxNode.maxReplicaCount`           | `8`                                | Max number of replicas that this browsernode can auto scale up to |
+| `firefoxNode.automountServiceAccountToken`| `false`                           | Determines automounting of service account token |
+| `firefoxNode.serviceAccount`             | ``                                 | Service account for firefox container |
 | `edgeNode.enabled`                      | `true`                             | Enable edge nodes                                                                                                          |
 | `edgeNode.replicas`                     | `1`                                | Number of edge nodes                                                                                                       |
 | `edgeNode.imageName`                    | `selenium/node-edge`               | Image of edge nodes                                                                                                        |
@@ -148,6 +161,12 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.lifecycle`                    | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `edgeNode.extraVolumeMounts`            | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `edgeNode.extraVolumes`                 | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `edgeNode.hpa.url`                     | `http://selenium-hub.default:4444/graphql` | Graphql Url of the hub or the router |
+| `edgeNode.hpa.browserName`             | `edge`                           | BrowserName from the capability |
+| `edgeNode.hpa.browserVersion`          | ``                               | BrowserVersion from the capability |
+| `edgeNode.maxReplicaCount`             | `8`                                | Max number of replicas that this browsernode can auto scale up to |
+| `edgeNode.automountServiceAccountToken`| `false`                           | Determines automounting of service account token |
+| `edgeNode.serviceAccount`              | ``                                 | Service account for edge container |
 | `customLabels`                          | `{}`                               | Custom labels for k8s resources                                                                                            |
 
 

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -29,6 +29,17 @@ helm install selenium-grid docker-selenium/selenium-grid --version <version>
 helm install selenium-grid --set ingress.hostname=selenium-grid.k8s.local docker-selenium/chart/selenium-grid/.
 ```
 
+## Enable Selenium Grid Autoscaling
+Selenium Grid has the ability to autoscale browser nodes up/down based on the requests pending in session queue. You can enable it setting 'autoscalingEnabled' to `true`. You need to install KEDA by following the [instructions](https://keda.sh/docs/2.8/deploy/#helm) in order for autoscaling to work. 
+
+The hpa.url value is configured to work for grid installed in `default` namespace. If you are installing the grid in some other namespace make sure to update the value of hpa.url accordingly. 
+
+## Enable Video Recording
+To enable video recording you can set `RECORD_VIDEO` env variable in the browser node container to `"true"`. You can specify the location to store the recorded video using `VIDEO_LOCATION` env variable. The videos will have name format of `<session id>.mp4`.
+
+## Upload recorded videos to AWS S3
+If you have enabled video recording, you can also enable uploading them to S3 by setting `UPLOAD_TO_S3` env variable to `"true"`. You can specify the S3 bucket in 'S3_VIDEOS_BUCKET' env variable.
+
 ## Updating Selenium-Grid release
 
 Once you have a new chart version, you can update your selenium-grid running:
@@ -95,6 +106,7 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.lifecycle`                  | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `chromeNode.extraVolumeMounts`          | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `chromeNode.extraVolumes`               | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `chromeNode.autoscalingEnabled`         | `false`                            | Enable/Disable autoscaling of browser nodes |
 | `chromeNode.hpa.url`                    | `http://selenium-hub.default:4444/graphql` | Graphql Url of the hub or the router |
 | `chromeNode.hpa.browserName`            | `chrome`                           | BrowserName from the capability |
 | `chromeNode.hpa.browserVersion`         | ``                                 | BrowserVersion from the capability |
@@ -128,6 +140,7 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.lifecycle`                 | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `firefoxNode.extraVolumeMounts`         | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `firefoxNode.extraVolumes`              | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `firefoxNode.autoscalingEnabled`        | `false`                            | Enable/Disable autoscaling of browser nodes |
 | `firefoxNode.hpa.url`                   | `http://selenium-hub.default:4444/graphql` | Graphql Url of the hub or the router |
 | `firefoxNode.hpa.browserName`           | `firefox`                          | BrowserName from the capability |
 | `firefoxNode.hpa.browserVersion`        | ``                                 | BrowserVersion from the capability |
@@ -161,6 +174,7 @@ This table contains the configuration parameters of the chart and their default 
 | `edgeNode.lifecycle`                    | `{}`                               | hooks to make pod correctly shutdown or started                                                                            |
 | `edgeNode.extraVolumeMounts`            | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `edgeNode.extraVolumes`                 | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `edgeNode.autoscalingEnabled`          | `false`                            | Enable/Disable autoscaling of browser nodes |
 | `edgeNode.hpa.url`                     | `http://selenium-hub.default:4444/graphql` | Graphql Url of the hub or the router |
 | `edgeNode.hpa.browserName`             | `edge`                           | BrowserName from the capability |
 | `edgeNode.hpa.browserVersion`          | ``                               | BrowserVersion from the capability |

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -38,7 +38,7 @@ The hpa.url value is configured to work for grid installed in `default` namespac
 To enable video recording you can set `RECORD_VIDEO` env variable in the browser node container to `"true"`. You can specify the location to store the recorded video using `VIDEO_LOCATION` env variable. The videos will have name format of `<session id>.mp4`.
 
 ## Upload recorded videos to AWS S3
-If you have enabled video recording, you can also enable uploading them to S3 by setting `UPLOAD_TO_S3` env variable to `"true"`. You can specify the S3 bucket in 'S3_VIDEOS_BUCKET' env variable.
+If you have enabled video recording, you can also enable uploading them to S3 by setting `UPLOAD_TO_S3` env variable to `"true"`. You can specify the S3 bucket in 'S3_VIDEOS_BUCKET' env variable. You can specify your AWS credentials directly using the `AWS_ACCESS_KEY_ID`, `AWS_SECRET_ACCESS_KEY` and 'AWS_DEFAULT_REGION' env variables. If you use [IRSA](https://docs.aws.amazon.com/eks/latest/userguide/iam-roles-for-service-accounts.html) based authentication, you can specify the service account using `serviceAccount` variable in the charts.
 
 ## Updating Selenium-Grid release
 

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -28,6 +28,12 @@ spec:
           {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{- if .Values.chromeNode.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.chromeNode.automountServiceAccountToken }}
+    {{- end }}
+    {{- if .Values.chromeNode.serviceAccount }}
+      serviceAccount: {{ .Values.chromeNode.serviceAccount }}
+    {{- end }}
     {{- with .Values.chromeNode.hostAliases }}
       hostAliases: {{ toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-hpa.yaml
+++ b/charts/selenium-grid/templates/chrome-node-hpa.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.chromeNode.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: selenium-grid-chrome-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    deploymentName: {{ template "seleniumGrid.chromeNode.fullname" . }}
+spec:
+  maxReplicaCount: {{ .Values.chromeNode.maxReplicaCount }}
+  scaleTargetRef:
+    name: {{ template "seleniumGrid.chromeNode.fullname" . }}
+  triggers:
+    - type: selenium-grid
+    {{- with .Values.chromeNode.hpa }}
+      metadata: {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/selenium-grid/templates/chrome-node-hpa.yaml
+++ b/charts/selenium-grid/templates/chrome-node-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.chromeNode.enabled }}
+{{- if and .Values.chromeNode.enabled .Values.chromeNode.autoscalingEnabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -28,6 +28,12 @@ spec:
           {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{- if .Values.edgeNode.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.edgeNode.automountServiceAccountToken }}
+    {{- end }}
+    {{- if .Values.edgeNode.serviceAccount }}
+      serviceAccount: {{ .Values.edgeNode.serviceAccount }}
+    {{- end }}
     {{- with .Values.edgeNode.hostAliases }}
       hostAliases: {{ toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/edge-node-hpa.yaml
+++ b/charts/selenium-grid/templates/edge-node-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.edgeNode.enabled }}
+{{- if and .Values.edgeNode.enabled .Values.edgeNode.autoscalingEnabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/selenium-grid/templates/edge-node-hpa.yaml
+++ b/charts/selenium-grid/templates/edge-node-hpa.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.edgeNode.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: selenium-grid-edge-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    deploymentName: {{ template "seleniumGrid.edgeNode.fullname" . }}
+spec:
+  maxReplicaCount: {{ .Values.edgeNode.maxReplicaCount }}
+  scaleTargetRef:
+    name: {{ template "seleniumGrid.edgeNode.fullname" . }}
+  triggers:
+    - type: selenium-grid
+    {{- with .Values.edgeNode.hpa }}
+      metadata: {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -28,6 +28,12 @@ spec:
           {{ toYaml . | nindent 8 }}
         {{- end }}
     spec:
+    {{- if .Values.firefoxNode.automountServiceAccountToken }}
+      automountServiceAccountToken: {{ .Values.firefoxNode.automountServiceAccountToken }}
+    {{- end }}
+    {{- if .Values.firefoxNode.serviceAccount }}
+      serviceAccount: {{ .Values.firefoxNode.serviceAccount }}
+    {{- end }}
     {{- with .Values.firefoxNode.hostAliases }}
       hostAliases: {{ toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-hpa.yaml
+++ b/charts/selenium-grid/templates/firefox-node-hpa.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.firefoxNode.enabled }}
+{{- if and .Values.firefoxNode.enabled .Values.firefoxNode.autoscalingEnabled }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/charts/selenium-grid/templates/firefox-node-hpa.yaml
+++ b/charts/selenium-grid/templates/firefox-node-hpa.yaml
@@ -1,0 +1,18 @@
+{{- if .Values.firefoxNode.enabled }}
+apiVersion: keda.sh/v1alpha1
+kind: ScaledObject
+metadata:
+  name: selenium-grid-firefox-scaledobject
+  namespace: {{ .Release.Namespace }}
+  labels:
+    deploymentName: {{ template "seleniumGrid.firefoxNode.fullname" . }}
+spec:
+  maxReplicaCount: {{ .Values.firefoxNode.maxReplicaCount }}
+  scaleTargetRef:
+    name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
+  triggers:
+    - type: selenium-grid
+    {{- with .Values.firefoxNode.hpa }}
+      metadata: {{- toYaml . | nindent 8 }}
+    {{- end }}
+{{- end }}

--- a/charts/selenium-grid/templates/ingress.yaml
+++ b/charts/selenium-grid/templates/ingress.yaml
@@ -45,7 +45,11 @@ spec:
     - http:
       {{- end }}
         paths:
+            {{- if $.Values.ingress.path }}
+          - path: {{ .Values.ingress.path }}
+            {{- else }}
           - path: /
+            {{- end }}  
             pathType: Prefix
             backend:
               service:

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -392,7 +392,7 @@ chromeNode:
           - -c
           - |
             curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-            while curl 127.0.0.1:5555/status; do sleep 1; done; sleep 30;
+            while curl 127.0.0.1:5555/status || pidof -x "start-s3-uploader.sh" >/dev/null; do sleep 1; done;
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -524,7 +524,7 @@ firefoxNode:
           - -c
           - |
             curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-            while curl 127.0.0.1:5555/status; do sleep 1; done; sleep 30;
+            while curl 127.0.0.1:5555/status || pidof -x "start-s3-uploader.sh" >/dev/null; do sleep 1; done;
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -646,7 +646,7 @@ edgeNode:
           - -c
           - |
             curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-            while curl 127.0.0.1:5555/status; do sleep 1; done; sleep 30;
+            while curl 127.0.0.1:5555/status || pidof -x "start-s3-uploader.sh" >/dev/null; do sleep 1; done;
 
   extraVolumeMounts: []
   # - name: my-extra-volume

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -22,6 +22,7 @@ ingress:
   hostname: selenium-grid.local
   # TLS backend configuration for ingress resource
   tls: []
+  path: /
 
 # ConfigMap that contains SE_EVENT_BUS_HOST, SE_EVENT_BUS_PUBLISH_PORT and SE_EVENT_BUS_SUBSCRIBE_PORT variables
 busConfigMap:
@@ -258,6 +259,8 @@ hub:
     successThreshold: 1
   # Custom environment variables for selenium-hub
   extraEnvironmentVariables:
+    - name: SE_OPTS
+      value: "--log-level INFO --structured-logs true --http-logs true --plain-logs false"
     # - name: SE_JAVA_OPTS
     #   value: "-Xmx512m"
     # - name: SECRET_VARIABLE
@@ -335,6 +338,24 @@ chromeNode:
     #     - "example.org"
   # Custom environment variables for chrome nodes
   extraEnvironmentVariables:
+    - name: LOG_FILE_NAME
+      value: /tmp/chrome.log
+    - name: SE_OPTS
+      value: "--log-level OFF --structured-logs true --http-logs true --plain-logs false"
+    - name: SE_JAVA_OPTS
+      value: -Dwebdriver.chrome.logfile=$(LOG_FILE_NAME) -Dwebdriver.chrome.verboseLogging=true
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: UPLOAD_TO_S3
+      value: "false"
+    - name: S3_VIDEOS_BUCKET
+      value: s3://selenium-grid/videos/
+    - name: S3_LOGS_BUCKET
+      value: s3://selenium-grid/logs/
+    - name: S3_FULL_LOGS_BUCKET
+      value: s3://selenium-grid/fulllogs/
     # - name: SE_JAVA_OPTS
     #   value: "-Xmx512m"
     # - name:
@@ -357,7 +378,7 @@ chromeNode:
     # Custom annotations for service
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
-  dshmVolumeSizeLimit: 1Gi
+  dshmVolumeSizeLimit: 2Gi
   # Priority class name for chrome-node pods
   priorityClassName: ""
 
@@ -369,17 +390,17 @@ chromeNode:
     # failureThreshold: 120
     # periodSeconds: 5
   # Time to wait for pod termination
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 3600
   # Allow pod correctly shutdown
-  lifecycle: {}
-    # preStop:
-    #   exec:
-    #     command:
-    #       - bash
-    #       - -c
-    #       - |
-    #         curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-    #         while curl 127.0.0.1:5555/status; do sleep 1; done
+  lifecycle: 
+    preStop:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
+            while curl 127.0.0.1:5555/status; do sleep 1; done; sleep 30;
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -391,6 +412,17 @@ chromeNode:
   # - name: my-extra-volume-from-pvc
   #   persistentVolumeClaim:
   #     claimName: my-pv-claim
+
+  automountServiceAccountToken: false
+  serviceAccount: ""
+
+  # Keda scaled object configuration
+  maxReplicaCount: 8
+  hpa:
+    url: http://selenium-hub.default:4444/graphql # Repalce your http graphql url here
+    browserName: chrome
+    # browserVersion: '91.0' # Optional. Only required when supporting multiple versions of browser in your Selenium Grid.
+    unsafeSsl : 'true' # Optional
 
 # Configuration for firefox nodes
 firefoxNode:
@@ -441,6 +473,28 @@ firefoxNode:
     #     - "example.org"
   # Custom environment variables for firefox nodes
   extraEnvironmentVariables:
+    - name: LOG_FILE_NAME
+      value: /tmp/firefox.log
+    - name: SE_OPTS
+      value: "--log-level OFF --structured-logs true --http-logs true --plain-logs false"
+    - name: SE_JAVA_OPTS
+      value: -Dwebdriver.firefox.logfile=$(LOG_FILE_NAME)
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name    
+    - name: UPLOAD_TO_S3
+      value: "false"
+    - name: S3_VIDEOS_BUCKET
+      value: s3://selenium-grid/videos/
+    - name: S3_LOGS_BUCKET
+      value: s3://selenium-grid/logs/
+    - name: S3_FULL_LOGS_BUCKET
+      value: s3://selenium-grid/fulllogs/
+    # - name: MOZ_LOG
+    #   value: raw,timestamp,nsHttp:5 #,cache2:5,nsSocketTransport:5,nsHostResolver:5,cookie:5
+    # - name: MOZ_LOG_FILE
+    #   value: /tmp/firefox_network
     # - name: SE_JAVA_OPTS
     #   value: "-Xmx512m"
     # - name:
@@ -463,7 +517,7 @@ firefoxNode:
     # Custom annotations for service
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
-  dshmVolumeSizeLimit: 1Gi
+  dshmVolumeSizeLimit: 2Gi
   # Priority class name for firefox-node pods
   priorityClassName: ""
 
@@ -475,17 +529,17 @@ firefoxNode:
     # failureThreshold: 120
     # periodSeconds: 5
   # Time to wait for pod termination
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 3600
   # Allow pod correctly shutdown
-  lifecycle: {}
-    # preStop:
-    #   exec:
-    #     command:
-    #       - bash
-    #       - -c
-    #       - |
-    #         curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-    #         while curl 127.0.0.1:5555/status; do sleep 1; done
+  lifecycle: 
+    preStop:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
+            while curl 127.0.0.1:5555/status; do sleep 1; done; sleep 30;
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -497,6 +551,13 @@ firefoxNode:
   # - name: my-extra-volume-from-pvc
   #   persistentVolumeClaim:
   #     claimName: my-pv-claim
+  automountServiceAccountToken: false
+  serviceAccount: ""
+  # Keda scaled object configuration
+  maxReplicaCount: 8
+  hpa:
+    url: http://selenium-hub.default:4444/graphql # Repalce your http graphql url here
+    browserName: firefox
 
 # Configuration for edge nodes
 edgeNode:
@@ -546,8 +607,24 @@ edgeNode:
     #     - "example.org"
   # Custom environment variables for edge nodes
   extraEnvironmentVariables:
-    # - name: SE_JAVA_OPTS
-    #   value: "-Xmx512m"
+    - name: LOG_FILE_NAME
+      value: /tmp/edge.log
+    - name: SE_OPTS
+      value: "--log-level OFF --structured-logs true --http-logs true --plain-logs false"
+    - name: SE_JAVA_OPTS
+      value: -Dwebdriver.edge.logfile=$(LOG_FILE_NAME) -Dwebdriver.edge.verboseLogging=true
+    - name: POD_NAME
+      valueFrom:
+        fieldRef:
+          fieldPath: metadata.name
+    - name: UPLOAD_TO_S3
+      value: "false"
+    - name: S3_VIDEOS_BUCKET
+      value: s3://selenium-grid/videos/
+    - name: S3_LOGS_BUCKET
+      value: s3://selenium-grid/logs/
+    - name: S3_FULL_LOGS_BUCKET
+      value: s3://selenium-grid/fulllogs/
     # - name:
     #   valueFrom:
     #     secretKeyRef:
@@ -569,7 +646,7 @@ edgeNode:
     annotations:
       hello: world
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
-  dshmVolumeSizeLimit: 1Gi
+  dshmVolumeSizeLimit: 2Gi
   # Priority class name for edge-node pods
   priorityClassName: ""
 
@@ -581,17 +658,17 @@ edgeNode:
     # failureThreshold: 120
     # periodSeconds: 5
   # Time to wait for pod termination
-  terminationGracePeriodSeconds: 30
+  terminationGracePeriodSeconds: 3600
   # Allow pod correctly shutdown
-  lifecycle: {}
-    # preStop:
-    #   exec:
-    #     command:
-    #       - bash
-    #       - -c
-    #       - |
-    #         curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-    #         while curl 127.0.0.1:5555/status; do sleep 1; done
+  lifecycle: 
+    preStop:
+      exec:
+        command:
+          - bash
+          - -c
+          - |
+            curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
+            while curl 127.0.0.1:5555/status; do sleep 1; done; sleep 30;
 
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -603,6 +680,13 @@ edgeNode:
   # - name: my-extra-volume-from-pvc
   #   persistentVolumeClaim:
   #     claimName: my-pv-claim
+  automountServiceAccountToken: false
+  serviceAccount: ""
+  # Keda scaled object configuration
+  maxReplicaCount: 8
+  hpa:
+    url: http://selenium-hub.default:4444/graphql # Repalce your http graphql url here
+    browserName: MicrosoftEdge
 
 # Custom labels for k8s resources
 customLabels: {}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -338,24 +338,16 @@ chromeNode:
     #     - "example.org"
   # Custom environment variables for chrome nodes
   extraEnvironmentVariables:
-    - name: LOG_FILE_NAME
-      value: /tmp/chrome.log
-    - name: SE_OPTS
-      value: "--log-level OFF --structured-logs true --http-logs true --plain-logs false"
-    - name: SE_JAVA_OPTS
-      value: -Dwebdriver.chrome.logfile=$(LOG_FILE_NAME) -Dwebdriver.chrome.verboseLogging=true
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
+    - name: VIDEO_LOCATION
+      value: /tmp
+    - name: RECORD_VIDEO
+      value: "false"
     - name: UPLOAD_TO_S3
       value: "false"
     - name: S3_VIDEOS_BUCKET
       value: s3://selenium-grid/videos/
-    - name: S3_LOGS_BUCKET
-      value: s3://selenium-grid/logs/
-    - name: S3_FULL_LOGS_BUCKET
-      value: s3://selenium-grid/fulllogs/
+    # - name: SE_OPTS
+    #   value: "--log-level OFF"
     # - name: SE_JAVA_OPTS
     #   value: "-Xmx512m"
     # - name:
@@ -417,6 +409,7 @@ chromeNode:
   serviceAccount: ""
 
   # Keda scaled object configuration
+  autoscalingEnabled: false
   maxReplicaCount: 8
   hpa:
     url: http://selenium-hub.default:4444/graphql # Repalce your http graphql url here
@@ -473,24 +466,16 @@ firefoxNode:
     #     - "example.org"
   # Custom environment variables for firefox nodes
   extraEnvironmentVariables:
-    - name: LOG_FILE_NAME
-      value: /tmp/firefox.log
-    - name: SE_OPTS
-      value: "--log-level OFF --structured-logs true --http-logs true --plain-logs false"
-    - name: SE_JAVA_OPTS
-      value: -Dwebdriver.firefox.logfile=$(LOG_FILE_NAME)
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name    
+    - name: VIDEO_LOCATION
+      value: /tmp
+    - name: RECORD_VIDEO
+      value: "false"
     - name: UPLOAD_TO_S3
       value: "false"
     - name: S3_VIDEOS_BUCKET
       value: s3://selenium-grid/videos/
-    - name: S3_LOGS_BUCKET
-      value: s3://selenium-grid/logs/
-    - name: S3_FULL_LOGS_BUCKET
-      value: s3://selenium-grid/fulllogs/
+    # - name: SE_OPTS
+    #   value: "--log-level OFF"
     # - name: MOZ_LOG
     #   value: raw,timestamp,nsHttp:5 #,cache2:5,nsSocketTransport:5,nsHostResolver:5,cookie:5
     # - name: MOZ_LOG_FILE
@@ -554,6 +539,7 @@ firefoxNode:
   automountServiceAccountToken: false
   serviceAccount: ""
   # Keda scaled object configuration
+  autoscalingEnabled: false
   maxReplicaCount: 8
   hpa:
     url: http://selenium-hub.default:4444/graphql # Repalce your http graphql url here
@@ -607,24 +593,16 @@ edgeNode:
     #     - "example.org"
   # Custom environment variables for edge nodes
   extraEnvironmentVariables:
-    - name: LOG_FILE_NAME
-      value: /tmp/edge.log
-    - name: SE_OPTS
-      value: "--log-level OFF --structured-logs true --http-logs true --plain-logs false"
-    - name: SE_JAVA_OPTS
-      value: -Dwebdriver.edge.logfile=$(LOG_FILE_NAME) -Dwebdriver.edge.verboseLogging=true
-    - name: POD_NAME
-      valueFrom:
-        fieldRef:
-          fieldPath: metadata.name
+    - name: VIDEO_LOCATION
+      value: /tmp
+    - name: RECORD_VIDEO
+      value: "false"
     - name: UPLOAD_TO_S3
       value: "false"
     - name: S3_VIDEOS_BUCKET
       value: s3://selenium-grid/videos/
-    - name: S3_LOGS_BUCKET
-      value: s3://selenium-grid/logs/
-    - name: S3_FULL_LOGS_BUCKET
-      value: s3://selenium-grid/fulllogs/
+    # - name: SE_OPTS
+    #   value: "--log-level OFF"
     # - name:
     #   valueFrom:
     #     secretKeyRef:
@@ -683,6 +661,7 @@ edgeNode:
   automountServiceAccountToken: false
   serviceAccount: ""
   # Keda scaled object configuration
+  autoscalingEnabled: false
   maxReplicaCount: 8
   hpa:
     url: http://selenium-hub.default:4444/graphql # Repalce your http graphql url here


### PR DESCRIPTION
### Description
Autoscale selenium browser nodes running in kubernetes based on the request pending in session queue using KEDA. It also includes ability to automatically record videos using ffmpeg and capture network, browser logs. 
The recorded videos and logs are stored under <session_id> name and can be uploaded directly to S3.

### Motivation and Context
Auto scaling selenium grid was a problem that was pending to be solved for long. So i took it up when there was a requirement at current my work place. KEDA seemed to the best candidate for the Job and i wrote a new scalar for Selenium Grid a year ago. I would like to have this enabled by default in our charts so everyone could use it.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
