### PR TITLE
feat(chart): Simplify config ports, probes, lifecycle hooks for Nodes

### DIFF
--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -67,10 +67,10 @@ jobs:
         with:
           name: ${{ matrix.test-strategy }}_${{ env.CHART_FILE_NAME }}
           path: ${{ env.CHART_PACKAGE_PATH }}
-      - name: Upload Helm chart template rendered
+      - name: Upload chart test artifacts
         if: always()
         uses: actions/upload-artifact@v4
         with:
-          name: ${{ matrix.test-strategy }}_chart_template_rendered.yaml
-          path: ./tests/tests/output_deployment.yaml
+          name: ${{ matrix.test-strategy }}-artifacts
+          path: ./tests/tests/
           if-no-files-found: ignore

--- a/Makefile
+++ b/Makefile
@@ -395,7 +395,7 @@ chart_test_edge:
 	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh NodeEdge
 
 chart_test_parallel_autoscaling:
-	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh ParallelAutoscaling
+	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh JobAutoscaling
 
 .PHONY: \
 	all \

--- a/charts/selenium-grid/TESTING.md
+++ b/charts/selenium-grid/TESTING.md
@@ -10,7 +10,7 @@ All related testing to this helm chart will be documented in this file.
 |                        | Basic Auth is enabled                                                | &cross;  |          |
 | Auto scaling           | Auto scaling with `enableWithExistingKEDA` is `true`                 | &check;  | Cluster  |
 |                        | Auto scaling with `scalingType` is `job`                             | &check;  | Cluster  |
-|                        | Auto scaling with `scalingType` is `deployment`                      | &cross;  |          |
+|                        | Auto scaling with `scalingType` is `deployment`                      | &check;  | Cluster  |
 |                        | Auto scaling with `autoscaling.scaledOptions.minReplicaCount` is `0` | &check;  | Cluster  |
 |                        | Parallel tests execution against node autoscaling                    | &check;  | Cluster  |
 | Ingress                | Ingress is enabled without `hostname`                                | &check;  | Cluster  |
@@ -27,6 +27,10 @@ All related testing to this helm chart will be documented in this file.
 |                        | Components are able to set `.affinity`                               | &check;  | Template |
 | Tracing                | Enable tracing via `SE_ENABLE_TRACING`                               | &check;  | Cluster  |
 |                        | Disable tracing via `SE_ENABLE_TRACING`                              | &check;  | Cluster  |
+| `Node` component       | `SE_NODE_PORT` can set a port different via `.port`                  | &check;  | Cluster  |
+|                        | Extra ports can be exposed on container via `.ports`                 | &check;  | Cluster  |
+|                        | Extra ports can be exposed on Service via `.service.ports`           | &check;  | Cluster  |
+|                        | Service type change to `NodePort`, specific NodePort can be set      | &check;  | Cluster  |
 
 ## Test Chart Template
 - By using `helm template` command, the chart template is tested without installing it to Kubernetes cluster.

--- a/charts/selenium-grid/templates/chrome-node-service.yaml
+++ b/charts/selenium-grid/templates/chrome-node-service.yaml
@@ -22,8 +22,11 @@ spec:
   ports:
     - name: tcp-chrome
       protocol: TCP
-      port: {{ .Values.chromeNode.seleniumServicePort }}
-      targetPort: {{ .Values.chromeNode.seleniumPort }}
+      port: {{ .Values.chromeNode.port }}
+      targetPort: {{ .Values.chromeNode.port }}
+      {{- if and (eq $.Values.chromeNode.service.type "NodePort") .Values.chromeNode.nodePort }}
+      nodePort: {{ .Values.chromeNode.nodePort }}
+      {{- end }}
   {{- with .Values.chromeNode.service.ports }}
     {{- range . }}
     - name: {{ .name }}

--- a/charts/selenium-grid/templates/edge-node-service.yaml
+++ b/charts/selenium-grid/templates/edge-node-service.yaml
@@ -22,8 +22,11 @@ spec:
   ports:
     - name: tcp-edge
       protocol: TCP
-      port: {{ .Values.edgeNode.seleniumServicePort }}
-      targetPort: {{ .Values.edgeNode.seleniumPort }}
+      port: {{ .Values.edgeNode.port }}
+      targetPort: {{ .Values.edgeNode.port }}
+      {{- if and (eq $.Values.edgeNode.service.type "NodePort") .Values.edgeNode.nodePort }}
+      nodePort: {{ .Values.edgeNode.nodePort }}
+      {{- end }}
   {{- with .Values.edgeNode.service.ports }}
     {{- range . }}
     - name: {{ .name }}

