### PR TITLE
feat(chart): Simplify to change log level in Kubernetes

### DIFF
--- a/Distributor/start-selenium-grid-distributor.sh
+++ b/Distributor/start-selenium-grid-distributor.sh
@@ -54,6 +54,11 @@ if [ ! -z "$SE_DISTRIBUTOR_PORT" ]; then
   PORT_CONFIG="--port ${SE_DISTRIBUTOR_PORT}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/EventBus/start-selenium-grid-eventbus.sh
+++ b/EventBus/start-selenium-grid-eventbus.sh
@@ -19,6 +19,11 @@ if [ ! -z "$SE_OPTS" ]; then
   echo "Appending Selenium options: ${SE_OPTS}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/Hub/start-selenium-grid-hub.sh
+++ b/Hub/start-selenium-grid-hub.sh
@@ -22,6 +22,11 @@ if [ ! -z "$SE_SUB_PATH" ]; then
   SUB_PATH_CONFIG="--sub-path ${SE_SUB_PATH}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/NodeBase/start-selenium-node.sh
+++ b/NodeBase/start-selenium-node.sh
@@ -36,6 +36,11 @@ if [ ! -z "$SE_NODE_SESSION_TIMEOUT" ]; then
   echo "Appending Selenium node session timeout via SE_OPTS: ${SE_OPTS}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 if [ "$GENERATE_CONFIG" = true ]; then
   echo "Generating Selenium Config"
   /opt/bin/generate_config

--- a/NodeDocker/start-selenium-grid-docker.sh
+++ b/NodeDocker/start-selenium-grid-docker.sh
@@ -29,6 +29,11 @@ if [ ! -z "$SE_NODE_GRID_URL" ]; then
   SE_GRID_URL="--grid-url ${SE_NODE_GRID_URL}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/Router/start-selenium-grid-router.sh
+++ b/Router/start-selenium-grid-router.sh
@@ -54,6 +54,11 @@ if [ ! -z "$SE_ROUTER_PORT" ]; then
   PORT_CONFIG="--port ${SE_ROUTER_PORT}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/SessionQueue/start-selenium-grid-session-queue.sh
+++ b/SessionQueue/start-selenium-grid-session-queue.sh
@@ -19,6 +19,11 @@ if [ ! -z "$SE_SESSION_QUEUE_PORT" ]; then
   PORT_CONFIG="--port ${SE_SESSION_QUEUE_PORT}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/Sessions/start-selenium-grid-sessions.sh
+++ b/Sessions/start-selenium-grid-sessions.sh
@@ -34,6 +34,11 @@ if [ ! -z "$SE_SESSIONS_PORT" ]; then
   PORT_CONFIG="--port ${SE_SESSIONS_PORT}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/Standalone/start-selenium-standalone.sh
+++ b/Standalone/start-selenium-standalone.sh
@@ -11,6 +11,11 @@ if [ ! -z "$SE_OPTS" ]; then
   echo "Appending Selenium options: ${SE_OPTS}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 /opt/bin/generate_config
 
 echo "Selenium Grid Standalone configuration: "

--- a/StandaloneDocker/start-selenium-grid-docker.sh
+++ b/StandaloneDocker/start-selenium-grid-docker.sh
@@ -14,6 +14,11 @@ if [ ! -z "$SE_NODE_GRID_URL" ]; then
   SE_GRID_URL="--grid-url ${SE_NODE_GRID_URL}"
 fi
 
+if [ ! -z "$SE_LOG_LEVEL" ]; then
+  echo "Appending Selenium options: --log-level ${SE_LOG_LEVEL}"
+  SE_OPTS="$SE_OPTS --log-level ${SE_LOG_LEVEL}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: 4.16.1-20231212
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png
 dependencies:
 - repository: https://kedacore.github.io/charts
-  version: 2.12.0
+  version: 2.12.1
   name: keda
   condition: autoscaling.enabled
 maintainers:

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -140,6 +140,7 @@ For now, global configuration supported is:
 | `global.seleniumGrid.imagePullSecret` | `""`                  | Pull secret to be used for all images |
 | `global.seleniumGrid.imagePullSecret` | `""`                  | Pull secret to be used for all images |
 | `global.seleniumGrid.affinity`        | `{}`                  | Affinity assigned globally            |
