### PR TITLE
Adding VNC_PASSWORD to configure VNC password

### DIFF
--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -28,6 +28,12 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ] ; then
         X11VNC_OPTS="${X11VNC_OPTS} -viewonly"
     fi
 
+    VNC_PASSWORD=${VNC_PASSWORD:-$SE_VNC_PASSWORD}
+    if [ ! -z $VNC_PASSWORD ]; then
+      echo "Starting VNC server with custom password"
+      x11vnc -storepasswd ${VNC_PASSWORD} ${HOME}/.vnc/passwd
+    fi
+
     for i in $(seq 1 10)
     do
       sleep 1

--- a/README.md
+++ b/README.md
@@ -1092,27 +1092,8 @@ Then, you would use in your VNC client:
 - Port 5901 to connect to the Edge container
 - Port 5902 to connect to the Firefox container
 
-If you get a prompt asking for a password, it is: `secret`. If you wish to change this, you should either change 
-it in the `/NodeBase/Dockerfile` and build the images yourself, or you can define a Docker image that derives from 
-the posted ones which reconfigures it:
-
-Dockerfile example that extends the `node-chrome:4.9.0-20230421`. You can choose another browser image or a Standalone
-browser image.
-
-``` dockerfile
-FROM selenium/node-chrome:4.9.0-20230421
-
-RUN x11vnc -storepasswd <your-password-here> /home/seluser/.vnc/passwd
-```
-
-Save the `Dockerfile` as `DockerfileVNCPasswordChanged`, open a terminal and on the same directory run:
-
-```shell
-docker build -t selenium/node-chrome-vnc-password-changed:4.9.0-20230421 -f DockerfileVNCPasswordChanged .
-```
-
-And from now on, instead of using `node-chrome:4.9.0-20230421` in your scripts or docker-compose files, use
-`selenium/node-chrome-vnc-password-changed:4.9.0-20230421`.
+If you get a prompt asking for a password, it is: `secret`. If you wish to change this, 
+you can set the environment variable `SE_VNC_PASSWORD`.
 
 If you want to run VNC without password authentication you can set the environment variable `SE_VNC_NO_PASSWORD=1`.
 


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

### Description
Adding the `SE_VNC_PASSWORD` environment variable to allow a custom VNC password to be configured.

### Motivation and Context
I have a similar requirement as described in https://github.com/SeleniumHQ/docker-selenium/issues/1772, I want the ability to control the VNC server password, without having to rebuild docker images.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