--- a/charts/selenium-grid/templates/event-bus-configmap.yaml
+++ b/charts/selenium-grid/templates/event-bus-configmap.yaml
@@ -1,4 +1,4 @@
-{{- $eventBusHost := ternary (include "seleniumGrid.eventBus.fullname" .) (include "seleniumGrid.hub.fullname" .) .Values.isolateComponents -}}
+{{- $eventBusHost := printf "%s.%s" (ternary (include "seleniumGrid.eventBus.fullname" .) (include "seleniumGrid.hub.fullname" .) .Values.isolateComponents) (.Release.Namespace) -}}
 {{- $eventBusPublishPort := ternary .Values.components.eventBus.publishPort .Values.hub.publishPort .Values.isolateComponents -}}
 {{- $eventBusSubscribePort := ternary .Values.components.eventBus.subscribePort .Values.hub.subscribePort .Values.isolateComponents -}}
 apiVersion: v1

--- a/charts/selenium-grid/templates/firefox-node-service.yaml
+++ b/charts/selenium-grid/templates/firefox-node-service.yaml
@@ -22,8 +22,11 @@ spec:
   ports:
     - name: tcp-firefox
       protocol: TCP
-      port: {{ .Values.firefoxNode.seleniumServicePort }}
-      targetPort: {{ .Values.firefoxNode.seleniumPort }}
+      port: {{ .Values.firefoxNode.port }}
+      targetPort: {{ .Values.firefoxNode.port }}
+      {{- if and (eq $.Values.firefoxNode.service.type "NodePort") .Values.firefoxNode.nodePort }}
+      nodePort: {{ .Values.firefoxNode.nodePort }}
+      {{- end }}
   {{- with .Values.firefoxNode.service.ports }}
     {{- range . }}
     - name: {{ .name }}

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -42,27 +42,53 @@ spec:
               protocol: TCP
             - containerPort: {{ .Values.hub.subscribePort }}
               protocol: TCP
-        {{- if .Values.hub.livenessProbe.enabled }}
-          livenessProbe:
+        {{- if .Values.hub.startupProbe.enabled }}
+          {{- with .Values.hub.startupProbe }}
+          startupProbe:
+          {{- if (ne (include "seleniumGrid.probe.fromUserDefine" .) "{}") }}
+            {{- include "seleniumGrid.probe.fromUserDefine" . | nindent 10 }}
+          {{- else }}
             httpGet:
-              path: {{ .Values.hub.livenessProbe.path }}
-              port: {{ .Values.hub.port }}
-            initialDelaySeconds: {{ .Values.hub.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.hub.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.hub.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.hub.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.hub.livenessProbe.failureThreshold }}
+              scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" .) .schema }}
+              path: {{ .path }}
+              port: {{ default ($.Values.hub.port) .port }}
+          {{- end }}
+          {{- if (ne (include "seleniumGrid.probe.settings" .) "{}") }}
+            {{- include "seleniumGrid.probe.settings" . | nindent 12 }}
+          {{- end }}
+          {{- end }}
         {{- end }}
         {{- if .Values.hub.readinessProbe.enabled }}
+          {{- with .Values.hub.readinessProbe }}
           readinessProbe:
+          {{- if (ne (include "seleniumGrid.probe.fromUserDefine" .) "{}") }}
+            {{- include "seleniumGrid.probe.fromUserDefine" . | nindent 10 }}
+          {{- else }}
             httpGet:
-              path: {{ .Values.hub.readinessProbe.path }}
-              port: {{ .Values.hub.port }}
-            initialDelaySeconds: {{ .Values.hub.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.hub.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.hub.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.hub.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.hub.readinessProbe.failureThreshold }}
+              scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" .) .schema }}
+              path: {{ .path }}
+              port: {{ default ($.Values.hub.port) .port }}
+          {{- end }}
+          {{- if (ne (include "seleniumGrid.probe.settings" .) "{}") }}
+            {{- include "seleniumGrid.probe.settings" . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.hub.livenessProbe.enabled }}
+          {{- with .Values.hub.livenessProbe }}
+          livenessProbe:
+          {{- if (ne (include "seleniumGrid.probe.fromUserDefine" .) "{}") }}
+            {{- include "seleniumGrid.probe.fromUserDefine" . | nindent 10 }}
+          {{- else }}
+            httpGet:
+              scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" .) .schema }}
+              path: {{ .path }}
+              port: {{ default ($.Values.hub.port) .port }}
+          {{- end }}
+          {{- if (ne (include "seleniumGrid.probe.settings" .) "{}") }}
+            {{- include "seleniumGrid.probe.settings" . | nindent 12 }}
+          {{- end }}
+          {{- end }}
         {{- end }}
           env:
             {{- with .Values.hub.subPath }}

--- a/charts/selenium-grid/templates/node-configmap.yaml
+++ b/charts/selenium-grid/templates/node-configmap.yaml
@@ -14,3 +14,11 @@ metadata:
 data:
   SE_DRAIN_AFTER_SESSION_COUNT: '{{- and (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") | ternary "1" "0" -}}'
   SE_NODE_GRID_URL: '{{ include "seleniumGrid.url" .}}'
