### PR TITLE
feat(chart): Simplify to access Selenium Grid from outside of Kubernetes

### DIFF
--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -10,6 +10,10 @@ dependencies:
   version: 2.12.1
   name: keda
   condition: autoscaling.enabled
+- repository: https://kubernetes.github.io/ingress-nginx
+  version: 4.8.3
+  name: ingress-nginx
+  condition: ingress-nginx.enabled
 maintainers:
   - name: SeleniumHQ
     email: selenium-developers@googlegroups.com

--- a/charts/selenium-grid/templates/NOTES.txt
+++ b/charts/selenium-grid/templates/NOTES.txt
@@ -9,20 +9,27 @@ Selenium Grid Server deployed successfully.
 {{- if .Values.ingress.enabled }}
     {{- if .Values.ingress.hostname }}
 1. Ingress is enabled, and it exposes the Grid Hub or Grid Router with the hostname you supplied.
-    To access Selenium from outside of Kubernetes, simply open http://{{ .Values.ingress.hostname }}.
-    {{- else}}
+    To access Selenium from outside of Kubernetes, simply open {{ include "seleniumGrid.url" .}}.
+    {{- else if and (empty .Values.ingress.hostname) .Values.global.K8S_PUBLIC_IP }}
+1. Ingress is enabled, but hostname doesn't set, and it exposes the Grid Hub or Grid Router with the K8S_PUBLIC_IP you supplied.
+    To access Selenium from outside of Kubernetes, simply open {{ include "seleniumGrid.url" .}}.
+    {{- else }}
 1. Ingress is enabled, but hostname doesn't set. All inbound HTTP traffic will be routed to the Grid by matching any host.
     Please keep in mind that it is rarely necessary, and in most cases, you shall provide `ingress.hostname` in values.yaml.
     To access Selenium from outside of Kubernetes:
-        - open IP of the any node with Ingress, or
+        - open the IP of any node with Ingress, or
         - any hostname pointing to the node with Ingress
     {{- end}}
 {{- else}}
-1. Ingress is disabled. To access Selenium from outside of Kubernetes, simply run these commands:
     {{- if contains "NodePort" $serviceType }}
-    export NODE_PORT=$(kubectl get -n {{ .Release.Namespace }} -o jsonpath="{.spec.ports[0].nodePort}" svc {{ $svcName }})
+      {{- if .Values.global.K8S_PUBLIC_IP }}
+1. Ingress is disabled, and it exposes the Grid Hub or Grid Router with NodePort and the K8S_PUBLIC_IP you supplied
+    To access Selenium from outside of Kubernetes with NodePort and K8S_PUBLIC_IP you supplied, simply open {{ include "seleniumGrid.url" .}}.
+      {{- else }}
+1. Ingress is disabled. To access Selenium from outside of Kubernetes, simply run these commands:
     export NODE_IP=$(kubectl get nodes -n {{ .Release.Namespace }} -o jsonpath="{.items[0].status.addresses[0].address}")
-    echo http://$NODE_IP:$NODE_PORT
+    echo http://$NODE_IP:{{ include "seleniumGrid.url.port" .}}{{ include "seleniumGrid.url.subPath" .}}
+      {{- end }}
     {{- else if contains "LoadBalancer" $serviceType }}
         NOTE: It may take a few minutes for the LoadBalancer IP to be available.
             You can watch the status of by running 'kubectl get -n {{ .Release.Namespace }} svc -w {{ $svcName }}'

--- a/charts/selenium-grid/templates/distributor-service.yaml
+++ b/charts/selenium-grid/templates/distributor-service.yaml
@@ -23,4 +23,7 @@ spec:
       protocol: TCP
       port: {{ .Values.components.distributor.port }}
       targetPort: {{ .Values.components.distributor.port }}
