### PR TITLE
Guard against high `ulimit -n` in when starting vnc

### DIFF
--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -44,6 +44,17 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ] ; then
       echo "Waiting for Xvfb..."
     done
 
+    # Guard against unreasonably high nofile limits. See https://github.com/SeleniumHQ/docker-selenium/issues/2045
+    if [[ $(ulimit -n) -gt 200000 ]]; then
+      echo "Trying to lower the open file descriptor limit from $(ulimit -n) to 65536."
+      ulimit -n 65536
+      if [ $? -eq 0 ]; then
+        echo "Successfully lowered the open file descriptor limit."
+      else
+        echo "Failed to lower the open file descriptor limit. This can result in delays when connecting to VNC."
+      fi
+    fi
+
     x11vnc ${X11VNC_OPTS} -forever -shared -rfbport ${VNC_PORT:-$SE_VNC_PORT} -rfbportv6 ${VNC_PORT:-$SE_VNC_PORT} -display ${DISPLAY}
   else
     echo "VNC won't start because SE_START_VNC is false."

--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -51,7 +51,7 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ] ; then
       if [ $? -eq 0 ]; then
         echo "Successfully lowered the open file descriptor limit."
       else
-        echo "Failed to lower the open file descriptor limit. This can result in delays when connecting to VNC."
+        echo "The open file descriptor limit could not be updated. This can result in delays when connecting to VNC."
       fi
     fi
 

--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -45,13 +45,13 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ] ; then
     done
 
     # Guard against unreasonably high nofile limits. See https://github.com/SeleniumHQ/docker-selenium/issues/2045
-    if [[ $(ulimit -n) -gt 200000 ]]; then
-      echo "Trying to lower the open file descriptor limit from $(ulimit -n) to 65536."
-      ulimit -n 65536
+    if [[ $(ulimit -n) -gt 200000 || ! -z "${SE_VNC_ULIMIT}" ]]; then
+      echo "Trying to update the open file descriptor limit from $(ulimit -n) to ${SE_VNC_ULIMIT:-65536}."
+      ulimit -n ${SE_VNC_ULIMIT:-65536}
       if [ $? -eq 0 ]; then
-        echo "Successfully lowered the open file descriptor limit."
+        echo "Successfully update the open file descriptor limit."
       else
-        echo "The open file descriptor limit could not be updated. This can result in delays when connecting to VNC."
+        echo "The open file descriptor limit could not be updated."
       fi
     fi
 

--- a/README.md
+++ b/README.md
@@ -1169,6 +1169,8 @@ If you want to run VNC without password authentication you can set the environme
 
 If you want to run VNC in view-only mode you can set the environment variable `SE_VNC_VIEW_ONLY=1`.
 
+If you want to modify the open file descriptor limit for the VNC server process you can set the environment variable `SE_VNC_ULIMIT=4096`.
+
 ### Using your browser (no VNC client is needed)
 
 This project uses [noVNC](https://github.com/novnc/noVNC) to allow users to inspect visually container activity with


### PR DESCRIPTION
### Description
See #2045. Basically what https://github.com/SeleniumHQ/docker-selenium/issues/2045#issuecomment-1849497065 proposed. If the ulimit is high, defensively lower it.

### Motivation and Context
Recent versions of docker in combination with the upstream systemd unit files pass an incredibly high `ulimit -n` to the docker container, up to 1 billion. That causes minute high delays and CPU spinning when connecting to VNC while it enumerates all the file descriptors.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
