### PR TITLE
fix(chart): Improve default value for videoRecorder

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -181,7 +181,7 @@ template:
         imagePullPolicy: {{ .Values.videoRecorder.imagePullPolicy }}
         env:
         - name: UPLOAD_DESTINATION_PREFIX
-          value: {{ .Values.videoRecorder.uploadDestinationPrefix }}
+          value: {{ .Values.videoRecorder.uploadDestinationPrefix | quote }}
       {{- with .Values.videoRecorder.extraEnvironmentVariables }}
         {{- tpl (toYaml .) $ | nindent 8 }}
       {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -25,6 +25,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" "selenium-chrome-node" -}}
 {{- $_ =  set $podScope "node" .Values.chromeNode  -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder .Values.videoRecorder.uploader) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
+++ b/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
@@ -35,6 +35,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" "selenium-chrome-node" -}}
 {{- $_ =  set $podScope "node" .Values.chromeNode  -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder .Values.videoRecorder.uploader) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 4 }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -25,6 +25,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" "selenium-edge-node" -}}
 {{- $_ =  set $podScope "node" .Values.edgeNode  -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder .Values.videoRecorder.uploader) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/edge-node-scaledjob.yaml
@@ -35,6 +35,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" "selenium-edge-node" -}}
 {{- $_ =  set $podScope "node" .Values.edgeNode  -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder .Values.videoRecorder.uploader) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 4 }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -25,6 +25,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" "selenium-firefox-node" -}}
 {{- $_ =  set $podScope "node" .Values.firefoxNode  -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder .Values.videoRecorder.uploader) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
@@ -35,6 +35,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" "selenium-firefox-node" -}}
 {{- $_ =  set $podScope "node" .Values.firefoxNode  -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder .Values.videoRecorder.uploader) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 4 }}
 {{- end }}

--- a/charts/selenium-grid/templates/video-cm.yaml
+++ b/charts/selenium-grid/templates/video-cm.yaml
@@ -64,7 +64,7 @@ data:
         if [[ "$session_id" != "null" && "$session_id" != "" && "$recording_started" = "false" ]]
         then
             video_file_name="$session_id.mp4"
-            video_file="${VIDEO_LOCATION:-/videos}/$video_file_name"
+            video_file="${SE_VIDEO_FOLDER:-/videos}/$video_file_name"
             echo "Starting to record video"
             ffmpeg -nostdin -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY} -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p $video_file &
             recording_started="true"
@@ -74,9 +74,12 @@ data:
             echo "Stopping to record video"
             kill -INT %1
             fg || echo ffmpeg exited with code $?
-            upload_destination=${UPLOAD_DESTINATION_PREFIX}${video_file_name}
-            echo "Uploading video to $upload_destination"
-            echo $video_file $upload_destination > /videos/uploadpipe &
+            if [[ "$UPLOAD_DESTINATION_PREFIX" != "false" ]]
+            then
+              upload_destination=${UPLOAD_DESTINATION_PREFIX}${video_file_name}
+              echo "Uploading video to $upload_destination"
+              echo $video_file $upload_destination > /videos/uploadpipe &
+            fi
             recording_started="false"
         elif [[ $recording_started = "true" ]]
         then

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -730,9 +730,10 @@ videoRecorder:
   imageName: selenium/video
   enabled: false
   # Where to upload the video file. Should be set to something like 's3://myvideobucket/'
-  uploadDestinationPrefix: ""
+  uploadDestinationPrefix: false
   # What uploader to use. See .videRecorder.s3 for how to create a new one.
-  uploader: s3
+  # uploader: s3
+  uploader: false
 
   # Image of video recorder
   imageTag: latest
@@ -749,7 +750,7 @@ videoRecorder:
       memory: "1Gi"
       cpu: "1"
   extraEnvironmentVariables: []
-  # - name: VIDEO_LOCATION
+  # - name: SE_VIDEO_FOLDER
   #   value: /videos
   # Custom environment variables by sourcing entire configMap, Secret, etc. for video recorder.
   extraEnvFrom:
@@ -761,6 +762,7 @@ videoRecorder:
   terminationGracePeriodSeconds: 30
   volume:
     emptyDir: {}
+  # Container spec for the uploader if above it is defined as "uploader: s3"
   s3:
     imageName: public.ecr.aws/bitnami/aws-cli
     imageTag: "2"


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Improve default value for videoRecorder in chart after #1881 

### Motivation and Context
Currently, by default, `videoRecorder.enabled=false`. When enabling videoRecorder, with default `uploader: s3` in chart values.yaml. User must input the appropriate value for `uploadDestinationPrefix`. Otherwise, the video container will be exited immediately (as video.sh in ConfigMap implemented).
In my point of view, in common use cases, not always the user has S3 destination ready. Basically, by default, all containers in the pod should be up fully before going to advanced configs. Use cases with the order of priority would be
1) Default `videoRecorder.enabled=false`. Node pod has 1/1 container running.
2) User configure `--set videoRecorder.enabled=true` only. Node pod has 2/2 containers running. Video records are persisted in PersistentVolume in Kubernetes.
3) User continue configure the uploader and upload destination `--set videoRecorder.uploader=s3 --set videoRecorder.uploadDestinationPrefix=s3://myvideobucket/`. Node pod has 3/3 containers running, and records are uploaded properly to destination S3.

Update to use the boolean value `false` to disable the uploader and skip upload by default.

Update ENV `VIDEO_LOCATION` -> `SE_VIDEO_FOLDER` to align with existing ENV present in video image selenium/video:ffmpeg-6.0

Update in chart templates:
- Wrap `(.Values.videoRecorder.uploader | toString)` to work with case value `uploader: false`. Avoid Helm raise the error: ` at <.Values.videoRecorder.uploader>: wrong type for value; expected string; got bool`
- Add `| quote` for `.Values.videoRecorder.uploadDestinationPrefix` is able to to work with bool value input

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
