### PR TITLE
Exiting container when Standalone or Node exits, even with error exit status

### DIFF
--- a/NodeBase/selenium.conf
+++ b/NodeBase/selenium.conf
@@ -55,7 +55,7 @@ stderr_capture_maxbytes=50MB
 
 [program:selenium-node]
 priority=15
-command=bash -c "/opt/bin/start-selenium-node.sh && kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`"
+command=bash -c "/opt/bin/start-selenium-node.sh; EXIT_CODE=$?; kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`; exit $EXIT_CODE"
 stopasgroup = true
 autostart=true
 autorestart=false

--- a/Standalone/selenium.conf
+++ b/Standalone/selenium.conf
@@ -61,7 +61,7 @@ stderr_capture_maxbytes=50MB
 
 [program:selenium-standalone]
 priority=15
-command=bash -c "/opt/bin/start-selenium-standalone.sh && kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`"
+command=bash -c "/opt/bin/start-selenium-standalone.sh; EXIT_CODE=$?; kill -s SIGINT `cat /var/run/supervisor/supervisord.pid`; exit $EXIT_CODE"
 stopasgroup = true
 autostart=true
 autorestart=false


### PR DESCRIPTION
### Description
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/1703

Stop supervisord if the Standalone or Node exits, even with an error exit status.

### Motivation and Context
If the selenium server process is for example killed (exit status != 0), supervisord continues to run, and Kubernetes won't restart the entire pod.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

I'll mark it as breaking change, but I hope people don't really rely on this functionality.

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
