### PR TITLE
feat(chart): Add RCLONE as default video uploader on Kubernetes

### DIFF
--- a/.github/workflows/nightly.yaml
+++ b/.github/workflows/nightly.yaml
@@ -1,11 +1,6 @@
 name: Nightly
 on:
   workflow_dispatch:
-    inputs:
-      NAMESPACE:
-        description: 'Set image registry'
-        required: true
-        default: 'selenium'
   schedule:
     - cron: '0 1 * * *'
 
@@ -29,7 +24,7 @@ jobs:
           echo "PRERELEASE=true" >> $GITHUB_ENV
           echo "NAME=${NAMESPACE}" >> $GITHUB_ENV
         env:
-          NAMESPACE: ${{ github.event.inputs.NAMESPACE || 'selenium' }}
+          NAMESPACE: ${{ secrets.DOCKER_NAMESPACE || 'selenium' }}
       - name: Build base image to get Grid version
         run: VERSION="local" BUILD_DATE=${BUILD_DATE} make base_nightly
       - name: Get Grid version

--- a/.github/workflows/update-dev-beta-browser-images.yml
+++ b/.github/workflows/update-dev-beta-browser-images.yml
@@ -17,7 +17,7 @@ jobs:
         browser: [chrome,firefox,edge]
         channel: [dev,beta]
     env:
-      NAME: selenium
+      NAME: ${{ secrets.DOCKER_NAMESPACE || 'selenium' }}
       BROWSER: ${{ matrix.browser }}
       CHANNEL: ${{ matrix.channel }}
 

--- a/Makefile
+++ b/Makefile
@@ -19,6 +19,8 @@ MAJOR_MINOR_PATCH := $(word 1,$(subst -, ,$(TAG_VERSION)))
 FFMPEG_TAG_VERSION := $(or $(FFMPEG_TAG_VERSION),$(FFMPEG_TAG_VERSION),ffmpeg-6.1)
 FFMPEG_BASED_NAME := $(or $(FFMPEG_BASED_NAME),$(FFMPEG_BASED_NAME),ndviet)
 FFMPEG_BASED_TAG := $(or $(FFMPEG_BASED_TAG),$(FFMPEG_BASED_TAG),6.1-ubuntu2204)
+RCLONE_BASED_TAG := $(or $(RCLONE_BASED_TAG),$(RCLONE_BASED_TAG),1.65)
+RCLONE_TAG_VERSION := $(or $(RCLONE_TAG_VERSION),$(RCLONE_TAG_VERSION),rclone-$(RCLONE_BASED_TAG))
 
 all: hub \
 	distributor \
@@ -34,6 +36,7 @@ all: hub \
 	standalone_edge \
 	standalone_firefox \
 	standalone_docker \
+	uploader \
 	video
 
 build_nightly:
@@ -130,6 +133,9 @@ standalone_edge_dev: edge_dev
 standalone_edge_beta: edge_beta
 	cd ./Standalone && docker build $(BUILD_ARGS) --build-arg NAMESPACE=$(NAME) --build-arg VERSION=beta --build-arg BASE=node-edge -t $(NAME)/standalone-edge:beta .
 
+uploader:
+	cd ./Uploader && docker build $(BUILD_ARGS) --build-arg BASED_TAG=$(RCLONE_BASED_TAG) -t $(NAME)/uploader:$(RCLONE_TAG_VERSION)-$(BUILD_DATE) .
+
 video:
 	cd ./Video && docker build $(BUILD_ARGS) --build-arg NAMESPACE=$(FFMPEG_BASED_NAME) --build-arg BASED_TAG=$(FFMPEG_BASED_TAG) -t $(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) .
 
@@ -165,6 +171,7 @@ tag_latest:
 	docker tag $(NAME)/standalone-firefox:$(TAG_VERSION) $(NAME)/standalone-firefox:latest
 	docker tag $(NAME)/standalone-docker:$(TAG_VERSION) $(NAME)/standalone-docker:latest
 	docker tag $(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) $(NAME)/video:latest
+	docker tag $(NAME)/uploader:$(RCLONE_TAG_VERSION)-$(BUILD_DATE) $(NAME)/uploader:latest
 
 release_latest:
 	docker push $(NAME)/base:latest
