### PR TITLE
[grid][chart] Allows users to turn off Deployment creation for Nodes

### DIFF
--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.13.0
+
+### Added
+- Added support to disable Chrome, Edge, and Firefox Deployment using `deploymentEnabled`
+
 ## :heavy_check_mark: 0.12.2
 
 ### Changed

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.12.2
+version: 0.13.0
 appVersion: 4.5.3-20221024
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -68,6 +68,7 @@ This table contains the configuration parameters of the chart and their default 
 | `ingress.tls`                           | `[]`                               | TLS backend configuration for ingress resource                                                                             |
 | `busConfigMap.annotations`              | `{}`                               | Custom annotations for configmap                                                                                           |
 | `chromeNode.enabled`                    | `true`                             | Enable chrome nodes                                                                                                        |
+| `chromeNode.deploymentEnabled`          | `true`                             | Enable creation of Deployment for chrome nodes                                                                             |
 | `chromeNode.replicas`                   | `1`                                | Number of chrome nodes                                                                                                     |
 | `chromeNode.imageName`                  | `selenium/node-chrome`             | Image of chrome nodes                                                                                                      |
 | `chromeNode.imageTag`                   | `4.5.3-20221024`                   | Image of chrome nodes                                                                                                      |
@@ -95,6 +96,7 @@ This table contains the configuration parameters of the chart and their default 
 | `chromeNode.extraVolumeMounts`          | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `chromeNode.extraVolumes`               | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `firefoxNode.enabled`                   | `true`                             | Enable firefox nodes                                                                                                       |
+| `firefoxNode.deploymentEnabled`         | `true`                             | Enable creation of Deployment for firefox nodes                                                                            |
 | `firefoxNode.replicas`                  | `1`                                | Number of firefox nodes                                                                                                    |
 | `firefoxNode.imageName`                 | `selenium/node-firefox`            | Image of firefox nodes                                                                                                     |
 | `firefoxNode.imageTag`                  | `4.5.3-20221024`                   | Image of firefox nodes                                                                                                     |
@@ -122,6 +124,7 @@ This table contains the configuration parameters of the chart and their default 
 | `firefoxNode.extraVolumeMounts`         | `[]`                               | Extra mounts of declared ExtraVolumes into pod                                                                             |
 | `firefoxNode.extraVolumes`              | `[]`                               | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
 | `edgeNode.enabled`                      | `true`                             | Enable edge nodes                                                                                                          |
+| `edgeNode.deploymentEnabled`            | `true`                             | Enable creation of Deployment for edge nodes                                                                               |
 | `edgeNode.replicas`                     | `1`                                | Number of edge nodes                                                                                                       |
 | `edgeNode.imageName`                    | `selenium/node-edge`               | Image of edge nodes                                                                                                        |
 | `edgeNode.imageTag`                     | `4.5.3-20221024`                   | Image of edge nodes                                                                                                        |

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.chromeNode.enabled }}
+{{- if and .Values.chromeNode.enabled .Values.chromeNode.deploymentEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.edgeNode.enabled }}
+{{- if and .Values.edgeNode.enabled .Values.edgeNode.deploymentEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -1,4 +1,4 @@
-{{- if .Values.firefoxNode.enabled }}
+{{- if and .Values.firefoxNode.enabled .Values.firefoxNode.deploymentEnabled }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -290,6 +290,12 @@ hub:
 chromeNode:
   # Enable chrome nodes
   enabled: true
+
+  # Enable creation of Deployment
+  # true (default) - if you want long living pods
+  # false - for provisioning your own custom type such as Jobs
+  deploymentEnabled: true
+
   # Number of chrome nodes
   replicas: 1
   # Image of chrome nodes
@@ -396,6 +402,12 @@ chromeNode:
 firefoxNode:
   # Enable firefox nodes
   enabled: true
+
+  # Enable creation of Deployment
+  # true (default) - if you want long living pods
+  # false - for provisioning your own custom type such as Jobs
+  deploymentEnabled: true
+
   # Number of firefox nodes
   replicas: 1
   # Image of firefox nodes
@@ -502,6 +514,12 @@ firefoxNode:
 edgeNode:
   # Enable edge nodes
   enabled: true
+
+  # Enable creation of Deployment
+  # true (default) - if you want long living pods
+  # false - for provisioning your own custom type such as Jobs
+  deploymentEnabled: true
+
   # Number of edge nodes
   replicas: 1
   # Image of edge nodes


### PR DESCRIPTION
### Description
This change introduces a new value called `deploymentEnabled` for each of the node browsers, if the value is set to `true` Deployments will be created for each of the respective nodes however if `false` no Deployments will be created.

This will allow users to turn off creation of the default deployments and to use other resource types instead such as jobs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
Fixes #1708

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [X] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [X] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