+  {{ .Values.nodeConfigMap.preStopScript }}: |
+    #!/bin/bash
+    if curl -sf 127.0.0.1:${SE_NODE_PORT}/status; then
+        curl -X POST 127.0.0.1:${SE_NODE_PORT}/se/grid/node/drain --header 'X-REGISTRATION-SECRET;'
+        while curl -sf 127.0.0.1:${SE_NODE_PORT}/status; do sleep 1; done
+    else
+        echo "Node is already drained. Shutting down gracefully!"
+    fi

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -67,27 +67,54 @@ spec:
           ports:
             - containerPort: {{ .Values.components.router.port }}
               protocol: TCP
-        {{- if .Values.components.router.livenessProbe.enabled }}
-          livenessProbe:
+        {{- if .Values.components.router.startupProbe.enabled }}
+          {{- with .Values.components.router.startupProbe }}
+          startupProbe:
+          {{- if (ne (include "seleniumGrid.probe.fromUserDefine" .) "{}") }}
+            {{- include "seleniumGrid.probe.fromUserDefine" . | nindent 10 }}
+          {{- else }}
             httpGet:
-              path: {{ .Values.components.router.livenessProbe.path }}
-              port: {{ .Values.components.router.port }}
-            initialDelaySeconds: {{ .Values.components.router.livenessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.components.router.livenessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.components.router.livenessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.components.router.livenessProbe.successThreshold }}
-            failureThreshold: {{ .Values.components.router.livenessProbe.failureThreshold }}
+              scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" .) .schema }}
+              path: {{ .path }}
+              port: {{ default ($.Values.components.router.port) .port }}
+          {{- end }}
+          {{- if (ne (include "seleniumGrid.probe.settings" .) "{}") }}
+            {{- include "seleniumGrid.probe.settings" . | nindent 12 }}
+          {{- end }}
+          {{- end }}
         {{- end }}
         {{- if .Values.components.router.readinessProbe.enabled }}
+          {{- with .Values.components.router.readinessProbe }}
           readinessProbe:
+          {{- if (ne (include "seleniumGrid.probe.fromUserDefine" .) "{}") }}
+            {{- include "seleniumGrid.probe.fromUserDefine" . | nindent 10 }}
+          {{- else }}
             httpGet:
