### PR TITLE
Update Dockerfile external jar versions

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -88,7 +88,7 @@ RUN curl -fLo /tmp/cs https://github.com/coursier/launchers/raw/master/coursier 
   && mkdir -p /external_jars \
   && chmod -R 775 /external_jars
 
-RUN /tmp/cs fetch --classpath --cache /external_jars io.opentelemetry:opentelemetry-exporter-otlp:1.30.1 io.opentelemetry:opentelemetry-exporter-jaeger:1.30.1 io.grpc:grpc-netty:1.58.0 > /external_jars/.classpath.txt
+RUN /tmp/cs fetch --classpath --cache /external_jars io.opentelemetry:opentelemetry-exporter-otlp:1.31.0 io.opentelemetry:opentelemetry-exporter-jaeger:1.31.0 io.grpc:grpc-netty:1.59.0 > /external_jars/.classpath.txt
 
 RUN chmod 664 /external_jars/.classpath.txt
 RUN rm -fr /root/.cache/*


### PR DESCRIPTION
### Description
Uplifting external jar versions.
  - io.opentelemetry:opentelemetry-exporter-otlp:1.30.1 to 1.31.0
  - io.opentelemetry:opentelemetry-exporter-jaeger:1.30.1 to 1.31.0
  - io.grpc:grpc-netty:1.58.0 to 1.59.0

### Motivation and Context
Because they are not the latest versions and have vulnerabilities.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
