### PR TITLE
Feat: support grid basic auth on helm chart

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -180,9 +180,9 @@ Get the url of the grid. If the external url can be figured out from the ingress
 */}}
 {{- define "seleniumGrid.url" -}}
 {{- if and .Values.ingress.enabled .Values.ingress.hostname (ne .Values.ingress.hostname "selenium-grid.local") -}}
-http{{if .Values.ingress.tls}}s{{end}}://{{.Values.ingress.hostname}}
+http{{if .Values.ingress.tls}}s{{end}}://{{- if eq .Values.basicAuth.enabled true}}{{ .Values.basicAuth.username}}:{{ .Values.basicAuth.password}}@{{- end}}{{.Values.ingress.hostname}}
 {{- else -}}
-http://{{ include ($.Values.isolateComponents | ternary "seleniumGrid.router.fullname" "seleniumGrid.hub.fullname") $ }}.{{ .Release.Namespace }}:{{ $.Values.components.router.port }}
+http://{{- if eq .Values.basicAuth.enabled true}}{{ .Values.basicAuth.username}}:{{ .Values.basicAuth.password}}@{{- end}}{{ include ($.Values.isolateComponents | ternary "seleniumGrid.router.fullname" "seleniumGrid.hub.fullname") $ }}.{{ .Release.Namespace }}:{{ $.Values.components.router.port }}
 {{- end }}
 {{- end -}}
 
@@ -190,7 +190,7 @@ http://{{ include ($.Values.isolateComponents | ternary "seleniumGrid.router.ful
 Graphql Url of the hub or the router
 */}}
 {{- define "seleniumGrid.graphqlURL" -}}
-http://{{ include ($.Values.isolateComponents | ternary "seleniumGrid.router.fullname" "seleniumGrid.hub.fullname") $ }}.{{ .Release.Namespace }}:{{ $.Values.components.router.port }}/graphql
+http://{{- if eq .Values.basicAuth.enabled true}}{{ .Values.basicAuth.username}}:{{ .Values.basicAuth.password}}@{{- end}}{{ include ($.Values.isolateComponents | ternary "seleniumGrid.router.fullname" "seleniumGrid.hub.fullname") $ }}.{{ .Release.Namespace }}:{{ $.Values.components.router.port }}/graphql
 {{- end -}}
 
 {{/*

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -64,6 +64,12 @@ spec:
           env:
             - name: SE_SUB_PATH
               value: {{ .Values.hub.subPath }}
+            {{- if eq .Values.basicAuth.enabled true}}
+            - name: ROUTER_USERNAME
+              value: {{ .Values.basicAuth.username }}
+            - name: ROUTER_PASSWORD
+              value: {{ .Values.basicAuth.username }}
+            {{- end }}
           {{- with .Values.hub.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -44,6 +44,12 @@ spec:
               value: {{ .Values.components.sessionQueue.port | quote }}
             - name: SE_SUB_PATH
               value: {{ .Values.components.subPath }}
+            {{- if eq .Values.basicAuth.enabled true}}
+            - name: ROUTER_USERNAME
+              value: {{ .Values.basicAuth.username }}
+            - name: ROUTER_PASSWORD
+              value: {{ .Values.basicAuth.password }}
+            {{- end }}
           {{- with .Values.components.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -5,7 +5,16 @@ global:
     # Image tag for browser's nodes
     nodesImageTag: 4.10.0-20230607
     # Pull secret for all components, can be overridden individually
-    imagePullSecret: ""
+    imagePullSecret: ""    
+
+# Basic auth settings for Selenium Grid
+basicAuth:
+      # Enable or disable basic auth
+      enabled: true
+      # Username for basic auth
+      username: admin
+      # Password for basic auth
+      password: admin    
 
 # Deploy Router, Distributor, EventBus, SessionMap and Nodes separately
 isolateComponents: false


### PR DESCRIPTION
### Description
Simple change to allow Selenium Grid basic auth to be enabled/disabled through the values.yaml file when deploying via the Helm chart. 

### Motivation and Context
Currently, it is not straightforward to enable basic auth because:
1. Selenium grid URLs used for internal communication between components are calculated using helpers (_helpers.tpl) that do not take basic auth into consideration.
2. Autoscaling HPA URL is determined using (1) - therefore autoscaling will not work when basic auth is enabled unless HPA URL is explicitly set without using helpers. This causes duplication of configuration.
3. Basic auth settings need to be applied to either the hub or router, depending on isolated components set up

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

Summary of changes:
1. Updated values.yaml template file to add new configuration items for basic auth
2. Updated helpers to correctly set seleniumGrid.url and seleniumGrid.graphqlURL when basic auth is enabled
3. Updated hub and router deployment templates to incorporate basic auth environment variables if basic auth is enabled
