### PR TITLE
fix: ensure language is not hardcoded in generated wrapper scripts

### DIFF
--- a/NodeChrome/wrap_chrome_binary
+++ b/NodeChrome/wrap_chrome_binary
@@ -4,22 +4,22 @@ WRAPPER_PATH=$(readlink -f /usr/bin/google-chrome)
 BASE_PATH="$WRAPPER_PATH-base"
 mv "$WRAPPER_PATH" "$BASE_PATH"
 
-# Debian/Ubuntu seems to not respect --lang, it instead needs to be a LANGUAGE environment var
-# See: https://stackoverflow.com/a/41893197/359999
-for var in "$@"; do
-   if [[ $var == --lang=* ]]; then
-      LANGUAGE=${var//--lang=}
-   fi
-done
-
 cat > "$WRAPPER_PATH" <<_EOF
 #!/bin/bash
 
 # umask 002 ensures default permissions of files are 664 (rw-rw-r--) and directories are 775 (rwxrwxr-x).
 umask 002
 
+# Debian/Ubuntu seems to not respect --lang, it instead needs to be a LANGUAGE environment var
+# See: https://stackoverflow.com/a/41893197/359999
+for var in "\$@"; do
+   if [[ \$var == --lang=* ]]; then
+      LANGUAGE=\${var//--lang=}
+   fi
+done
+
 # Set language environment variable
-export LANGUAGE="$LANGUAGE"
+export LANGUAGE="\$LANGUAGE"
 
 # Note: exec -a below is a bashism.
 exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"

--- a/NodeEdge/wrap_edge_binary
+++ b/NodeEdge/wrap_edge_binary
@@ -4,22 +4,22 @@ WRAPPER_PATH=$(readlink -f /usr/bin/microsoft-edge)
 BASE_PATH="$WRAPPER_PATH-base"
 mv "$WRAPPER_PATH" "$BASE_PATH"
 
-# Debian/Ubuntu seems to not respect --lang, it instead needs to be a LANGUAGE environment var
-# See: https://stackoverflow.com/a/41893197/359999
-for var in "$@"; do
-   if [[ $var == --lang=* ]]; then
-      LANGUAGE=${var//--lang=}
-   fi
-done
-
 cat > "$WRAPPER_PATH" <<_EOF
 #!/bin/bash
 
 # umask 002 ensures default permissions of files are 664 (rw-rw-r--) and directories are 775 (rwxrwxr-x).
 umask 002
 
+# Debian/Ubuntu seems to not respect --lang, it instead needs to be a LANGUAGE environment var
+# See: https://stackoverflow.com/a/41893197/359999
+for var in "\$@"; do
+   if [[ \$var == --lang=* ]]; then
+      LANGUAGE=\${var//--lang=}
+   fi
+done
+
 # Set language environment variable
-export LANGUAGE="$LANGUAGE"
+export LANGUAGE="\$LANGUAGE"
 
 # Note: exec -a below is a bashism.
 exec -a "\$0" "$BASE_PATH" --no-sandbox "\$@"


### PR DESCRIPTION
### Description

Ensures LANGUAGE is not hardcoded in standalone images by moving logic into the generated wrapper script.

### Motivation and Context
See #1788 for related issue.

I have interpreted the original intention in #1778 to attempt to translate `--lang` to `LANGUAGE` at runtime, not build-time.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