@@ -184,6 +191,7 @@ release_latest:
 	docker push $(NAME)/standalone-firefox:latest
 	docker push $(NAME)/standalone-docker:latest
 	docker push $(NAME)/video:latest
+	docker push $(NAME)/uploader:latest
 
 tag_nightly:
 	docker tag $(NAME)/base:$(TAG_VERSION) $(NAME)/base:nightly
@@ -203,6 +211,7 @@ tag_nightly:
 	docker tag $(NAME)/standalone-firefox:$(TAG_VERSION) $(NAME)/standalone-firefox:nightly
 	docker tag $(NAME)/standalone-docker:$(TAG_VERSION) $(NAME)/standalone-docker:nightly
 	docker tag $(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) $(NAME)/video:nightly
+	docker tag $(NAME)/uploader:$(RCLONE_TAG_VERSION)-$(BUILD_DATE) $(NAME)/uploader:nightly
 
 release_nightly:
 	docker push $(NAME)/base:nightly
@@ -222,6 +231,7 @@ release_nightly:
 	docker push $(NAME)/standalone-firefox:nightly
 	docker push $(NAME)/standalone-docker:nightly
 	docker push $(NAME)/video:nightly
+	docker push $(NAME)/uploader:nightly
 
 tag_major_minor:
 	docker tag $(NAME)/base:$(TAG_VERSION) $(NAME)/base:$(MAJOR)
@@ -355,6 +365,7 @@ release: tag_major_minor
 	docker push $(NAME)/standalone-firefox:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/standalone-docker:$(MAJOR_MINOR_PATCH)
 	docker push $(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE)
+	docker push $(NAME)/uploader:$(RCLONE_TAG_VERSION)-$(BUILD_DATE)
 
 test: test_chrome \
  test_firefox \
@@ -438,19 +449,23 @@ chart_test_template:
 	./tests/charts/bootstrap.sh
 
 chart_test_chrome:
