### PR TITLE
Remove flags for event-bus in start-selenium-grid-session-queue.sh after removal in 4.5.0

### DIFF
--- a/SessionQueue/start-selenium-grid-session-queue.sh
+++ b/SessionQueue/start-selenium-grid-session-queue.sh
@@ -5,21 +5,6 @@ set -e
 
 echo "Starting Selenium Grid SessionQueue..."
 
-if [[ -z "${SE_EVENT_BUS_HOST}" ]]; then
-  echo "SE_EVENT_BUS_HOST not set, exiting!" 1>&2
-  exit 1
-fi
-
-if [[ -z "${SE_EVENT_BUS_PUBLISH_PORT}" ]]; then
-  echo "SE_EVENT_BUS_PUBLISH_PORT not set, exiting!" 1>&2
-  exit 1
-fi
-
-if [[ -z "${SE_EVENT_BUS_SUBSCRIBE_PORT}" ]]; then
-  echo "SE_EVENT_BUS_SUBSCRIBE_PORT not set, exiting!" 1>&2
-  exit 1
-fi
-
 if [ ! -z "$SE_OPTS" ]; then
   echo "Appending Selenium options: ${SE_OPTS}"
 fi
@@ -35,8 +20,6 @@ if [ ! -z "$SE_SESSION_QUEUE_PORT" ]; then
 fi
 
 java ${JAVA_OPTS:-$SE_JAVA_OPTS} -jar /opt/selenium/selenium-server.jar sessionqueue \
-  --publish-events tcp://"${SE_EVENT_BUS_HOST}":${SE_EVENT_BUS_PUBLISH_PORT} \
-  --subscribe-events tcp://"${SE_EVENT_BUS_HOST}":${SE_EVENT_BUS_SUBSCRIBE_PORT} \
   --session-request-timeout ${SE_SESSION_REQUEST_TIMEOUT} \
   --session-retry-interval ${SE_SESSION_RETRY_INTERVAL} \
   --bind-host ${SE_BIND_HOST} \


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Remove `--publish-events` and `--subscribe-events` flags from being passed in [start-selenium-grid-sessions-queue.sh](https://github.com/SeleniumHQ/docker-selenium/blob/trunk/SessionQueue/start-selenium-grid-session-queue.sh)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
As seen in [1687](https://github.com/SeleniumHQ/docker-selenium/issues/1687), if a user supplies an environment variables `SE_EVENT_BUS_HOST`, `SE_EVENT_BUS_PUBLISH_PORT`, and `SE_EVENT_BUS_SUBSCRIBE_PORT`, they are passed to selenium-server.jar as launch flags `--publish-events` and `--subscribe-events`.  These flags were removed in 4.5.0, [specifically this commit](https://github.com/SeleniumHQ/selenium/commit/4b19fa416be02542c994bf839ca3c3408ded4b16).

Currently, if a user with the aforementioned environment variables set runs the bash file, it will fail to launch with:
`Was passed main parameter '--publish-events' but no main parameter was defined in your arg class`.  Removing the flags allows the session queue to launch.

I was unable to find any documentation that still referenced the `--publish-events` or `--subscribe-events` flags.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
