### PR TITLE
fix(obsolescence): bumped up packages

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -90,9 +90,10 @@ RUN curl -fLo /tmp/cs https://github.com/coursier/launchers/raw/master/coursier 
   && mkdir -p /external_jars \
   && chmod -R 775 /external_jars
 
-RUN /tmp/cs fetch --classpath --cache /external_jars io.opentelemetry:opentelemetry-exporter-otlp:1.28.0 io.opentelemetry:opentelemetry-exporter-jaeger:1.28.0 io.grpc:grpc-netty:1.57.1 > /external_jars/.classpath.txt
+RUN /tmp/cs fetch --classpath --cache /external_jars io.opentelemetry:opentelemetry-exporter-otlp:1.30.1 io.opentelemetry:opentelemetry-exporter-jaeger:1.30.1 io.grpc:grpc-netty:1.58.0 > /external_jars/.classpath.txt
 
 RUN chmod 664 /external_jars/.classpath.txt
+RUN rm -fr /root/.cache/*
 
 #===================================================
 # Run the following commands as non-privileged user

--- a/Video/Dockerfile
+++ b/Video/Dockerfile
@@ -19,6 +19,9 @@ RUN apt-get -qqy update \
   && apt-get upgrade -yq \
   && apt-get -qqy --no-install-recommends install \
     supervisor x11-xserver-utils python3-pip \
+  && python3 -m pip install --upgrade pip \
+  && python3 -m pip install --upgrade setuptools \
+  && python3 -m pip install --upgrade wheel \    
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #======================================


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
PR for Issue https://github.com/SeleniumHQ/docker-selenium/issues/1959


### Motivation and Context
1. Bumped up opentelemetry jars
2. Delete coursier cache folder to delete vulnerable jars (commons-compress-1.23.0.jar,plexus-archiver) and reduce image size
3. Bumped up Python settuptools and wheel package to address vulnerabilities.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
