### PR TITLE
Fix environment variable naming in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -844,12 +844,12 @@ captured in the same video.
 [Chrome](https://developers.google.com/web/updates/2017/04/headless-chrome), 
 When using headless mode, there's no need for the [Xvfb](https://en.wikipedia.org/wiki/Xvfb) server to be started.
 
-To avoid starting the server you can set the `SE_START_XVFB` environment variable to `false` 
+To avoid starting the server you can set the `START_XVFB` environment variable to `false` 
 (or any other value than `true`), for example:
 
 ``` bash
 $ docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
-  -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 -e SE_START_XVFB=false --shm-size="2g" selenium/node-chrome:4.7.2-20221219
+  -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 -e START_XVFB=false --shm-size="2g" selenium/node-chrome:4.7.2-20221219
 ```
 
 For more information, see this GitHub [issue](https://github.com/SeleniumHQ/docker-selenium/issues/567).
@@ -1204,7 +1204,7 @@ or
 
 `Message: unknown error: Chrome failed to start: exited abnormally`
 
-The reason _might_ be that you've set the `SE_START_XVFB` environment variable to "false", but forgot to 
+The reason _might_ be that you've set the `START_XVFB` environment variable to "false", but forgot to 
 actually run Firefox, Chrome or Edge in headless mode.
 
 ### Mounting volumes to retrieve downloaded files


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

<!-- **Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.-->


<!--- Provide a general summary of your changes in the Title above -->

### Description
This PR renames the environment variable `SE_START_XVFB` to `START_XVFB` in the README. 

### Motivation and Context
The “temporal fix” introduced in https://github.com/SeleniumHQ/docker-selenium/issues/1610 sets both variables `SE_START_XVFB` and `START_XVFB`. Since `SE_START_XVFB` is used only as a fallback for `START_XVFB` (i.e., it is evaluated only if `START_XVFB` is null or unset) in this repository’s shell scripts, setting only `SE_START_XVFB` to `false` has no effect, and overwriting `START_XVFB` is required. As suggested [here](https://github.com/SeleniumHQ/docker-selenium/issues/1610#issuecomment-1368963724), the best way to handle this issue for now is to update the README.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