+      {{- if and (eq .Values.components.distributor.serviceType "NodePort") .Values.components.distributor.nodePort }}
+      nodePort: {{ .Values.components.distributor.nodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/event-bus-service.yaml
+++ b/charts/selenium-grid/templates/event-bus-service.yaml
@@ -23,12 +23,21 @@ spec:
       protocol: TCP
       port: {{ .Values.components.eventBus.port }}
       targetPort: {{ .Values.components.eventBus.port }}
+      {{- if and (eq .Values.components.eventBus.serviceType "NodePort") .Values.components.eventBus.nodePort }}
+      nodePort: {{ .Values.components.eventBus.nodePort }}
+      {{- end }}
     - name: tcp-evtbus-pub
       protocol: TCP
       port: {{ .Values.components.eventBus.publishPort }}
       targetPort: {{ .Values.components.eventBus.publishPort }}
+      {{- if and (eq .Values.components.eventBus.serviceType "NodePort") .Values.components.eventBus.publishNodePort }}
+      nodePort: {{ .Values.components.eventBus.publishNodePort }}
+      {{- end }}
     - name: tcp-evtbus-sub
       protocol: TCP
       port: {{ .Values.components.eventBus.subscribePort }}
       targetPort: {{ .Values.components.eventBus.subscribePort }}
+      {{- if and (eq .Values.components.eventBus.serviceType "NodePort") .Values.components.eventBus.subscribeNodePort }}
+      nodePort: {{ .Values.components.eventBus.subscribeNodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/hub-service.yaml
+++ b/charts/selenium-grid/templates/hub-service.yaml
@@ -26,12 +26,21 @@ spec:
       protocol: TCP
       port: {{ .Values.hub.port }}
       targetPort: {{ .Values.hub.port }}
+      {{- if and (eq .Values.hub.serviceType "NodePort") .Values.hub.nodePort }}
+      nodePort: {{ .Values.hub.nodePort }}
+      {{- end }}
     - name: tcp-hub-pub
       protocol: TCP
       port: {{ .Values.hub.publishPort }}
       targetPort: {{ .Values.hub.publishPort }}
+      {{- if and (eq .Values.hub.serviceType "NodePort") .Values.hub.publishNodePort }}
+      nodePort: {{ .Values.hub.publishNodePort }}
+      {{- end }}
     - name: tcp-hub-sub
       protocol: TCP
       port: {{ .Values.hub.subscribePort }}
       targetPort: {{ .Values.hub.subscribePort }}
+      {{- if and (eq .Values.hub.serviceType "NodePort") .Values.hub.subscribeNodePort }}
+      nodePort: {{ .Values.hub.subscribeNodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/node-configmap.yaml
+++ b/charts/selenium-grid/templates/node-configmap.yaml
@@ -13,4 +13,4 @@ metadata:
     {{- end }}
 data:
   SE_DRAIN_AFTER_SESSION_COUNT: '{{- and (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") | ternary "1" "0" -}}'
-  SE_NODE_GRID_URL: '{{ include "seleniumGrid.url" .}}{{ include "seleniumGrid.url.subPath" .}}'
+  SE_NODE_GRID_URL: '{{ include "seleniumGrid.url" .}}'

--- a/charts/selenium-grid/templates/router-service.yaml
+++ b/charts/selenium-grid/templates/router-service.yaml
@@ -26,4 +26,7 @@ spec:
       protocol: TCP
       port: {{ .Values.components.router.port }}
       targetPort: {{ .Values.components.router.port }}
+      {{- if and (eq $.Values.components.router.serviceType "NodePort") $.Values.components.router.nodePort }}
+      nodePort: {{ $.Values.components.router.nodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/session-queuer-service.yaml
+++ b/charts/selenium-grid/templates/session-queuer-service.yaml
@@ -23,4 +23,7 @@ spec:
       protocol: TCP
       port: {{ .Values.components.sessionQueue.port }}
       targetPort: {{ .Values.components.sessionQueue.port }}
+      {{- if and (eq .Values.components.sessionQueue.serviceType "NodePort") .Values.components.sessionQueue.nodePort }}
+      nodePort: {{ .Values.components.sessionQueue.nodePort }}
+      {{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -1,4 +1,8 @@
 global:
+  # Public IP of the host running Kubernetes cluster.
+  # This is used to access the Selenium Grid from outside the cluster when ingress is disabled or enabled without a hostname is set.
+  # This is part of constructing SE_NODE_GRID_URL and rewrite URL of `se:vnc`, `se:cdp` in the capabilities when `ingress.hostname` is unset
+  K8S_PUBLIC_IP: ""
   seleniumGrid:
     # Image registry for all selenium components
     imageRegistry: selenium
@@ -44,6 +48,9 @@ ingress:
     proxyBuffer:
       size: 512M
       number: 4
+  ports:
+    http: 80
+    https: 443
   # Custom annotations for ingress resource
   annotations: {}
   # Default host for the ingress resource
@@ -96,6 +103,7 @@ components:
     annotations: {}
     # Router port
     port: 4444
+    nodePort: 30444
     # Liveness probe settings
     livenessProbe:
       enabled: true
@@ -148,6 +156,7 @@ components:
     annotations: {}
     # Distributor port
     port: 5553
+    nodePort: 30553
     # Resources for Distributor container
     resources: {}
     # SecurityContext for Distributor container
@@ -180,10 +189,13 @@ components:
     annotations: {}
     # Event Bus port
     port: 5557
+    nodePort: 30557
     # Port where events are published
     publishPort: 4442
+    publishNodePort: 30442
     # Port where to subscribe for events
     subscribePort: 4443
+    subscribeNodePort: 30443
     # Resources for event-bus container
     resources: {}
     # SecurityContext for event-bus container
@@ -246,6 +258,7 @@ components:
     # Custom annotations for Session Queue pods
     annotations: {}
     port: 5559
+    nodePort: 30559
     # Resources for Session Queue container
     resources: {}
     # SecurityContext for Session Queue container
@@ -299,10 +312,13 @@ hub:
   labels: {}
   # Port where events are published
   publishPort: 4442
+  publishNodePort: 31442
   # Port where to subscribe for events
   subscribePort: 4443
+  subscribeNodePort: 31443
   # Selenium Hub port
   port: 4444
+  nodePort: 31444
   # Liveness probe settings
   livenessProbe:
     enabled: true
@@ -387,7 +403,8 @@ autoscaling:
   # see https://keda.sh/docs/latest/concepts/scaling-jobs/#scaledjob-spec
   scaledJobOptions:
     scalingStrategy:
-      strategy: accurate
+      # Change this to "accurate" when the calculation problem is fixed
+      strategy: default
     # Number of Completed jobs should be kept
     successfulJobsHistoryLimit: 0
     # Number of Failed jobs should be kept (for troubleshooting purposes)
@@ -535,8 +552,9 @@ chromeNode:
   hpa:
     url: '{{ include "seleniumGrid.graphqlURL" . }}'
     browserName: chrome
+    sessionBrowserName: 'chrome'
     # browserVersion: '91.0' # Optional. Only required when supporting multiple versions of browser in your Selenium Grid.
-    unsafeSsl: 'true'  # Optional
+    unsafeSsl: '{{ include "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
 
   # It is used to add a sidecars proxy in the same pod of the browser node.
   # It means it will add a new container to the deployment itself.
@@ -668,6 +686,8 @@ firefoxNode:
   hpa:
     url: '{{ include "seleniumGrid.graphqlURL" . }}'
     browserName: firefox
+    sessionBrowserName: 'firefox'
+    unsafeSsl: '{{ include "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
 
   # It is used to add a sidecars proxy in the same pod of the browser node.
   # It means it will add a new container to the deployment itself.
@@ -798,6 +818,7 @@ edgeNode:
     url: '{{ include "seleniumGrid.graphqlURL" . }}'
     browserName: MicrosoftEdge
     sessionBrowserName: 'msedge'
+    unsafeSsl: '{{ include "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
 
   # It is used to add a sidecars proxy in the same pod of the browser node.
   # It means it will add a new container to the deployment itself.
@@ -918,3 +939,17 @@ videoRecorder:
 
 # Custom labels for k8s resources
 customLabels: {}
+
+# Configuration for dependency chart keda
+keda:
+  http:
+    timeout: 60000
+  webhooks:
+    enabled: false
+
+# Configuration for dependency chart ingress-nginx
+ingress-nginx:
+  enabled: false
+  controller:
+    admissionWebhooks:
+      enabled: false

--- a/tests/charts/ci/ParallelAutoscaling-values.yaml
+++ b/tests/charts/ci/ParallelAutoscaling-values.yaml
@@ -31,10 +31,3 @@ ingress:
           name: '{{ template "seleniumGrid.hub.fullname" $ }}'
           port:
             number: 4444
-    - path: /(/?)(session/.*/se/vnc)
-      pathType: ImplementationSpecific
-      backend:
-        service:
-          name: '{{ template "seleniumGrid.hub.fullname" $ }}'
-          port:
-            number: 4444

--- a/tests/charts/ci/auth-ingress-values.yaml
+++ b/tests/charts/ci/auth-ingress-values.yaml
@@ -1,11 +1,16 @@
+global:
+  K8S_PUBLIC_IP: localhost
+
 ingress:
   annotations:
+    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/app-root: &gridAppRoot "/selenium"
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "360"
     nginx.ingress.kubernetes.io/proxy-read-timeout: "360"
     nginx.ingress.kubernetes.io/proxy-send-timeout: "360"
+  ingressClassName: nginx
   hostname: ""
   paths:
     - path: /selenium(/|$)(.*)
@@ -15,16 +20,10 @@ ingress:
           name: '{{ template "seleniumGrid.router.fullname" $ }}'
           port:
             number: 4444
-    - path: /(/?)(session/.*/se/vnc)
-      pathType: ImplementationSpecific
-      backend:
-        service:
-          name: '{{ template "seleniumGrid.router.fullname" $ }}'
-          port:
-            number: 4444
 
 basicAuth:
   enabled: false
+
 isolateComponents: true
 
 hub:
@@ -32,3 +31,11 @@ hub:
 
 components:
   subPath: *gridAppRoot
+
+ingress-nginx:
+  enabled: true
+  controller:
+    hostNetwork: true
+    kind: DaemonSet
+    service:
+      type: ClusterIP

--- a/tests/charts/config/ct.yaml
+++ b/tests/charts/config/ct.yaml
@@ -5,6 +5,7 @@ chart-dirs:
   - charts
 chart-repos:
   - kedacore=https://kedacore.github.io/charts
+  - ingressNginx=https://kubernetes.github.io/ingress-nginx
 upgrade: false
 helm-extra-args: --timeout 600s
 check-version-increment: false

--- a/tests/charts/make/chart_cluster_setup.sh
+++ b/tests/charts/make/chart_cluster_setup.sh
@@ -38,13 +38,6 @@ kind create cluster --wait ${WAIT_TIMEOUT} --name ${CLUSTER_NAME} --config tests
 echo "Install KEDA core on kind kubernetes cluster"
 kubectl apply --server-side -f https://github.com/kedacore/keda/releases/download/v2.12.1/keda-2.12.1-core.yaml
 
-echo "Install ingress-nginx on kind kubernetes cluster"
-kubectl apply -n ${INGRESS_NAMESPACE} -f https://raw.githubusercontent.com/kubernetes/ingress-nginx/main/deploy/static/provider/kind/deploy.yaml
-kubectl wait --namespace ${INGRESS_NAMESPACE} \
-  --for=condition=ready pod \
-  --selector=app.kubernetes.io/component=controller \
-  --timeout=${WAIT_TIMEOUT}
-
 echo "Load built local Docker Images into Kind Cluster"
 image_list=$(docker images --format "{{.Repository}}:{{.Tag}}" | grep ${NAMESPACE} | grep ${VERSION})
 for image in $image_list; do

--- a/tests/charts/refValues/simplex-minikube.yaml
+++ b/tests/charts/refValues/simplex-minikube.yaml
@@ -1,0 +1,95 @@
+# README: This is a sample values for chart deployment in Minikube
+# Chart dependency ingress-nginx is installed together by enabling `ingress-nginx.enabled`
+# Chart dependency keda is installed together by enabling `autoscaling.enable`
+# Enabled ingress without hostname, set the subPath `/selenium`. Set K8S_PUBLIC_IP point to the public host IP, where Minikube is running
+# `ingress-nginx.controller.hostNetwork` is set to true to allow access from outside the cluster via http://<K8S_PUBLIC_IP>/selenium
+# Components serviceType is set to NodePort to allow access from outside the cluster via K8S_PUBLIC_IP and NodePort http://<K8S_PUBLIC_IP>:30444/selenium
+global:
+  K8S_PUBLIC_IP: "10.10.10.10" # Replace with your public IP
+  seleniumGrid:
+    logLevel: INFO
+#    imageRegistry: selenium
+#    imageTag: latest
+#    nodesImageTag: latest
+#    videoImageTag: latest
+
+ingress:
+  enabled: true
+  annotations:
+    kubernetes.io/ingress.class: nginx
+    nginx.ingress.kubernetes.io/use-regex: "true"
+    nginx.ingress.kubernetes.io/rewrite-target: /$2
+    nginx.ingress.kubernetes.io/app-root: &gridAppRoot "/selenium"
+  ingressClassName: nginx
+  hostname: ""
+  paths:
+    - path: /selenium(/|$)(.*)
+      pathType: ImplementationSpecific
+      backend:
+        service:
+          name: '{{ template "seleniumGrid.router.fullname" $ }}'
+          port:
+            number: 4444
+
+basicAuth:
+  enabled: true
+
+isolateComponents: true
+
+autoscaling:
+  enabled: true
+  scalingType: job
+  annotations:
+    helm.sh/hook: post-install,post-upgrade,post-rollback
+  scaledOptions:
+    minReplicaCount: 0
+    maxReplicaCount: 8
+    pollingInterval: 15
+  scaledJobOptions:
+    successfulJobsHistoryLimit: 0
+    failedJobsHistoryLimit: 5
+    scalingStrategy:
+      strategy: default
+
+hub:
+  subPath: *gridAppRoot
+  serviceType: NodePort
+
+components:
+  subPath: *gridAppRoot
+  router:
+    serviceType: NodePort
+
+chromeNode:
+  extraEnvironmentVariables: &extraEnvironmentVariablesNodes
+    - name: SE_NODE_SESSION_TIMEOUT
+      value: "300"
+    - name: SE_VNC_NO_PASSWORD
+      value: "true"
+    - name: SE_OPTS
+      value: "--enable-managed-downloads true"
+  startupProbe: &nodeStartupProbe
+    httpGet:
+      path: /status
+      port: 5555
+    failureThreshold: 120
+    periodSeconds: 1
+
+firefoxNode:
+  extraEnvironmentVariables: *extraEnvironmentVariablesNodes
+  startupProbe: *nodeStartupProbe
+
+edgeNode:
+  extraEnvironmentVariables: *extraEnvironmentVariablesNodes
+  startupProbe: *nodeStartupProbe
+
+videoRecorder:
+  enabled: false
+
+ingress-nginx:
+  enabled: true
+  controller:
+    hostNetwork: true
+    kind: DaemonSet
+    service:
+      type: ClusterIP

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -1,5 +1,6 @@
 # This is dummy values file for chart template testing
 global:
+  K8S_PUBLIC_IP: "10.10.10.10"
   seleniumGrid:
     logLevel: FINE
     affinity: &affinity
@@ -12,6 +13,11 @@ global:
                   values:
                     - selenium
             topologyKey: "kubernetes.io/hostname"
+
+basicAuth:
+  username: sysadmin
+  password: strongPassword
+
 ingress:
   nginx:
     proxyTimeout: 360 # Set different proxy timout
@@ -25,6 +31,9 @@ ingress:
     nginx.ingress.kubernetes.io/proxy-connect-timeout: "3600" # Override default key
     nginx.ingress.kubernetes.io/proxy-send-timeout: "3600" # Override default key
   hostname: ""
+  ports:
+    http: 8081
+    https: 8443
   paths:
     - path: /selenium(/|$)(.*)
       pathType: ImplementationSpecific
@@ -45,6 +54,16 @@ isolateComponents: true
 
 components:
   subPath: *gridAppRoot
+  router:
+    serviceType: NodePort
+  distributor:
+    serviceType: NodePort
+  eventBus:
+    serviceType: NodePort
+  sessionQueue:
+    serviceType: NodePort
+  sessionMap:
+    serviceType: NodePort
 
 chromeNode:
   affinity: *affinity

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -51,7 +51,7 @@ class ChartTemplateTests(unittest.TestCase):
         for doc in LIST_OF_DOCUMENTS:
             if doc['metadata']['name'] in resources_name and doc['kind'] == 'ConfigMap':
                 logger.info(f"Assert subPath is appended to node grid url")
-                self.assertTrue(doc['data']['SE_NODE_GRID_URL'] == 'http://admin:admin@selenium-router.default:4444/selenium')
+                self.assertTrue(doc['data']['SE_NODE_GRID_URL'] == 'http://sysadmin:strongPassword@10.10.10.10:8081/selenium')
                 count += 1
         self.assertEqual(count, len(resources_name), "No node config resources found")
 
@@ -89,6 +89,17 @@ class ChartTemplateTests(unittest.TestCase):
                 self.assertTrue(is_present, "envFrom doesn't contain logging ConfigMap")
                 count += 1
         self.assertEqual(count, len(resources_name), "Logging ConfigMap is not present in expected resources")
+
+    def test_node_port_set_when_service_type_is_node_port(self):
+        single_node_port = {'selenium-distributor': 30553, 'selenium-router': 30444, 'selenium-session-queue': 30559}
+        count = 0
+        logger.info(f"Assert NodePort is set to components service")
+        for doc in LIST_OF_DOCUMENTS:
+            if doc['metadata']['name'] in single_node_port.keys() and doc['kind'] == 'Service':
+                logger.info(f"Assert NodePort is set to service {doc['metadata']['name']}")
+                self.assertTrue(doc['spec']['ports'][0]['nodePort'] == single_node_port[doc['metadata']['name']], f"Service {doc['metadata']['name']} with expect NodePort {single_node_port[doc['metadata']['name']]} is not found")
+                count += 1
+        self.assertEqual(count, len(single_node_port.keys()), "Number of services with NodePort is not correct")
 
 if __name__ == '__main__':
     failed = False


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
feat(chart): Simplify to access Selenium from outside of Kubernetes

### Motivation and Context
- Components service `NodePort` is set static via chart `values.yaml`. NodePort will not be assigned randomly anymore. The user is able to change the values if wants to use another port
- Embedded Ingress NGINX Controller as dependency chart and is enabled via `ingress-nginx.enabled=true`. Instead of the user having to find and download the ingress chart separately, the user can utilize this dependent chart and install it together with the Selenium Grid.
- Add config `ingress.ports.http` and `ingress.ports.https` to set specific ports in case your ingress not using default `80` and `443`. This is used to construct the `SE_NODE_GRID_URL` which is important for Grid can be accessed from outside (e.g Distributed Nodes register to Hub, Grid UI, Session NoVNC/CDP URL, etc.
- Add config `global.K8S_PUBLIC_IP` for user can set the public IP of the host running the Kubernetes cluster, which is used to construct the `SE_NODE_GRID_URL` in such use cases:
  - Ingress is enabled without setting `ingress.hostname`. All the services will be exposed via the public IP is set in `K8S_PUBLIC_IP`
  - Using NodePort to expose the services. All the services will be exposed via the public IP is set in `K8S_PUBLIC_IP`
  - Using LoadBalancer to expose the services. All the services will be exposed via the LB External IP is set in `K8S_PUBLIC_IP`

- Some values files are used to test and deploy the Selenium Grid chart. Users can find them in
  - [tests/charts/refValues](tests/charts/refValues).
  - [tests/charts/ci](tests/charts/ci).

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
