### PR TITLE
feat: Ability to create/specify Service Account

### DIFF
--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -73,19 +73,22 @@ helm uninstall selenium-grid
 
 For now, global configuration supported is:
 
-| Parameter                             | Default                            | Description                           |
-| -----------------------------------   | ---------------------------------- | ------------------------------------- |
-| `global.seleniumGrid.imageTag`        | `4.11.0-20230801`                  | Image tag for all selenium components |
-| `global.seleniumGrid.nodesImageTag`   | `4.11.0-20230801`                  | Image tag for browser's nodes         |
-| `global.seleniumGrid.imagePullSecret` | `""`                               | Pull secret to be used for all images |
-| `global.seleniumGrid.imagePullSecret` | `""`                               | Pull secret to be used for all images |
-| `global.seleniumGrid.affinity`        | `{}`                               | Affinity assigned globally            |
+| Parameter                             | Default           | Description                           |
+|---------------------------------------|-------------------|---------------------------------------|
+| `global.seleniumGrid.imageTag`        | `4.11.0-20230801` | Image tag for all selenium components |
+| `global.seleniumGrid.nodesImageTag`   | `4.11.0-20230801` | Image tag for browser's nodes         |
+| `global.seleniumGrid.imagePullSecret` | `""`              | Pull secret to be used for all images |
+| `global.seleniumGrid.imagePullSecret` | `""`              | Pull secret to be used for all images |
+| `global.seleniumGrid.affinity`        | `{}`              | Affinity assigned globally            |
 
 This table contains the configuration parameters of the chart and their default values:
 
 | Parameter                                   | Default                                     | Description                                                                                                                |
-| ---------------------------------------     | ----------------------------------          | -------------------------------------------------------------------------------------------------------------------------- |
+|---------------------------------------------|---------------------------------------------|----------------------------------------------------------------------------------------------------------------------------|
 | `isolateComponents`                         | `false`                                     | Deploy Router, Distributor, EventBus, SessionMap and Nodes separately                                                      |
