### PR TITLE
feat(chart): Append subPath to ENV variable SE_NODE_GRID_URL

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -346,6 +346,16 @@ http://{{- if eq .Values.basicAuth.enabled true}}{{ .Values.basicAuth.username}}
 {{- end }}
 {{- end -}}
 
+{{- define "seleniumGrid.url.subPath" -}}
+{{- $subPath := "/" -}}
+{{ if $.Values.isolateComponents }}
+  {{- $subPath = default $subPath $.Values.components.subPath -}}
+{{- else -}}
+  {{- $subPath = default $subPath $.Values.hub.subPath -}}
+{{- end -}}
+{{ $subPath }}
+{{- end -}}
+
 {{/*
 Graphql Url of the hub or the router
 */}}

--- a/charts/selenium-grid/templates/node-configmap.yaml
+++ b/charts/selenium-grid/templates/node-configmap.yaml
@@ -13,4 +13,4 @@ metadata:
     {{- end }}
 data:
   SE_DRAIN_AFTER_SESSION_COUNT: '{{- and (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") | ternary "1" "0" -}}'
-  SE_NODE_GRID_URL: '{{ include "seleniumGrid.url" .}}'
+  SE_NODE_GRID_URL: '{{ include "seleniumGrid.url" .}}{{ include "seleniumGrid.url.subPath" .}}'

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -42,6 +42,9 @@ ingress:
 
 isolateComponents: true
 
+components:
+  subPath: *gridAppRoot
+
 chromeNode:
   affinity: *affinity
 

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -45,6 +45,28 @@ class ChartTemplateTests(unittest.TestCase):
                 count += 1
         self.assertEqual(count, len(resources_name), "No ingress resources found")
 
+    def test_sub_path_append_to_node_grid_url(self):
+        resources_name = ['selenium-node-config']
+        count = 0
+        for doc in LIST_OF_DOCUMENTS:
+            if doc['metadata']['name'] in resources_name and doc['kind'] == 'ConfigMap':
+                logger.info(f"Assert subPath is appended to node grid url")
+                self.assertTrue(doc['data']['SE_NODE_GRID_URL'] == 'http://admin:admin@selenium-router.default:4444/selenium')
+                count += 1
+        self.assertEqual(count, len(resources_name), "No node config resources found")
+
+    def test_sub_path_set_to_grid_env_var(self):
+        resources_name = ['selenium-router']
+        is_present = False
+        for doc in LIST_OF_DOCUMENTS:
+            if doc['metadata']['name'] in resources_name and doc['kind'] == 'Deployment':
+                logger.info(f"Assert subPath is set to grid ENV variable")
+                list_env = doc['spec']['template']['spec']['containers'][0]['env']
+                for env in list_env:
+                    if env['name'] == 'SE_SUB_PATH' and env['value'] == '/selenium':
+                        is_present = True
+        self.assertTrue(is_present, "ENV variable SE_SUB_PATH is not populated")
+
 if __name__ == '__main__':
     failed = False
     try:


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
feat(chart): Append subPath to ENV variable SE_NODE_GRID_URL

### Motivation and Context
When `hub.subPath` or `components.subPath` (belong to `isolateComponents: true`) is set proper value. It would be appended to node ENV variable `SE_NODE_GRID_URL` accordingly.

For example
```yaml
isolateComponents: true
components:
  subPath: /selenium
```
`SE_NODE_GRID_URL` populated value `http://admin:admin@selenium-router.default:4444/selenium`

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
