### PR TITLE
Make ingress compatible with format prior to 1.19-0 k8s version

### DIFF
--- a/charts/selenium-grid/CHANGELOG.md
+++ b/charts/selenium-grid/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this helm chart will be documented in this file.
 
+## :heavy_check_mark: 0.15.3
+
+### Changed
+- Make ingress compatible with format prior to 1.19-0 k8s version
+
 ## :heavy_check_mark: 0.15.2
 
 ### Changed

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,6 +2,6 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.15.2
+version: 0.15.3
 appVersion: 4.8.1-20230221
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png

--- a/charts/selenium-grid/templates/ingress.yaml
+++ b/charts/selenium-grid/templates/ingress.yaml
@@ -44,6 +44,7 @@ spec:
       {{- else }}
     - http:
       {{- end }}
+      {{- if semverCompare ">=1.19-0" $.Capabilities.KubeVersion.Version }}
         paths:
           - path: /
             pathType: Prefix
@@ -58,4 +59,16 @@ spec:
                 port:
                   number: {{ $.Values.hub.port }}
                 {{- end }}
+      {{- else }}
+        paths:
+          - path: /
+            backend:
+              {{- if $.Values.isolateComponents }}
+              serviceName: {{ template "seleniumGrid.router.fullname" $ }}
+              servicePort: {{ $.Values.components.router.port }}
+              {{- else }}
+              serviceName: {{ template "seleniumGrid.hub.fullname" $ }}
+              servicePort: {{ $.Values.hub.port }}
+              {{- end }}
+      {{- end }}
 {{- end }}


### PR DESCRIPTION
The PR objective is to support old ingress API version.
In our case we use a 3.11 OpenShift (kubernetes 1.11) and we had this error message:

`Error: INSTALLATION FAILED: unable to build kubernetes objects from release manifest: error validating "": error validating data: [ValidationError(Ingress.spec.rules[0].http.paths[0].backend): unknown field "service" in io.k8s.api.extensions.v1beta1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): missing required field "serviceName" in io.k8s.api.extensions.v1beta1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0].backend): missing required field "servicePort" in io.k8s.api.extensions.v1beta1.IngressBackend, ValidationError(Ingress.spec.rules[0].http.paths[0]): unknown field "pathType" in io.k8s.api.extensions.v1beta1.HTTPIngressPath]`

So I added a if to check if the kubernetes is in version prior to  1.19-0 to use the old ingress API