+| `global.seleniumGrid.logLevel`        | `INFO`                | Set log level for all components      |
 
 This table contains the configuration parameters of the chart and their default values:
 

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -207,6 +207,8 @@ template:
               name: {{ .Values.busConfigMap.name }}
           - configMapRef:
               name: {{ .Values.nodeConfigMap.name }}
+          - configMapRef:
+              name: {{ .Values.loggingConfigMap.name }}
           {{- with .node.extraEnvFrom }}
             {{- tpl (toYaml .) $ | nindent 10 }}
           {{- end }}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -47,6 +47,8 @@ spec:
           envFrom:
             - configMapRef:
                 name: {{ .Values.busConfigMap.name }}
+            - configMapRef:
+                name: {{ .Values.loggingConfigMap.name }}
             {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
             {{- end }}

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -42,10 +42,12 @@ spec:
         {{- with .Values.components.extraEnvironmentVariables }}
           env: {{- tpl (toYaml .) $ | nindent 12 }}
         {{- end }}
-        {{- with .Values.components.extraEnvFrom }}
           envFrom:
+            - configMapRef:
+                name: {{ .Values.loggingConfigMap.name }}
+          {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-        {{- end }}
+          {{- end }}
         {{- with .Values.components.eventBus.resources }}
           resources: {{- toYaml . | nindent 12 }}
         {{- end }}

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -76,10 +76,12 @@ spec:
           {{- with .Values.hub.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-        {{- with .Values.hub.extraEnvFrom }}
           envFrom:
+            - configMapRef:
+                name: {{ .Values.loggingConfigMap.name }}
+          {{- with .Values.hub.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-        {{- end }}
+          {{- end }}
         {{- with .Values.hub.extraVolumeMounts }}
           volumeMounts:
             {{- tpl (toYaml .) $ | nindent 12 }}

--- a/charts/selenium-grid/templates/logging-configmap.yaml
+++ b/charts/selenium-grid/templates/logging-configmap.yaml
@@ -1,0 +1,15 @@
+apiVersion: v1
+kind: ConfigMap
+metadata:
+  name: {{ .Values.loggingConfigMap.name }}
+  namespace: {{ .Release.Namespace }}
+{{- with .Values.loggingConfigMap.annotations }}
+  annotations: {{- toYaml . | nindent 4 }}
+{{- end }}
+  labels:
+    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+data:
+  SE_LOG_LEVEL: "{{ default "INFO" .Values.global.seleniumGrid.logLevel }}"

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -56,10 +56,12 @@ spec:
           {{- with .Values.components.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}
-          {{- with .Values.components.extraEnvFrom }}
           envFrom:
+            - configMapRef:
+                name: {{ .Values.loggingConfigMap.name }}
+            {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-          {{- end }}
+            {{- end }}
           ports:
             - containerPort: {{ .Values.components.router.port }}
               protocol: TCP

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -37,6 +37,8 @@ spec:
         {{- end }}
           envFrom:
             - configMapRef:
+                name: {{ .Values.loggingConfigMap.name }}
+            - configMapRef:
                 name: {{ .Values.busConfigMap.name }}
             {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}

--- a/charts/selenium-grid/templates/session-queuer-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queuer-deployment.yaml
@@ -35,10 +35,12 @@ spec:
         {{- with .Values.components.extraEnvironmentVariables }}
           env: {{- tpl (toYaml .) $ | nindent 12 }}
         {{- end }}
-        {{- with .Values.components.extraEnvFrom }}
           envFrom:
+            - configMapRef:
+                name: {{ .Values.loggingConfigMap.name }}
+          {{- with .Values.components.extraEnvFrom }}
               {{- toYaml . | nindent 12 }}
-        {{- end }}
+          {{- end }}
           ports:
             - containerPort: {{ .Values.components.sessionQueue.port }}
               protocol: TCP

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -10,6 +10,8 @@ global:
     videoImageTag: ffmpeg-6.1-20231212
     # Pull secret for all components, can be overridden individually
     imagePullSecret: ""
+    # Log level for all components. Possible values describe here: https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging
+    logLevel: INFO
 
 # Basic auth settings for Selenium Grid
 basicAuth:
@@ -65,6 +67,12 @@ busConfigMap:
 # ConfigMap that contains common environment variables for browser nodes
 nodeConfigMap:
   name: selenium-node-config
+  # Custom annotations for configmap
+  annotations: {}
+
+# ConfigMap that contains common environment variables for Logging (https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging)
+loggingConfigMap:
+  name: selenium-logging-config
   # Custom annotations for configmap
   annotations: {}
 

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -1,6 +1,7 @@
 # This is dummy values file for chart template testing
 global:
   seleniumGrid:
+    logLevel: FINE
     affinity: &affinity
       podAffinity:
         requiredDuringSchedulingIgnoredDuringExecution:

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -67,6 +67,29 @@ class ChartTemplateTests(unittest.TestCase):
                         is_present = True
         self.assertTrue(is_present, "ENV variable SE_SUB_PATH is not populated")
 
+    def test_log_level_set_to_logging_config_map(self):
+        resources_name = ['selenium-chrome-node', 'selenium-distributor', 'selenium-edge-node', 'selenium-firefox-node',
+                          'selenium-event-bus', 'selenium-router', 'selenium-session-map', 'selenium-session-queue']
+        logger.info(f"Assert log level value is set to logging ConfigMap")
+        count_config = 0
+        for doc in LIST_OF_DOCUMENTS:
+            if doc['metadata']['name'] == 'selenium-logging-config' and doc['kind'] == 'ConfigMap':
+                self.assertTrue(doc['data']['SE_LOG_LEVEL'] == 'FINE')
+                count_config += 1
+        self.assertEqual(count_config, 1, "No logging ConfigMap found")
+        count = 0
+        for doc in LIST_OF_DOCUMENTS:
+            if doc['metadata']['name'] in resources_name and doc['kind'] == 'Deployment':
+                is_present = False
+                logger.info(f"Assert logging ConfigMap is set to envFrom in resource {doc['metadata']['name']}")
+                list_env_from = doc['spec']['template']['spec']['containers'][0]['envFrom']
+                for env in list_env_from:
+                    if env['configMapRef']['name'] == 'selenium-logging-config':
+                        is_present = True
+                self.assertTrue(is_present, "envFrom doesn't contain logging ConfigMap")
+                count += 1
+        self.assertEqual(count, len(resources_name), "Logging ConfigMap is not present in expected resources")
+
 if __name__ == '__main__':
     failed = False
     try:


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
feat(chart): Simplify to change log level in Kubernetes

### Motivation and Context
Sometimes, a few questions related to Selenium Grid deployed on vendors cloud K8s service with issues like Node could not register to Hub, and relevant logs given something like
```bash
10:25:20.758 INFO [NodeServer.execute] - Started Selenium node 4.14.1 (revision 03f8ede370): http://10.244.4.8:5555
10:25:20.777 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
10:25:30.781 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
10:25:40.782 INFO [NodeServer$1.lambda$start$1] - Sending registration event...
```
Then we get back to ask log level `FINE` to see lower debug logs for the problem troubleshooting.
With the Selenium Grid chart, the user needs more steps to do that, find all components and set `extraEnvironmentVariables` within `SE_OPTS=--log-level FINE`

Via this change, we try to simplify this config change by:
- Docker image side: adding a separate ENV `SE_LOG_LEVEL` to get input value, internally it would append value to `SE_OPTS` and start the components
- Chart side:
  - Adding a ConfigMap for logging options (https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging). As of now only `SE_LOG_LEVEL` data is added
  - All other components container ENV refer to that ConfigMap for logging configs. (As the table matrix https://www.selenium.dev/documentation/grid/configuration/cli_options/#sections - Logging supports all components)
  - Chart value `global.seleniumGrid.logLevel` is used to set a specific value.
 
For example: If the user wants to change the log level to `FINE`, now it would be done by
`helm upgrade -i test --set global.seleniumGrid.logLevel=FINE --values myConfigs.yaml selenium-grid-4.16.1-20231218.tgz`

Added the test to ensure template renders config correctly

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
