### PR TITLE
bug: x11vnc delayed

### DIFF
--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -44,7 +44,7 @@ RUN apt-get -qqy update \
 #=====
 RUN apt-get update -qqy \
   && apt-get -qqy --no-install-recommends install \
-  x11vnc \
+  x11vnc x11-utils fluxbox \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #=========


### PR DESCRIPTION
Fixes #2118

### Description
This change installs the dependencies used in NodeBase/start-vnc.sh to avoid x11vnc delays.

### Motivation and Context
Since #2061 the dependencies are missing due to --no-install-recommends causing x11vnc startup delays.
The packages where tested in a 4.17.0-20240123 container which has been restarted to confirm that the delays are fixed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
