### PR TITLE
fix(chart): minor issues after PR #1881 and #1981

### DIFF
--- a/Video/Dockerfile
+++ b/Video/Dockerfile
@@ -6,7 +6,7 @@ LABEL authors="Selenium <selenium-developers@googlegroups.com>"
 #========================
 RUN apk update \
   && apk upgrade \
-  && apk add --no-cache --update --virtual .build-deps supervisor bash curl jq xset python3 py3-psutil py3-pip \
+  && apk add --no-cache --update --virtual .build-deps supervisor bash curl jq xset xdpyinfo python3 py3-psutil py3-pip \
   && ln -sf python3 /usr/bin/python \
   && rm -rf /tmp/* /var/cache/apk/*
 

--- a/Video/supervisord.conf
+++ b/Video/supervisord.conf
@@ -10,6 +10,7 @@ pidfile=/var/run/supervisor/supervisord.pid   ; (supervisord pidfile;default sup
 nodaemon=true                                 ; (start in foreground if true;default false)
 minfds=1024                                   ; (min. avail startup file descriptors;default 1024)
 minprocs=200                                  ; (min. avail process descriptors;default 200)
+user=root                                     ; (default is current user, required if root)
 
 [program:video-recording]
 priority=0

--- a/charts/selenium-grid/templates/video-cm.yaml
+++ b/charts/selenium-grid/templates/video-cm.yaml
@@ -20,7 +20,10 @@ data:
     return_code=1
     max_attempts=600
     attempts=0
-    mkfifo /videos/uploadpipe
+    if [ ! -p /videos/uploadpipe ];
+    then
+      mkfifo /videos/uploadpipe
+    fi
     if [[ "$UPLOAD_DESTINATION_PREFIX" = "" ]]
     then
         echo Upload destination not known since UPLOAD_DESTINATION_PREFIX is not set. Exiting video recorder.


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fix minor issues after PR #1881 and #1981

### Motivation and Context
**Issue#1**
From pod logs, an error could be seen, which caused pod `CrashLoopBackOff` after restarting multiple times
```bash
selenium-chrome-node-6966f9c8b9-q4dkg    1/3     CrashLoopBackOff

2023-10-25 19:33:44,306 INFO supervisord started with pid 7
2023-10-25 19:33:45,309 INFO spawned: 'video-recording' with pid 9
2023-10-25 19:33:45,312 INFO spawned: 'video-ready' with pid 10
mkfifo: /videos/uploadpipe: File exists
2023-10-25 19:33:45,318 INFO exited: video-recording (exit status 1; not expected)
2023-10-25 19:33:45,318 WARN received SIGINT indicating exit request
```
Fix: Add if condition to check pipe file existed before creating by command mkfifo
```
-p file
       True if file exists and is a named pipe (FIFO).
```

**Issue#2**
```bash
Checking if the display is open
/opt/bin/video.sh: line 37: xdpyinfo: command not found
Checking if node API responds
```
Fix: Add dependency "xdpyinfo" in the Dockerfile of video image

**Issue#3**
```bash
2023-10-25 20:06:45,766 CRIT Supervisor is running as root.  Privileges were not dropped because no user is specified in the config file.  If you intend to run as root, you can set user=root in the config file to avoid this message.
2023-10-25 20:06:45,769 INFO supervisord started with pid 7
```
Improve: Clear the redundant message from video container logs by adding user=root to Video/supervisord.conf

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