-	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh NodeChrome
+	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) UPLOADER_TAG=$(RCLONE_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \
+	./tests/charts/make/chart_test.sh NodeChrome
 
 chart_test_firefox:
-	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh NodeFirefox
+	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) UPLOADER_TAG=$(RCLONE_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \
+	./tests/charts/make/chart_test.sh NodeFirefox
 
 chart_test_edge:
-	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh NodeEdge
+	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) UPLOADER_TAG=$(RCLONE_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \
+	./tests/charts/make/chart_test.sh NodeEdge
 
 chart_test_parallel_autoscaling_https:
 	SELENIUM_GRID_PROTOCOL=https SELENIUM_GRID_PORT=443 make chart_test_parallel_autoscaling
 
 chart_test_parallel_autoscaling:
-	VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) ./tests/charts/make/chart_test.sh JobAutoscaling
+	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) UPLOADER_TAG=$(RCLONE_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \
+	./tests/charts/make/chart_test.sh JobAutoscaling
 
 .PHONY: \
 	all \

--- a/Uploader/Dockerfile
+++ b/Uploader/Dockerfile
@@ -1,0 +1,12 @@
+ARG BASED_TAG
+FROM rclone/rclone:${BASED_TAG}
+
+RUN apk update \
+  && apk add --no-cache --update \
+    bash \
+    curl \
+    wget \
+    jq \
+  && rm -rf /tmp/* /var/cache/apk/*
+
+USER rclone

--- a/charts/selenium-grid/configs/uploader/rclone/entry_point.sh
+++ b/charts/selenium-grid/configs/uploader/rclone/entry_point.sh
@@ -1,0 +1,37 @@
+#!/usr/bin/env bash
+
+SE_VIDEO_FOLDER=${SE_VIDEO_FOLDER:-"/videos"}
+UPLOAD_CONFIG_DIRECTORY=${UPLOAD_CONFIG_DIRECTORY:-"/opt/bin"}
+UPLOAD_CONFIG_FILE_NAME=${UPLOAD_CONFIG_FILE_NAME:-"rclone.conf"}
+UPLOAD_COMMAND=${UPLOAD_COMMAND:-"copy"}
+
+function consume_force_exit() {
+    rm -f ${SE_VIDEO_FOLDER}/force_exit
+    echo "Force exit signal consumed"
+}
+trap consume_force_exit EXIT
+
+while [ ! -p ${SE_VIDEO_FOLDER}/uploadpipe ];
+do
+      echo "Waiting for ${SE_VIDEO_FOLDER}/uploadpipe to be created"
+      sleep 1
+done
+
+echo "Waiting for video files put into pipe for proceeding to upload"
+
+while read FILE DESTINATION < ${SE_VIDEO_FOLDER}/uploadpipe
+do
+    if [ "${FILE}" = "exit" ];
+    then
+        exit
+    else [ "$FILE" != "" ] && [ "$DESTINATION" != "" ];
+        echo "Uploading ${FILE} to ${DESTINATION}"
+        rclone --config ${UPLOAD_CONFIG_DIRECTORY}/${UPLOAD_CONFIG_FILE_NAME} ${UPLOAD_COMMAND} ${UPLOAD_OPTS} "${FILE}" "${DESTINATION}"
+    fi
+    if [ -f ${SE_VIDEO_FOLDER}/force_exit ] && [ ! -s ${SE_VIDEO_FOLDER}/uploadpipe ];
+    then
+        exit
+    fi
+done
+
+consume_force_exit

--- a/charts/selenium-grid/configs/uploader/rclone/rclone.conf
+++ b/charts/selenium-grid/configs/uploader/rclone/rclone.conf
@@ -1,0 +1,9 @@
+[mys3]
+type = s3
+provider = AWS
+env_auth = true
+region =
+location_constraint =
+acl = private
+access_key_id =
+secret_access_key =

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -25,6 +25,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
 {{- $_ =  set $podScope "node" .Values.chromeNode -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
+++ b/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
@@ -22,7 +22,7 @@ spec:
   {{- $podScope := deepCopy . -}}
   {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
   {{- $_ =  set $podScope "node" .Values.chromeNode -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
+  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -25,6 +25,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
 {{- $_ =  set $podScope "node" .Values.edgeNode -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/edge-node-scaledjob.yaml
@@ -22,7 +22,7 @@ spec:
   {{- $podScope := deepCopy . -}}
   {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
   {{- $_ =  set $podScope "node" .Values.edgeNode -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
+  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -25,6 +25,6 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
 {{- $_ =  set $podScope "node" .Values.firefoxNode -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
@@ -22,7 +22,7 @@ spec:
   {{- $podScope := deepCopy . -}}
   {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
   {{- $_ =  set $podScope "node" .Values.firefoxNode -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader | toString)) -}}
+  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/node-configmap.yaml
+++ b/charts/selenium-grid/templates/node-configmap.yaml
@@ -14,4 +14,8 @@ metadata:
 data:
   SE_DRAIN_AFTER_SESSION_COUNT: '{{- and (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") | ternary "1" "0" -}}'
   SE_NODE_GRID_URL: '{{ include "seleniumGrid.url" .}}'
+  UPLOAD_ENABLED: '{{ .Values.videoRecorder.uploader.enabled }}'
+  UPLOAD_DESTINATION_PREFIX: '{{ .Values.videoRecorder.uploader.destinationPrefix }}'
+  UPLOAD_CONFIG_FILE_NAME: '{{ .Values.videoRecorder.uploader.configFileName }}'
+  UPLOAD_CONFIG_DIRECTORY: '{{ .Values.videoRecorder.uploader.scriptMountPath }}'
 {{ (.Files.Glob "configs/node/*").AsConfig | indent 2 }}

--- a/charts/selenium-grid/templates/secrets.yaml
+++ b/charts/selenium-grid/templates/secrets.yaml
@@ -30,4 +30,16 @@ data:
 {{- if (include "seleniumGrid.tls.registrationSecret.enabled" $) }}
   SE_REGISTRATION_SECRET: {{ .Values.tls.registrationSecret.value | b64enc }}
 {{- end }}
+{{- if .Values.videoRecorder.uploader.secrets }}
+{{- range $name, $value := .Values.videoRecorder.uploader.secrets }}
+{{- if not (empty $value) }}
+  {{ $name }}: {{ tpl ($value) $ | b64enc }}
+{{- end }}
+{{- end }}
+{{- end }}
+{{- if and .Values.videoRecorder.uploader.enabled .Values.videoRecorder.uploader.config }}
+  {{ .Values.videoRecorder.uploader.configFileName }}: {{ .Values.videoRecorder.uploader.config | b64enc }}
+{{- else if and .Values.videoRecorder.uploader.enabled (not .Values.videoRecorder.uploader.config) }}
+{{ (.Files.Glob (printf "configs/uploader/%s/*.conf" $.Values.videoRecorder.uploader.name)).AsSecrets | indent 2 }}
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/video-cm.yaml
+++ b/charts/selenium-grid/templates/video-cm.yaml
@@ -4,8 +4,11 @@ kind: ConfigMap
 metadata:
   name: {{ template "seleniumGrid.video.fullname" . }}
 data:
-{{ (.Files.Glob "configs/video/*").AsConfig | indent 2 }}
-{{- if and $.Values.videoRecorder.uploadDestinationPrefix $.Values.videoRecorder.uploader }}
-{{ (.Files.Glob (printf "configs/uploader/%s/*" $.Values.videoRecorder.uploader)).AsConfig | indent 2 }}
+{{ (.Files.Glob "configs/recorder/*").AsConfig | indent 2 }}
+{{- if and .Values.videoRecorder.uploader.enabled .Values.videoRecorder.uploader.entryPoint }}
+{{ .Values.videoRecorder.uploader.entryPointFileName | indent 2 -}}: |
+{{ .Values.videoRecorder.uploader.entryPoint | indent 4 }}
+{{- else if and .Values.videoRecorder.uploader.enabled (not .Values.videoRecorder.uploader.entryPoint) }}
+{{ (.Files.Glob (printf "configs/uploader/%s/*.sh" $.Values.videoRecorder.uploader.name)).AsConfig | indent 2 }}
 {{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -12,6 +12,8 @@ global:
     nodesImageTag: 4.16.1-20231219
     # Image tag for browser's video recorder
     videoImageTag: ffmpeg-6.1-20231219
+    # Image tag for browser's uploader
+    uploaderImageTag: rclone-1.65-20231219
     # Pull secret for all components, can be overridden individually
     imagePullSecret: ""
     # Log level for all components. Possible values describe here: https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging
@@ -985,13 +987,39 @@ videoRecorder:
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
   # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
-
-  # What uploader to use. See .videRecorder.s3 for how to create a new one.
-  # uploader: s3
-  uploader: false
-  # Where to upload the video file. Should be set to something like 's3://myvideobucket/'
-  uploadDestinationPrefix: false
-
+  uploader:
+    enabled: false
+    # Where to upload the video file e.g. remoteName://bucketName/path. Refer to destination syntax of rclone https://rclone.org/docs/
+    destinationPrefix:
+    # What uploader to use. See .videRecorder.rclone for how to create a new one.
+    name: "rclone"
+    configFileName: "rclone.conf"
+    entryPointFileName: "entry_point.sh"
+    scriptMountPath: "/opt/bin"
+    # Config file for rclone.
+    config:
+    # Script to control the upload process.
+    entryPoint:
+    # For environment variables used in uploader which contains sensitive information, store in secret and refer envFrom
+    # Set config for rclone via ENV var with format: RCLONE_CONFIG_ + name of remote + _ + name of config file option (make it all uppercase)
+    secrets:
+    #  RCLONE_CONFIG_S3_TYPE: "s3"
+    #  RCLONE_CONFIG_S3_PROVIDER: "AWS"
+    #  RCLONE_CONFIG_S3_ENV_AUTH: "true"
+    #  RCLONE_CONFIG_S3_REGION: "ap-southeast-1"
+    #  RCLONE_CONFIG_S3_LOCATION_CONSTRAINT: "ap-southeast-1"
+    #  RCLONE_CONFIG_S3_ACL: "private"
+    #  RCLONE_CONFIG_S3_ACCESS_KEY_ID: "xxx"
+    #  RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "xxx"
+    #  RCLONE_CONFIG_GS_TYPE: "s3"
+    #  RCLONE_CONFIG_GS_PROVIDER: "GCS"
+    #  RCLONE_CONFIG_GS_ENV_AUTH: "true"
+    #  RCLONE_CONFIG_GS_REGION: "asia-southeast1"
+    #  RCLONE_CONFIG_GS_LOCATION_CONSTRAINT: "asia-southeast1"
+    #  RCLONE_CONFIG_GS_ACL: "private"
+    #  RCLONE_CONFIG_GS_ACCESS_KEY_ID: "xxx"
+    #  RCLONE_CONFIG_GS_SECRET_ACCESS_KEY: "xxx"
+    #  RCLONE_CONFIG_GS_ENDPOINT: "https://storage.googleapis.com"
   ports:
   - 9000
   resources:
@@ -1001,6 +1029,9 @@ videoRecorder:
     limits:
       memory: "1Gi"
       cpu: "1"
+  # SecurityContext for recorder container
+  securityContext:
+    runAsUser: 0
   extraEnvironmentVariables:
   # - name: SE_VIDEO_FOLDER
   #   value: /videos
@@ -1049,15 +1080,34 @@ videoRecorder:
   #   persistentVolumeClaim:
   #     claimName: video-pv-claim
 
-  # Container spec for the uploader if above it is defined as "uploader: s3"
+  # Container spec for the uploader if above it is defined as "uploader.name: rclone"
+  rclone:
+    # imageRegistry: selenium
+    imageName: uploader
+    # imageTag: "rclone-1.65-20240119"
+    imagePullPolicy: IfNotPresent
+    # SecurityContext for uploader container
+    securityContext:
+      runAsUser: 0
+    command: []
+    args: []
+    extraEnvironmentVariables:
+    # Extra options for rclone. Refer to https://rclone.org/flags
+      - name: UPLOAD_OPTS
+        value: "--progress"
+    #  - name: UPLOAD_COMMAND
+    #    value: "copy"
+
+  # Container spec for the uploader if above it is defined as "uploader.name: s3"
   s3:
-    imageName: public.ecr.aws/bitnami/aws-cli
-    imageTag: "2"
+    imageRegistry: public.ecr.aws
+    imageName: bitnami/aws-cli
+    imageTag: latest
     imagePullPolicy: IfNotPresent
     securityContext:
       runAsUser: 0
-    command: ["/bin/sh"]
-    args: ["-c", "/opt/bin/entry_point.sh"]
+    command: []
+    args: []
     extraEnvironmentVariables:
     # - name: AWS_ACCESS_KEY_ID
     #   value: aws_access_key_id

--- a/generate_release_notes.sh
+++ b/generate_release_notes.sh
@@ -19,6 +19,7 @@ EDGEDRIVER_VERSION=$(docker run --rm ${NAMESPACE}/node-edge:${TAG_VERSION} msedg
 FIREFOX_VERSION=$(docker run --rm ${NAMESPACE}/node-firefox:${TAG_VERSION} firefox --version | awk '{print $3}')
 GECKODRIVER_VERSION=$(docker run --rm ${NAMESPACE}/node-firefox:${TAG_VERSION} geckodriver --version | awk 'NR==1{print $2}')
 FFMPEG_VERSION=$(docker run --entrypoint="" --rm ${NAMESPACE}/video:ffmpeg-6.1-${BUILD_DATE} ffmpeg -version | awk '{print $3}' | head -n 1)
+RCLONE_VERSION=$(docker run --entrypoint="" --rm ${NAMESPACE}/uploader:rclone-1.65-${BUILD_DATE} rclone version | head -n 1 | awk '{print $2}')
 
 
 echo "" >> release_notes.md
@@ -31,6 +32,7 @@ echo "* EdgeDriver: ${EDGEDRIVER_VERSION}" >> release_notes.md
 echo "* Firefox: ${FIREFOX_VERSION}" >> release_notes.md
 echo "* GeckoDriver: ${GECKODRIVER_VERSION}" >> release_notes.md
 echo "* ffmpeg: ${FFMPEG_VERSION}" >> release_notes.md
+echo "* rclone: ${RCLONE_VERSION}" >> release_notes.md
 
 echo "" >> release_notes.md
 echo "### Published Docker images" >> release_notes.md

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -25,8 +25,13 @@ class SeleniumGenericTests(unittest.TestCase):
     def test_with_frames(self):
         driver = self.driver
         driver.get('http://the-internet.herokuapp.com/nested_frames')
-        driver.switch_to.frame('frame-top')
-        driver.switch_to.frame('frame-middle')
+        wait = WebDriverWait(driver, WEB_DRIVER_WAIT_TIMEOUT)
+        frame_top = wait.until(
+            EC.frame_to_be_available_and_switch_to_it('frame-top')
+        )
+        frame_middle = wait.until(
+            EC.frame_to_be_available_and_switch_to_it('frame-middle')
+        )
         self.assertTrue(driver.find_element(By.ID, 'content').text == "MIDDLE", "content should be MIDDLE")
 
     # https://github.com/tourdedave/elemental-selenium-tips/blob/master/05-select-from-a-dropdown/python/dropdown.py
@@ -140,11 +145,11 @@ class JobAutoscaling():
                 try:
                     result = future.result()
                     if not result.wasSuccessful():
-                        raise Exception("Test failed")
+                        raise Exception(f"Test {str(test)} failed")
                 except Exception as e:
-                    print(f"Test {str(test)} failed with exception: {str(e)}")
+                    print(f"{str(test)} failed with exception: {str(e)}")
                     print(traceback.format_exc())
-                    raise Exception("Parallel tests failed")
+                    raise Exception(f"Parallel tests failed: {str(test)} failed with exception: {str(e)}")
 
 class JobAutoscalingTests(unittest.TestCase):
     def test_parallel_autoscaling(self):

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -23,6 +23,8 @@ WEB_DRIVER_WAIT_TIMEOUT=${WEB_DRIVER_WAIT_TIMEOUT:-120}
 SKIP_CLEANUP=${SKIP_CLEANUP:-"false"} # For debugging purposes, retain the cluster after the test run
 CHART_CERT_PATH=${CHART_CERT_PATH:-"${CHART_PATH}/certs/selenium.pem"}
 SSL_CERT_DIR=${SSL_CERT_DIR:-"/etc/ssl/certs"}
+VIDEO_TAG=${VIDEO_TAG:-"latest"}
+UPLOADER_TAG=${UPLOADER_TAG:-"latest"}
 
 cleanup() {
   if [ "${SKIP_CLEANUP}" = "false" ]; then
@@ -63,12 +65,15 @@ HELM_COMMAND_ARGS="${RELEASE_NAME} \
 ${HELM_COMMAND_SET_AUTOSCALING} \
 ${HELM_COMMAND_SET_TLS} \
 --values ${TEST_VALUES_PATH}/${MATRIX_BROWSER}-values.yaml \
---set global.seleniumGrid.imageTag=${VERSION} --set global.seleniumGrid.imageRegistry=${NAMESPACE} \
+--set global.seleniumGrid.imageRegistry=${NAMESPACE} \
+--set global.seleniumGrid.imageTag=${VERSION} \
 --set global.seleniumGrid.nodesImageTag=${VERSION} \
+--set global.seleniumGrid.videoImageTag=${VIDEO_TAG} \
+--set global.seleniumGrid.uploaderImageTag=${UPLOADER_TAG} \
 ${CHART_PATH} --namespace ${SELENIUM_NAMESPACE} --create-namespace"
 
 echo "Render manifests YAML for this deployment"
-helm template ${HELM_COMMAND_ARGS} > tests/tests/cluster_deployment_manifests_${MATRIX_BROWSER}.yaml
+helm template --debug ${HELM_COMMAND_ARGS} > tests/tests/cluster_deployment_manifests_${MATRIX_BROWSER}.yaml
 
 echo "Deploy Selenium Grid Chart"
 helm upgrade --install ${HELM_COMMAND_ARGS}

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -81,13 +81,15 @@ edgeNode:
 
 videoRecorder:
   enabled: true
-  uploader: s3
-  uploadDestinationPrefix: "s3://ndviet"
-  s3:
-    extraEnvironmentVariables:
-     - name: AWS_ACCESS_KEY_ID
-       value: "xxxx"
-     - name: AWS_SECRET_ACCESS_KEY
-       value: "xxxx"
-     - name: AWS_REGION
-       value: "ap-southeast-1"
+  uploader:
+    enabled: true
+    destinationPrefix: "s3://ndviet"
+    secrets:
+      RCLONE_CONFIG_S3_TYPE: "s3"
+      RCLONE_CONFIG_S3_PROVIDER: "AWS"
+      RCLONE_CONFIG_S3_ENV_AUTH: "true"
+      RCLONE_CONFIG_S3_REGION: "ap-southeast-1"
+      RCLONE_CONFIG_S3_LOCATION_CONSTRAINT: "ap-southeast-1"
+      RCLONE_CONFIG_S3_ACL: "private"
+      RCLONE_CONFIG_S3_ACCESS_KEY_ID: "xxx"
+      RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: "xxx"


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
feat(chart): Add RCLONE as default video uploader on Kubernetes

### Motivation and Context
- Add [RCLONE](https://github.com/rclone/rclone) as the default video uploader.
- Update Chart support users can pass different configs via chart values (based on their demand) to configure the uploader

---

### Configuration of video recorder and video uploader

#### Video recorder

The video recorder is a sidecar that is deployed with the browser nodes. It is responsible for recording the video of the browser session. The video recorder is disabled by default. To enable it, you need to set the following values:

```yaml
videoRecorder:
  enabled: true
```

#### Video uploader

The uploader is a sidecar that is deployed with the browser nodes. It is responsible for uploading the video to a remote location. The uploader is disabled by default. To enable it, you need to set the following values:

```yaml
videoRecorder:
  uploader:
    enabled: true
```

By default, the uploader uses [RCLONE](https://rclone.org/) to upload the video to a remote location. RCLONE requires a configuration file to define different remote locations. Refer to [RCLONE docs](https://rclone.org/docs/#config-file) for more details. Config file might contain sensitive information such as access key, secret key, etc. hence it is stored in Secret.

The uploader requires `destinationPrefix` to be set. It is used to instruct the uploader where to upload the video. The format of destinationPrefix is `remote-name://bucket-name/path`. The `remote-name` is configured in RCLONE. The bucket-name is the name of the bucket in the remote location. The path is the path to the folder in the bucket.

By default, the config file is loaded from file [configs/uploader/rclone/rclone.conf](configs/uploader/rclone/rclone.conf) to the Secret. You can override the config file via `--set-file videoRecorder.uploader.config=/path/to/config` or set via YAML values.

For example, to configure an S3 remote hosted on AWS with named `mys3` and the bucket name is `mybucket`, you can set the following values:

```bash
videoRecorder:
  uploader:
    destinationPrefix: "mys3://mybucket"
    config: |
        [mys3]
        type = s3
        provider = AWS
        env_auth = true
        region = ap-southeast-1
        location_constraint = ap-southeast-1
        acl = private
        access_key_id = xxx
        secret_access_key = xxx
```

You can prepare a config file with multiple remotes are defined. Ensure that `[remoteName]` is unique for each remote.
You also can replace your config to default file `configs/uploader/rclone/rclone.conf` in chart.

Instead of using config file, another way that RCLONE also supports to pass the information via environment variables. ENV variable with format: `RCLONE_CONFIG_ + name of remote + _ + name of config file option` (make it all uppercase). In this case the remote name it can only contain letters, digits, or the _ (underscore) character. All those ENV variables can be set via `videoRecorder.uploader.secrets`, it will be stored in Secret.

For example, the same above config can be set via ENV vars as below:

```yaml
videoRecorder:
  uploader:
    destinationPrefix: "mys3://mybucket"
    secrets:
      RCLONE_CONFIG_MYS3_TYPE: "s3"
      RCLONE_CONFIG_MYS3_PROVIDER: "GCS"
      RCLONE_CONFIG_MYS3_ENV_AUTH: "true"
      RCLONE_CONFIG_MYS3_REGION: "asia-southeast1"
      RCLONE_CONFIG_MYS3_LOCATION_CONSTRAINT: "asia-southeast1"
      RCLONE_CONFIG_MYS3_ACL: "private"
      RCLONE_CONFIG_MYS3_ACCESS_KEY_ID: "xxx"
      RCLONE_CONFIG_MYS3_SECRET_ACCESS_KEY: "xxx"
```

Those 2 ways are equivalent. You can choose one of them or combine them together. When both config file and ENV vars are set, value in `rclone.conf` will take precedence.

Beside the configuration, the script for entry point of uploader container also needed. By default, it is loaded from file [configs/uploader/rclone/entry_point.sh](configs/uploader/rclone/entry_point.sh) to the ConfigMap. You can override the script via `--set-file videoRecorder.uploader.entryPoint=/path/to/script` or set via YAML values. For example:

```yaml
videoRecorder:
  uploader:
    entryPoint: |
        #!/bin/bash
        echo "Your custom script"
```

You also can replace your script to default file `configs/uploader/rclone/entry_point.sh` in chart.


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
