### PR TITLE
bug(#1888): TimeZone change behavior changed

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -39,8 +39,9 @@ RUN apt-get -qqy update \
 # Possible alternative: https://github.com/docker/docker/issues/3359#issuecomment-32150214
 #===================
 ENV TZ "UTC"
-RUN echo "${TZ}" > /etc/timezone \
-  && dpkg-reconfigure --frontend noninteractive tzdata
+RUN ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime && \
+    dpkg-reconfigure -f noninteractive tzdata && \
+    cat /etc/timezone
 
 #========================================
 # Add normal user and group with passwordless sudo


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fix #1888

### Motivation and Context
Update the command to set timezone as per request #1888. The result would be
```bash
Step 7/19 : RUN ln -fs /usr/share/zoneinfo/${TZ} /etc/localtime &&     dpkg-reconfigure -f noninteractive tzdata &&     cat /etc/timezone
 ---> Running in 5ddabe277c0d

Current default time zone: 'Asia/Shanghai'
Local time is now:      Wed Nov 29 03:16:57 CST 2023.
Universal Time is now:  Tue Nov 28 19:16:57 UTC 2023.

Asia/Shanghai

```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