+| `serviceAccount.create`                     | `true`                                      | Enable or disable creation of service account (if `false`, `serviceAccount.name` MUST be specified                         |
+| `serviceAccount.name`                       | `""`                                        | Name of the service account to be made or existing service account to use for all deployments and jobs                     |
+| `serviceAccount.annotations`                | `{}`                                        | Custom annotations for service account                                                                                     |
 | `busConfigMap.name`                         | `selenium-event-bus-config`                 | Name of the configmap that contains SE_EVENT_BUS_HOST, SE_EVENT_BUS_PUBLISH_PORT and SE_EVENT_BUS_SUBSCRIBE_PORT variables |
 | `busConfigMap.annotations`                  | `{}`                                        | Custom annotations for configmap                                                                                           |
 | `nodeConfigMap.name`                        | `selenium-node-config`                      | Name of the configmap that contains common environment variables for browser nodes                                         |
@@ -219,7 +222,7 @@ https://github.com/kedacore/charts/blob/main/keda/README.md for more details.
 
 ### Configuration for Selenium-Hub
 
-You can configure the Selenium Hub with this values:
+You can configure the Selenium Hub with these values:
 
 | Parameter                       | Default           | Description                                                                                                                                      |
 |---------------------------------|-------------------|--------------------------------------------------------------------------------------------------------------------------------------------------|
@@ -241,8 +244,8 @@ You can configure the Selenium Hub with this values:
 | `hub.subPath`                   | `/`               | Custom sub path for the hub deployment                                                                                                           |
 | `hub.extraEnvironmentVariables` | `nil`             | Custom environment variables for selenium-hub                                                                                                    |
 | `hub.extraEnvFrom`              | `nil`             | Custom environment variables for selenium taken from `configMap` or `secret`-hub                                                                 |
-| `hub.extraVolumeMounts`         | `[]`              | Extra mounts of declared ExtraVolumes into pod                                                                             |
-| `hub.extraVolumes`              | `[]`              | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)     |
+| `hub.extraVolumeMounts`         | `[]`              | Extra mounts of declared ExtraVolumes into pod                                                                                                   |
+| `hub.extraVolumes`              | `[]`              | Extra Volumes declarations to be used in the pod (can be any supported volume type: ConfigMap, Secret, PVC, NFS, etc.)                           |
 | `hub.resources`                 | `{}`              | Resources for selenium-hub container                                                                                                             |
 | `hub.securityContext`           | `See values.yaml` | Security context for selenium-hub container                                                                                                      |
 | `hub.serviceType`               | `ClusterIP`       | Kubernetes service type (see https://kubernetes.io/docs/concepts/services-networking/service/#publishing-services-service-types)                 |

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -81,6 +81,13 @@ Ingress fullname
 {{- end -}}
 
 {{/*
+Service Account fullname
+*/}}
+{{- define "seleniumGrid.serviceAccount.fullname" -}}
+{{- .Values.serviceAccount.name | default "selenium-serviceaccount" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
 Is autoscaling using KEDA enabled
 */}}
 {{- define "seleniumGrid.useKEDA" -}}
@@ -110,6 +117,8 @@ template:
         {{ toYaml . | nindent 6 }}
       {{- end }}
   spec:
+    serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+    serviceAccount: {{ template  "seleniumGrid.serviceAccount.fullname" . }}
     restartPolicy: {{ and (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") | ternary "Never" "Always" }}
   {{- with .node.hostAliases }}
     hostAliases: {{ toYaml . | nindent 6 }}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -24,6 +24,8 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+      serviceAccount: {{ template "seleniumGrid.serviceAccount.fullname" . }}
       containers:
         - name: selenium-distributor
           {{- $imageTag := default .Values.global.seleniumGrid.imageTag .Values.components.distributor.imageTag }}

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -24,6 +24,8 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+      serviceAccount: {{ template "seleniumGrid.serviceAccount.fullname" . }}
       containers:
         - name: selenium-event-bus
           {{- $imageTag := default .Values.global.seleniumGrid.imageTag .Values.components.eventBus.imageTag }}

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -27,6 +27,8 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+      serviceAccount: {{ template  "seleniumGrid.serviceAccount.fullname" . }}
       containers:
         - name: selenium-hub
           {{- $imageTag := default .Values.global.seleniumGrid.imageTag .Values.hub.imageTag }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -24,6 +24,8 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+      serviceAccount: {{ template "seleniumGrid.serviceAccount.fullname" . }}
       containers:
         - name: selenium-router
           {{- $imageTag := default .Values.global.seleniumGrid.imageTag .Values.components.router.imageTag }}

--- a/charts/selenium-grid/templates/serviceaccount.yaml
+++ b/charts/selenium-grid/templates/serviceaccount.yaml
@@ -1,0 +1,17 @@
+{{- if .Values.serviceAccount.create }}
+apiVersion: v1
+kind: ServiceAccount
+metadata:
+  name: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    app.kubernetes.io/name: selenium-service-account
+    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.serviceAccount.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+{{- end }}

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -24,6 +24,8 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+      serviceAccount: {{ template "seleniumGrid.serviceAccount.fullname" . }}
       containers:
         - name: selenium-session-map
           {{- $imageTag := default .Values.global.seleniumGrid.imageTag .Values.components.sessionMap.imageTag }}

--- a/charts/selenium-grid/templates/session-queuer-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queuer-deployment.yaml
@@ -24,6 +24,8 @@ spec:
       annotations: {{- toYaml . | nindent 8 }}
     {{- end }}
     spec:
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" . }}
+      serviceAccount: {{ template "seleniumGrid.serviceAccount.fullname" . }}
       containers:
         - name: selenium-session-queue
           {{- $imageTag := default .Values.global.seleniumGrid.imageTag .Values.components.sessionQueue.imageTag }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -33,7 +33,6 @@ ingress:
   path: /
   # TLS backend configuration for ingress resource
   tls: []
-  path: /
 
 # ConfigMap that contains SE_EVENT_BUS_HOST, SE_EVENT_BUS_PUBLISH_PORT and SE_EVENT_BUS_SUBSCRIBE_PORT variables
 busConfigMap:

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -19,6 +19,12 @@ basicAuth:
 # Deploy Router, Distributor, EventBus, SessionMap and Nodes separately
 isolateComponents: false
 
+# Service Account for all components
+serviceAccount:
+  create: true
+  name: ""
+  annotations: {}
+
 # Configure the ingress resource to access the Grid installation.
 ingress:
   # Enable or disable ingress resource


### PR DESCRIPTION
### Description
This PR adds the ability to automatically create a service account for selenium-grid deployment. By default, a service account by the name of `selenium-serviceaccount` will be made. This functionality can be disabled with `.serviceAccount.create: false` and a pre-existing service account can be specified via `.serviceAccount.name`.

Both `.spec.serviceAccountName` and `.spec.serviceAccount` were added to maintain some backwards compatibility.

Also minor nit-pick, I removed a duplicate key in `.ingress`.

### Motivation and Context
I wanted it for my environment and also https://github.com/SeleniumHQ/docker-selenium/issues/1783 needed it so why not.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