-              path: {{ .Values.components.router.readinessProbe.path }}
-              port: {{ .Values.components.router.port }}
-            initialDelaySeconds: {{ .Values.components.router.readinessProbe.initialDelaySeconds }}
-            periodSeconds: {{ .Values.components.router.readinessProbe.periodSeconds }}
-            timeoutSeconds: {{ .Values.components.router.readinessProbe.timeoutSeconds }}
-            successThreshold: {{ .Values.components.router.readinessProbe.successThreshold }}
-            failureThreshold: {{ .Values.components.router.readinessProbe.failureThreshold }}
+              scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" .) .schema }}
+              path: {{ .path }}
+              port: {{ default ($.Values.components.router.port) .port }}
+          {{- end }}
+          {{- if (ne (include "seleniumGrid.probe.settings" .) "{}") }}
+            {{- include "seleniumGrid.probe.settings" . | nindent 12 }}
+          {{- end }}
+          {{- end }}
+        {{- end }}
+        {{- if .Values.components.router.livenessProbe.enabled }}
+          livenessProbe:
+          {{- with .Values.components.router.livenessProbe }}
+          livenessProbe:
+          {{- if (ne (include "seleniumGrid.probe.fromUserDefine" .) "{}") }}
+            {{- include "seleniumGrid.probe.fromUserDefine" . | nindent 10 }}
+          {{- else }}
+            httpGet:
+              scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" .) .schema }}
+              path: {{ .path }}
+              port: {{ default ($.Values.components.router.port) .port }}
+          {{- end }}
+          {{- if (ne (include "seleniumGrid.probe.settings" .) "{}") }}
+            {{- include "seleniumGrid.probe.settings" . | nindent 12 }}
+          {{- end }}
+          {{- end }}
         {{- end }}
         {{- with .Values.components.router.resources }}
           resources: {{- toYaml . | nindent 12 }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -74,6 +74,12 @@ busConfigMap:
 # ConfigMap that contains common environment variables for browser nodes
 nodeConfigMap:
   name: selenium-node-config
+  # Default mode for ConfigMap is mounted as file
+  defaultMode: 0755
+  # File name of preStop script in ConfigMap
+  preStopScript: nodePreStop.sh
+  # Name of volume mount is used to mount scripts in the ConfigMap
+  scriptVolumeMountName: node-helper-scripts
   # Custom annotations for configmap
   annotations: {}
 
@@ -104,11 +110,11 @@ components:
     # Router port
     port: 4444
     nodePort: 30444
-    # Liveness probe settings
-    livenessProbe:
+    # Wait for pod startup
+    startupProbe:
       enabled: true
       path: /readyz
-      initialDelaySeconds: 10
+      initialDelaySeconds: 5
       failureThreshold: 10
       timeoutSeconds: 10
       periodSeconds: 10
@@ -118,6 +124,15 @@ components:
       enabled: true
       path: /readyz
       initialDelaySeconds: 12
+      failureThreshold: 10
+      timeoutSeconds: 10
+      periodSeconds: 10
+      successThreshold: 1
+    # Liveness probe settings
+    livenessProbe:
+      enabled: true
+      path: /readyz
+      initialDelaySeconds: 10
       failureThreshold: 10
       timeoutSeconds: 10
       periodSeconds: 10
@@ -319,11 +334,11 @@ hub:
   # Selenium Hub port
   port: 4444
   nodePort: 31444
-  # Liveness probe settings
-  livenessProbe:
+  # Wait for pod startup
+  startupProbe:
     enabled: true
     path: /readyz
-    initialDelaySeconds: 10
+    initialDelaySeconds: 5
     failureThreshold: 10
     timeoutSeconds: 10
     periodSeconds: 10
@@ -333,6 +348,15 @@ hub:
     enabled: true
     path: /readyz
     initialDelaySeconds: 12
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
+  # Liveness probe settings
+  livenessProbe:
+    enabled: true
+    path: /readyz
+    initialDelaySeconds: 10
     failureThreshold: 10
     timeoutSeconds: 10
     periodSeconds: 10
@@ -418,15 +442,13 @@ autoscaling:
   scaledObjectOptions:
     scaleTargetRef:
       kind: Deployment
+  # Define terminationGracePeriodSeconds for scalingType "deployment". Period for `deregisterLifecycle` to gracefully shut down the node before force killing it
+  terminationGracePeriodSeconds: 3600
+  # Define preStop command to shuts down the node gracefully when scalingType is set to "deployment"
   deregisterLifecycle:
-    preStop:
-      exec:
-        command:
-          - bash
-          - -c
-          - |
-            curl -X POST 127.0.0.1:5555/se/grid/node/drain --header 'X-REGISTRATION-SECRET;' && \
-            while curl 127.0.0.1:5555/status; do sleep 1; done;
+  #  preStop:
+  #    exec:
+  #      command: [ "bash", "-c", "/opt/selenium/nodePreStop.sh" ]
 
 # Configuration for chrome nodes
 chromeNode:
@@ -451,13 +473,13 @@ chromeNode:
   # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
   imagePullSecret: ""
 
-  # Port list to enable on container
-  ports:
-    - 5555
-  # Selenium port (spec.ports[0].targetPort in kubernetes service)
-  seleniumPort: 5900
-  # Selenium port exposed in service (spec.ports[0].port in kubernetes service)
-  seleniumServicePort: 6900
+  # Extra ports list to enable on the node container (e.g. SSH, VNC, NoVNC, etc.)
+  ports: []
+  # - 5900
+  # - 7900
+  # Node component port
+  port: 5555
+  nodePort:
   # Annotations for chrome-node pods
   annotations: {}
   # Labels for chrome-node pods
@@ -510,9 +532,9 @@ chromeNode:
     loadBalancerIP: ""
     # Extra ports exposed in node service
     ports:
-    # - name: node-port
-    #   port: 5555
-    #   targetPort: 5555
+    # - name: vnc-port
+    #   port: 5900
+    #   targetPort: 5900
     # Custom annotations for service
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
@@ -521,18 +543,40 @@ chromeNode:
   priorityClassName: ""
 
   # Wait for pod startup
-  startupProbe: {}
-    # httpGet:
-    #   path: /status
-    #   port: 5555
-    # failureThreshold: 120
-    # periodSeconds: 5
+  startupProbe:
+    enabled: true
+    path: /status
+    initialDelaySeconds: 0
+    failureThreshold: 10
+    timeoutSeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+
+  # Readiness probe settings
+  readinessProbe:
+    enabled: false
+    path: /status
+    initialDelaySeconds: 10
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
 
   # Liveness probe settings
-  livenessProbe: {}
+  livenessProbe:
+    enabled: false
+    path: /status
+    initialDelaySeconds: 15
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
 
   # Time to wait for pod termination
   terminationGracePeriodSeconds: 30
+  # Define preStop command to shuts down the chrome node gracefully. This overwrites autoscaling.deregisterLifecycle
+  deregisterLifecycle:
+  # Define postStart and preStop events. This overwrites the defined preStop in deregisterLifecycle if any
   lifecycle: {}
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -585,13 +629,13 @@ firefoxNode:
   # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
   imagePullSecret: ""
 
-  # Port list to enable on container
-  ports:
-    - 5555
-  # Selenium port (spec.ports[0].targetPort in kubernetes service)
-  seleniumPort: 5900
-  # Selenium port exposed in service (spec.ports[0].port in kubernetes service)
-  seleniumServicePort: 6900
+  # Extra ports list to enable on the node container (e.g. SSH, VNC, NoVNC, etc.)
+  ports: []
+  # - 5900
+  # - 7900
+  # Node component port
+  port: 5555
+  nodePort:
   # Annotations for firefox-node pods
   annotations: {}
   # Labels for firefox-node pods
@@ -644,9 +688,9 @@ firefoxNode:
     loadBalancerIP: ""
     # Extra ports exposed in node service
     ports:
-    # - name: node-port
-    #   port: 5555
-    #   targetPort: 5555
+    # - name: vnc-port
+    #   port: 5900
+    #   targetPort: 5900
     # Custom annotations for service
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
@@ -655,18 +699,40 @@ firefoxNode:
   priorityClassName: ""
 
   # Wait for pod startup
-  startupProbe: {}
-    # httpGet:
-    #   path: /status
-    #   port: 5555
-    # failureThreshold: 120
-    # periodSeconds: 5
+  startupProbe:
+    enabled: true
+    path: /status
+    initialDelaySeconds: 0
+    failureThreshold: 10
+    timeoutSeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+
+  # Readiness probe settings
+  readinessProbe:
+    enabled: false
+    path: /status
+    initialDelaySeconds: 10
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
 
   # Liveness probe settings
-  livenessProbe: {}
+  livenessProbe:
+    enabled: false
+    path: /status
+    initialDelaySeconds: 15
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
 
   # Time to wait for pod termination
   terminationGracePeriodSeconds: 30
+  # Define preStop command to shuts down the chrome node gracefully. This overwrites autoscaling.deregisterLifecycle
+  deregisterLifecycle:
+  # Define postStart and preStop events. This overwrites the defined preStop in deregisterLifecycle if any
   lifecycle: {}
   extraVolumeMounts: []
   # - name: my-extra-volume
@@ -717,12 +783,13 @@ edgeNode:
   # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
   imagePullSecret: ""
 
-  ports:
-    - 5555
-  # Selenium port (spec.ports[0].targetPort in kubernetes service)
-  seleniumPort: 5900
-  # Selenium port exposed in service (spec.ports[0].port in kubernetes service)
-  seleniumServicePort: 6900
+  # Extra ports list to enable on the node container (e.g. SSH, VNC, NoVNC, etc.)
+  ports: []
+  # - 5900
+  # - 7900
+  # Node component port
+  port: 5555
+  nodePort:
   # Annotations for edge-node pods
   annotations: {}
   # Labels for edge-node pods
@@ -775,9 +842,9 @@ edgeNode:
     loadBalancerIP: ""
     # Extra ports exposed in node service
     ports:
-    # - name: node-port
-    #   port: 5555
-    #   targetPort: 5555
+    # - name: vnc-port
+    #   port: 5900
+    #   targetPort: 5900
     # Custom annotations for service
     annotations: {}
   # Size limit for DSH volume mounted in container (if not set, default is "1Gi")
@@ -786,18 +853,40 @@ edgeNode:
   priorityClassName: ""
 
   # Wait for pod startup
-  startupProbe: {}
-    # httpGet:
-    #   path: /status
-    #   port: 5555
-    # failureThreshold: 120
-    # periodSeconds: 5
+  startupProbe:
+    enabled: true
+    path: /status
+    initialDelaySeconds: 0
+    failureThreshold: 10
+    timeoutSeconds: 5
+    periodSeconds: 5
+    successThreshold: 1
+
+  # Readiness probe settings
+  readinessProbe:
+    enabled: false
+    path: /status
+    initialDelaySeconds: 10
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
 
   # Liveness probe settings
-  livenessProbe: {}
+  livenessProbe:
+    enabled: false
+    path: /status
+    initialDelaySeconds: 15
+    failureThreshold: 10
+    timeoutSeconds: 10
+    periodSeconds: 10
+    successThreshold: 1
 
   # Time to wait for pod termination
   terminationGracePeriodSeconds: 30
+  # Define preStop command to shuts down the chrome node gracefully. This overwrites autoscaling.deregisterLifecycle
+  deregisterLifecycle:
+  # Define postStart and preStop events. This overwrites the defined preStop in deregisterLifecycle if any
   lifecycle: {}
   extraVolumeMounts: []
   # - name: my-extra-volume

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -127,7 +127,7 @@ class FirefoxTests(SeleniumGenericTests):
         self.driver.maximize_window()
         self.assertTrue(self.driver.title == 'The Internet')
 
-class ParallelAutoscaling():
+class JobAutoscaling():
     def run(self, test_classes):
         with concurrent.futures.ThreadPoolExecutor() as executor:
             futures = []
@@ -138,7 +138,7 @@ class ParallelAutoscaling():
             for future in concurrent.futures.as_completed(futures):
                 future.result()
 
-class ParallelAutoscalingTests(unittest.TestCase):
+class JobAutoscalingTests(unittest.TestCase):
     def test_parallel_autoscaling(self):
-        runner = ParallelAutoscaling()
+        runner = JobAutoscaling()
         runner.run([ChromeTests, EdgeTests, FirefoxTests])

--- a/tests/charts/bootstrap.sh
+++ b/tests/charts/bootstrap.sh
@@ -13,9 +13,9 @@ python -m pip install pyyaml==6.0.1 \
 
 cd ..
 helm template dummy --values tests/charts/templates/render/dummy.yaml \
-  charts/selenium-grid > ./tests/tests/output_deployment.yaml
+  charts/selenium-grid > ./tests/tests/dummy_template_manifests.yaml
 
-python tests/charts/templates/test.py "./tests/tests/output_deployment.yaml"
+python tests/charts/templates/test.py "./tests/tests/dummy_template_manifests.yaml"
 ret_code=$?
 
 if [ "${CI:-false}" = "false" ]; then

--- a/tests/charts/ci/DeploymentAutoScaling-values.yaml
+++ b/tests/charts/ci/DeploymentAutoScaling-values.yaml
@@ -1,0 +1,72 @@
+autoscaling:
+  enableWithExistingKEDA: true
+  scalingType: deployment
+  scaledOptions:
+    minReplicaCount: 0
+    maxReplicaCount: 3
+  scaledObjectOptions:
+    cooldownPeriod: 30
+  terminationGracePeriodSeconds: 360
+# Configuration for chrome nodes
+chromeNode:
+  # (test): user is able to change `SE_NODE_PORT`
+  port: 6666
+  # (test): user is able to set NodePort to expose `SE_NODE_PORT`
+  nodePort: 30666
+  # (test): user is able to define list extra container ports
+  ports:
+    - 5900
+    - 7900
+  service:
+    type: NodePort
+    # (test): user is able to define extra ports for Node service
+    ports:
+      - name: vnc-port
+        protocol: TCP
+        port: 5900
+        targetPort: 5900
+        nodePort: 30590
+      - name: novnc-port
+        protocol: TCP
+        port: 7900
+        targetPort: 7900
+        # NodePort will be assigned randomly if not set
+  nameOverride: my-chrome-name
+  extraEnvironmentVariables: &extraEnvironmentVariables
+    - name: SE_OPTS
+      value: "--enable-managed-downloads true"
+    - name: SE_DRAIN_AFTER_SESSION_COUNT
+      value: "0"
+  readinessProbe:
+    enabled: &readinessProbe true
+  livenessProbe:
+    enabled: &livenessProbe true
+# Configuration for edge nodes
+edgeNode:
+  # (test): user is able to define extra container ports
+  ports:
+    - containerPort: 5900
+      name: vnc
+      protocol: TCP
+    - containerPort: 7900
+      name: novnc
+      protocol: TCP
+  nameOverride: my-edge-name
+  extraEnvironmentVariables: *extraEnvironmentVariables
+  # (test): user is able to override probe method
+  startupProbe:
+    enabled: true
+    tcpSocket:
+      port: 8888
+  readinessProbe:
+    enabled: *readinessProbe
+  livenessProbe:
+    enabled: *livenessProbe
+# Configuration for firefox nodes
+firefoxNode:
+  nameOverride: my-firefox-name
+  extraEnvironmentVariables: *extraEnvironmentVariables
+  readinessProbe:
+    enabled: *readinessProbe
+  livenessProbe:
+    enabled: *livenessProbe

--- a/tests/charts/ci/JobAutoscaling-values.yaml
+++ b/tests/charts/ci/JobAutoscaling-values.yaml
@@ -1,26 +1,43 @@
 isolateComponents: false
+
 autoscaling:
+  enableWithExistingKEDA: true
+  scalingType: job
   strategy: default
   scaledOptions:
     minReplicaCount: 0
     maxReplicaCount: 5
+    pollingInterval: 20
+# Configuration for chrome nodes
 chromeNode:
   nameOverride: my-chrome-name
   extraEnvironmentVariables:
     - name: SE_OPTS
       value: "--enable-managed-downloads true"
+  readinessProbe:
+    enabled: &readinessProbe false
+  livenessProbe:
+    enabled: &livenessProbe false
 # Configuration for edge nodes
 edgeNode:
   nameOverride: my-edge-name
   extraEnvironmentVariables:
     - name: SE_OPTS
       value: "--enable-managed-downloads true"
+  readinessProbe:
+    enabled: *readinessProbe
+  livenessProbe:
+    enabled: *livenessProbe
 # Configuration for firefox nodes
 firefoxNode:
   nameOverride: my-firefox-name
   extraEnvironmentVariables:
     - name: SE_OPTS
       value: "--enable-managed-downloads true"
+  readinessProbe:
+    enabled: *readinessProbe
+  livenessProbe:
+    enabled: *livenessProbe
 
 ingress:
   paths:

--- a/tests/charts/ci/NodeChrome-values.yaml
+++ b/tests/charts/ci/NodeChrome-values.yaml
@@ -1,6 +1,7 @@
 # This is used in Helm chart testing
 # Configuration for chrome nodes
 chromeNode:
+  port: 6666
   nameOverride: my-chrome-name
   extraEnvironmentVariables:
     - name: SE_OPTS

--- a/tests/charts/ci/NodeEdge-values.yaml
+++ b/tests/charts/ci/NodeEdge-values.yaml
@@ -4,6 +4,7 @@ chromeNode:
   enabled: false
 # Configuration for edge nodes
 edgeNode:
+  port: 8888
   nameOverride: my-edge-name
   extraEnvironmentVariables:
     - name: SE_OPTS

--- a/tests/charts/ci/NodeFirefox-values.yaml
+++ b/tests/charts/ci/NodeFirefox-values.yaml
@@ -7,6 +7,7 @@ edgeNode:
   enabled: false
 # Configuration for firefox nodes
 firefoxNode:
+  port: 7777
   nameOverride: my-firefox-name
   extraEnvironmentVariables:
     - name: SE_OPTS

--- a/tests/charts/ci/autoscaling-values.yaml
+++ b/tests/charts/ci/autoscaling-values.yaml
@@ -1,5 +1,0 @@
-autoscaling:
-  enableWithExistingKEDA: true
-  scalingType: job
-  scaledOptions:
-    minReplicaCount: 0

--- a/tests/charts/refValues/sample-aws.yaml
+++ b/tests/charts/refValues/sample-aws.yaml
@@ -60,20 +60,12 @@ chromeNode:
       value: "true"
     - name: SE_OPTS
       value: "--enable-managed-downloads true"
-  startupProbe: &nodeStartupProbe
-    httpGet:
-      path: /status
-      port: 5555
-    failureThreshold: 120
-    periodSeconds: 1
 
 firefoxNode:
   extraEnvironmentVariables: *extraEnvironmentVariablesNodes
-  startupProbe: *nodeStartupProbe
 
 edgeNode:
   extraEnvironmentVariables: *extraEnvironmentVariablesNodes
-  startupProbe: *nodeStartupProbe
 
 videoRecorder:
   enabled: false

--- a/tests/charts/refValues/simplex-minikube.yaml
+++ b/tests/charts/refValues/simplex-minikube.yaml
@@ -33,7 +33,7 @@ ingress:
             number: 4444
 
 basicAuth:
-  enabled: true
+  enabled: false
 
 isolateComponents: true
 
@@ -69,20 +69,12 @@ chromeNode:
       value: "true"
     - name: SE_OPTS
       value: "--enable-managed-downloads true"
-  startupProbe: &nodeStartupProbe
-    httpGet:
-      path: /status
-      port: 5555
-    failureThreshold: 120
-    periodSeconds: 1
 
 firefoxNode:
   extraEnvironmentVariables: *extraEnvironmentVariablesNodes
-  startupProbe: *nodeStartupProbe
 
 edgeNode:
   extraEnvironmentVariables: *extraEnvironmentVariablesNodes
-  startupProbe: *nodeStartupProbe
 
 videoRecorder:
   enabled: false

--- a/tests/test.py
+++ b/tests/test.py
@@ -57,7 +57,7 @@ TEST_NAME_MAP = {
     'StandaloneFirefox': 'FirefoxTests',
 
     # Chart Parallel Test
-    'ParallelAutoscaling': 'ParallelAutoscalingTests'
+    'JobAutoscaling': 'JobAutoscalingTests'
 }
 
 FROM_IMAGE_ARGS = {


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
feat(chart): Simplify config ports, probes, and lifecycle hooks for Nodes

### Motivation and Context

---

### Configuration of Nodes

#### Container ports and Service ports

By default, Node will use port `5555` to listen on container (following [this](https://www.selenium.dev/documentation/grid/configuration/cli_options/#server)) and expose via Service. You can update this value via `.port` in respective node type. This will be used to set `SE_NODE_PORT` environment variable to pass to option `--port` when starting the node and update in Service accordingly.

By default, if httpGet probes are enabled, it will use `.port` value in respective node type unless you override it via e.g. `.startupProbe.port` `.readinessProbe.port` or `.livenessProbe.port` in respective node type.

In a node container, there are other running services can be exposed. For example: VNC, NoVNC, SSH, etc. You can easily expose them on container via `.ports` and on Service `service.ports` in respective node type.

```yaml
chromeNode:
  port: 6666 # Update `SE_NODE_PORT` to 6666
  nodePort: 30666 # Specify a NodePort to expose `SE_NODE_PORT` to outside traffic
  ports:
    - 5900 # You can give port number alone, default protocol is TCP
    - 7900
  service:
    type: NodePort # Expose entire ports on Service via NodePort
    ports:
      - name: vnc-port
        protocol: TCP
        port: 5900
        targetPort: 5900
        nodePort: 30590 # Specify a NodePort to expose VNC port
      - name: novnc-port
        protocol: TCP
        port: 7900
        targetPort: 7900
        # NodePort will be assigned randomly if not set
edgeNode:
  ports: # You also can give object following manifest of container ports
    - containerPort: 5900
      name: vnc
      protocol: TCP
    - containerPort: 7900
      name: novnc
      protocol: TCP
```

#### Probes

By default, `startupProbe` is enabled and `readinessProbe` and `livenessProbe` are disabled. You can enable/disable them via `.startupProbe.enabled` `.readinessProbe.enabled` `.livenessProbe.enabled` in respective node type.

By default, probes are using `httpGet` method to check the node state. It will use `.port` value in respective node type unless you override it via e.g. `.startupProbe.port` `.readinessProbe.port` or `.livenessProbe.port` in respective node type.

Other settings of probe support to override under `.startupProbe` `.readinessProbe` `.livenessProbe` in respective node type.

```markdown
    schema
    path
    port
    initialDelaySeconds
    failureThreshold
    timeoutSeconds
    periodSeconds
    successThreshold
```

You can easily configure the probes (as Kubernetes [supports](https://kubernetes.io/docs/tasks/configure-pod-container/configure-liveness-readiness-startup-probes/)) to override the default settings. For example:

```yaml
edgeNode:
  port: 5555
  startupProbe:
    enabled: true
    tcpSocket:
      port: 5555
    failureThreshold: 10
    periodSeconds: 5
```

---

### Settings common for both `job` and `deployment` scalingType

There are few settings that are common for both scaling types. These are grouped under `autoscaling.scaledOptions`.

In case individual node should be scaled differently, you can override the upstream settings with `.scaledOptions` for each node type. For example:

```yaml
autoscaling:
  scaledOptions:
    minReplicaCount: 0
    maxReplicaCount: 8
    pollingInterval: 20

chromeNode:
  scaledOptions:
    minReplicaCount: 1
    maxReplicaCount: 16
    pollingInterval: 10
```

### Settings when scalingType with `deployment` 

By default, `autoscaling.terminationGracePeriodSeconds` is set to 3600 seconds. This is used when scalingType is set to `deployment`. You can adjust this value, it will affect to all nodes.

In case individual node which needs to set different period, you can override the upstream settings with `.terminationGracePeriodSeconds` for each node type. Note that override value must be greater than upstream setting to take effect. For example:

```yaml
autoscaling:
  terminationGracePeriodSeconds: 3600 #default
chromeNode:
  terminationGracePeriodSeconds: 7200 #override
firefoxNode:
  terminationGracePeriodSeconds: 1800 #not override
```

When scaling using deployments the HPA choose pods to terminate randomly. If the chosen pod is currently executing a test rather
than being idle, then there is `terminationGracePeriodSeconds` seconds before the test is expected to complete. If your test is
still executing after `terminationGracePeriodSeconds` seconds, it would result in failure as the pod will be killed.

During `terminationGracePeriodSeconds` period, there is `preStop` hook to execute command to wait for the pod can be shut down gracefully which can be defined in `.deregisterLifecycle`
- There is a `_helpers` template with name `seleniumGrid.node.deregisterLifecycle` render value for pod `lifecycle.preStop`. By default, hook to execute the script to drain node and wait for current session to complete if any. The script is stored in node ConfigMap, more details can be seen in config `nodeConfigMap.`
- You can define your custom `preStop` hook which is applied for all nodes via `autoscaling.deregisterLifecycle`
- In case individual node which needs different hook, you can override the upstream settings with `.deregisterLifecycle` for each node type. If you want to disable upstream hook in a node, pass the value as `false`
- If an individual node has settings `.lifecycle` itself, it would take the highest precedence to override the above use cases.

```yaml
autoscaling:
  deregisterLifecycle:
    preStop:
      exec:
        command: ["bash", "-c", "echo 'Your custom preStop hook applied for all nodes'"]
chromeNode:
  deregisterLifecycle: false #disable upstream hook in chrome node
firefoxNode:
  deregisterLifecycle:
    preStop:
      exec:
        command: ["bash", "-c", "echo 'Your custom preStop hook specific for firefox node'"]
edgeNode:
  lifecycle:
    preStop:
      exec:
        command: ["bash", "-c", "echo 'preStop hook is defined in edge node lifecycle itself'"]
```

For other settings that KEDA [ScaledObject spec](https://keda.sh/docs/latest/concepts/scaling-deployments/#scaledobject-spec) supports, you can set them via `autoscaling.scaledObjectOptions`. For example:

```yaml
autoscaling:
  scaledObjectOptions:
    cooldownPeriod: 60
```

### Settings when scalingType with `job`

Settings that KEDA [ScaledJob spec](https://keda.sh/docs/latest/concepts/scaling-jobs/#scaledjob-spec) supports can be set via `autoscaling.scaledJobOptions`.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
