### PR TITLE
feat(chart): Enable HTTPS on distributed components

### DIFF
--- a/SessionQueue/start-selenium-grid-session-queue.sh
+++ b/SessionQueue/start-selenium-grid-session-queue.sh
@@ -48,6 +48,11 @@ if [ ! -z "$SE_JAVA_SSL_TRUST_STORE" ]; then
   SE_JAVA_OPTS="$SE_JAVA_OPTS -Djdk.internal.httpclient.disableHostnameVerification=${SE_JAVA_DISABLE_HOSTNAME_VERIFICATION:-true}"
 fi
 
+if [ ! -z "$SE_REGISTRATION_SECRET" ]; then
+  echo "Appending Selenium options: --registration-secret ${SE_REGISTRATION_SECRET}"
+  SE_OPTS="$SE_OPTS --registration-secret ${SE_REGISTRATION_SECRET}"
+fi
+
 EXTRA_LIBS=""
 
 if [ ! -z "$SE_ENABLE_TRACING" ]; then

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -137,7 +137,9 @@ class JobAutoscaling():
                 for test in suite:
                     futures.append(executor.submit(test))
             for future in concurrent.futures.as_completed(futures):
-                future.result()
+                result = future.result()
+                if not result.wasSuccessful():
+                    raise Exception("Parallel tests failed")
 
 class JobAutoscalingTests(unittest.TestCase):
     def test_parallel_autoscaling(self):


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Continue the feat simplify to enable HTTPS/TLS in Selenium Grid on Kubernetes

### Motivation and Context
- When `--set isolateComponents=true`, the Router could not be up due to wait for startup probe on API `/readyz` - this is fixed on upstream https://github.com/SeleniumHQ/selenium/pull/13413 and will be released in `4.17.0`
- On the Node registration secret, the option `--registration-secret` needs to be added to SessionQueue, otherwise, the client gets error 401, secret doesn't match.
- Add tests, docs if needed

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
