### PR TITLE
feat: enable tracing observability in docker-compose and helm chart

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -140,6 +140,9 @@ ENV SE_BIND_HOST false
 # Boolean value, maps "--reject-unsupported-caps"
 ENV SE_REJECT_UNSUPPORTED_CAPS false
 
+ENV SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED true
+ENV SE_OTEL_TRACES_EXPORTER "otlp"
+
 # A too high maximum number of file descriptors (with the default value
 # inherited from the docker host) can cause issues with some of our tools:
 #  - sanitizers hanging: https://github.com/google/sanitizers/issues/1662

--- a/Distributor/Dockerfile
+++ b/Distributor/Dockerfile
@@ -21,3 +21,5 @@ COPY selenium-grid-distributor.conf /etc/supervisor/conf.d/
 ENV SE_SESSION_REQUEST_TIMEOUT 300
 # In seconds, maps to "--session-retry-interval"
 ENV SE_SESSION_RETRY_INTERVAL 15
+
+ENV SE_OTEL_SERVICE_NAME "selenium-distributor"

--- a/Distributor/start-selenium-grid-distributor.sh
+++ b/Distributor/start-selenium-grid-distributor.sh
@@ -95,12 +95,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/EventBus/Dockerfile
+++ b/EventBus/Dockerfile
@@ -21,3 +21,5 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-grid-eventbus.sh \
     /opt/bin/
 
 COPY selenium-grid-eventbus.conf /etc/supervisor/conf.d/
+
+ENV SE_OTEL_SERVICE_NAME "selenium-event-bus"

--- a/EventBus/start-selenium-grid-eventbus.sh
+++ b/EventBus/start-selenium-grid-eventbus.sh
@@ -50,12 +50,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/Hub/Dockerfile
+++ b/Hub/Dockerfile
@@ -25,3 +25,5 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-grid-hub.sh \
     /opt/bin/
 
 COPY selenium-grid-hub.conf /etc/supervisor/conf.d/
+
+ENV SE_OTEL_SERVICE_NAME "selenium-hub"

--- a/Hub/start-selenium-grid-hub.sh
+++ b/Hub/start-selenium-grid-hub.sh
@@ -68,12 +68,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/Makefile
+++ b/Makefile
@@ -450,11 +450,11 @@ chart_test_autoscaling_deployment_https:
 	SELENIUM_GRID_TEST_HEADLESS=true SELENIUM_GRID_PROTOCOL=https SELENIUM_GRID_PORT=443 make chart_test_autoscaling_deployment
 
 chart_test_autoscaling_deployment:
-	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \
+	SE_ENABLE_TRACING=true VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \
 	./tests/charts/make/chart_test.sh DeploymentAutoscaling
 
 chart_test_autoscaling_job_https:
-	SELENIUM_GRID_TEST_HEADLESS=true SELENIUM_GRID_PROTOCOL=https SELENIUM_GRID_PORT=443 make chart_test_autoscaling_job
+	SE_ENABLE_TRACING=true SELENIUM_GRID_TEST_HEADLESS=true SELENIUM_GRID_PROTOCOL=https SELENIUM_GRID_PORT=443 make chart_test_autoscaling_job
 
 chart_test_autoscaling_job:
 	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) NAMESPACE=$(NAMESPACE) \

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -198,6 +198,7 @@ ENV SE_NODE_OVERRIDE_MAX_SESSIONS false
 
 # Following line fixes https://github.com/SeleniumHQ/docker-selenium/issues/87
 ENV DBUS_SESSION_BUS_ADDRESS=/dev/null
+ENV SE_OTEL_SERVICE_NAME "selenium-node"
 
 # Copying configuration script generator
 COPY --chown="${SEL_UID}:${SEL_GID}" generate_config /opt/bin/generate_config

--- a/NodeBase/start-selenium-node.sh
+++ b/NodeBase/start-selenium-node.sh
@@ -92,12 +92,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -61,3 +61,5 @@ USER ${SEL_UID}
 RUN echo "chrome" > /opt/selenium/browser_name
 RUN google-chrome --version | awk '{print $3}' > /opt/selenium/browser_version
 RUN echo "\"goog:chromeOptions\": {\"binary\": \"/usr/bin/google-chrome\"}" > /opt/selenium/browser_binary_location
+
+ENV SE_OTEL_SERVICE_NAME "selenium-node-chrome"

--- a/NodeDocker/Dockerfile
+++ b/NodeDocker/Dockerfile
@@ -28,3 +28,4 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-grid-docker.sh \
 
 COPY selenium-grid-docker.conf /etc/supervisor/conf.d/
 
+ENV SE_OTEL_SERVICE_NAME "selenium-node-docker"

--- a/NodeDocker/start-selenium-grid-docker.sh
+++ b/NodeDocker/start-selenium-grid-docker.sh
@@ -60,12 +60,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/NodeEdge/Dockerfile
+++ b/NodeEdge/Dockerfile
@@ -54,3 +54,5 @@ USER ${SEL_UID}
 RUN echo "MicrosoftEdge" > /opt/selenium/browser_name
 RUN microsoft-edge --version | awk '{print $3}' > /opt/selenium/browser_version
 RUN echo "\"ms:edgeOptions\": {\"binary\": \"/usr/bin/microsoft-edge\"}" > /opt/selenium/browser_binary_location
+
+ENV SE_OTEL_SERVICE_NAME "selenium-node-edge"

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -44,3 +44,5 @@ USER ${SEL_UID}
 RUN echo "firefox" > /opt/selenium/browser_name
 RUN firefox --version | awk '{print $3}' > /opt/selenium/browser_version
 RUN echo "\"moz:firefoxOptions\": {\"binary\": \"/usr/bin/firefox\"}" > /opt/selenium/browser_binary_location
+
+ENV SE_OTEL_SERVICE_NAME "selenium-node-firefox"

--- a/README.md
+++ b/README.md
@@ -1267,26 +1267,29 @@ In order to enable tracing in the Selenium Grid container, the following command
 
 ```bash
 docker network create grid
-docker run -d -p 16686:16686 -p 14250:14250 --net grid --name jaeger jaegertracing/all-in-one:1.17
+docker run -d -p 16686:16686 -p 14250:14250 -p 4317:4317 --net grid --name jaeger jaegertracing/all-in-one:1.54
 docker run -d -p 4442-4444:4442-4444 --net grid --name selenium-hub selenium/hub:4.17.0-20240123
 docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub \
     --shm-size="2g" \
 	-e SE_ENABLE_TRACING=true \
-	-e JAVA_OPTS="-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-chrome" \
+	-e SE_OTEL_TRACES_EXPORTER=otlp \
+	-e SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 \
     -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
     -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
     selenium/node-chrome:4.17.0-20240123
 docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub \
     --shm-size="2g" \
 	-e SE_ENABLE_TRACING=true \
-	-e JAVA_OPTS="-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-edge" \
+	-e SE_OTEL_TRACES_EXPORTER=otlp \
+	-e SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 \
     -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
     -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
     selenium/node-edge:4.17.0-20240123
 docker run -d --net grid -e SE_EVENT_BUS_HOST=selenium-hub \
     --shm-size="2g" \
 	-e SE_ENABLE_TRACING=true \
-	-e JAVA_OPTS="-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-firefox" \
+	-e SE_OTEL_TRACES_EXPORTER=otlp \
+	-e SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 \
     -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
     -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
     selenium/node-firefox:4.17.0-20240123
@@ -1298,7 +1301,7 @@ You can also refer to the below docker-compose yaml files to be able to start a 
 * Simple Grid [v2 yaml file](docker-compose-v2-tracing.yml)
 * Dynamic Grid [v3 yaml file](docker-compose-v3-full-grid-tracing.yml)
 
-You can view the [Jaegar UI](http://localhost:16686/) and trace your request.
+You can view the [Jaeger UI](http://localhost:16686/) and trace your request.
 ___
 
 ## Troubleshooting

--- a/Router/Dockerfile
+++ b/Router/Dockerfile
@@ -21,3 +21,5 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-grid-router.sh \
     /opt/bin/
 
 COPY selenium-grid-router.conf /etc/supervisor/conf.d/
+
+ENV SE_OTEL_SERVICE_NAME "selenium-router"

--- a/Router/start-selenium-grid-router.sh
+++ b/Router/start-selenium-grid-router.sh
@@ -95,12 +95,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/SessionQueue/Dockerfile
+++ b/SessionQueue/Dockerfile
@@ -21,3 +21,5 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-grid-session-queue.sh \
     /opt/bin/
 
 COPY selenium-grid-session-queue.conf /etc/supervisor/conf.d/
+
+ENV SE_OTEL_SERVICE_NAME "selenium-session-queue"

--- a/SessionQueue/start-selenium-grid-session-queue.sh
+++ b/SessionQueue/start-selenium-grid-session-queue.sh
@@ -55,12 +55,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/Sessions/Dockerfile
+++ b/Sessions/Dockerfile
@@ -16,3 +16,5 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-grid-sessions.sh \
     /opt/bin/
 
 COPY selenium-grid-sessions.conf /etc/supervisor/conf.d/
+
+ENV SE_OTEL_SERVICE_NAME "selenium-session-map"

--- a/Sessions/start-selenium-grid-sessions.sh
+++ b/Sessions/start-selenium-grid-sessions.sh
@@ -65,12 +65,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/Standalone/Dockerfile
+++ b/Standalone/Dockerfile
@@ -29,4 +29,4 @@ ENV SE_RELAX_CHECKS true
 
 EXPOSE 4444
 
-
+ENV SE_OTEL_SERVICE_NAME "selenium-standalone"

--- a/Standalone/start-selenium-standalone.sh
+++ b/Standalone/start-selenium-standalone.sh
@@ -68,12 +68,28 @@ echo "Starting Selenium Grid Standalone..."
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/StandaloneDocker/Dockerfile
+++ b/StandaloneDocker/Dockerfile
@@ -20,3 +20,5 @@ ENV SE_SESSION_REQUEST_TIMEOUT 300
 ENV SE_SESSION_RETRY_INTERVAL 15
 # Boolean value, maps "--relax-checks"
 ENV SE_RELAX_CHECKS true
+
+ENV SE_OTEL_SERVICE_NAME "selenium-standalone-docker"

--- a/StandaloneDocker/start-selenium-grid-docker.sh
+++ b/StandaloneDocker/start-selenium-grid-docker.sh
@@ -45,12 +45,28 @@ fi
 
 EXTRA_LIBS=""
 
-if [ ! -z "$SE_ENABLE_TRACING" ]; then
+if [ "$SE_ENABLE_TRACING" = "true" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}
   echo "Tracing is enabled"
   echo "Classpath will be enriched with these external jars : " ${EXTRA_LIBS}
+  if [ -n "$SE_OTEL_SERVICE_NAME" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.resource.attributes=service.name=${SE_OTEL_SERVICE_NAME}"
+  fi
+  if [ -n "$SE_OTEL_TRACES_EXPORTER" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.traces.exporter=${SE_OTEL_TRACES_EXPORTER}"
+  fi
+  if [ -n "$SE_OTEL_EXPORTER_ENDPOINT" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.exporter.${SE_OTEL_TRACES_EXPORTER,,}.endpoint=${SE_OTEL_EXPORTER_ENDPOINT}"
+  fi
+  if [ -n "$SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED" ]; then
+    SE_OTEL_JVM_ARGS="$SE_OTEL_JVM_ARGS -Dotel.java.global-autoconfigure.enabled=${SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED}"
+  fi
+  if [ -n "$SE_OTEL_JVM_ARGS" ]; then
+    echo "List arguments for OpenTelemetry: ${SE_OTEL_JVM_ARGS}"
+    SE_JAVA_OPTS="$SE_JAVA_OPTS ${SE_OTEL_JVM_ARGS}"
+  fi
 else
   echo "Tracing is disabled"
 fi

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -14,6 +14,10 @@ dependencies:
   version: 4.9.0
   name: ingress-nginx
   condition: ingress-nginx.enabled
+- repository: https://jaegertracing.github.io/helm-charts
+  version: 1.0.0
+  name: jaeger
+  condition: tracing.enabled
 maintainers:
   - name: SeleniumHQ
     email: selenium-developers@googlegroups.com

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -619,6 +619,28 @@ tls:
     value: "matchThisSecret"
 ```
 
+### Configuration of tracing observability
+
+The chart supports tracing observability via Jaeger. To enable it, you need to set the following values:
+
+```yaml
+tracing:
+  enabled: true
+```
+
+With this configuration, by default, Jaeger (all-in-one) will be deployed in the same namespace as Selenium Grid.
+The Jaeger UI can be accessed via same ingress with prefix `/jaeger`, for example: `http://your.host.name/jaeger`.
+The traces will be collected from all the components of Selenium Grid and can be viewed in the Jaeger UI.
+
+In case you want to use your own existing Jaeger instance, you can set the following values:
+
+```yaml
+tracing:
+    enabledWithExistingEndpoint: true
+    exporter: otlp #or jaeger
+    exporterEndpoint: 'http://jaeger.domain.com:4317' #or 'http://jaeger.domain.com:14250'
+```
+
 ### Configuration of Selenium Grid chart
 This table contains the configuration parameters of the chart and their default values:
 
@@ -825,6 +847,11 @@ https://github.com/kedacore/charts/blob/main/keda/README.md for more details.
 
 If you are setting `ingress-nginx.enabled` to `true`, chart Ingress NGINX Controller is installed and can be configured with
 values with the prefix `ingress-nginx`. See https://github.com/kubernetes/ingress-nginx for more details.
+
+### Configuration of Jaeger
+
+If you are setting `tracing.enabled` to `true`, chart Jaeger is installed and can be configured with
+values with the prefix `jaeger`. See https://github.com/jaegertracing/helm-charts for more details.
 
 ### Configuration for Selenium-Hub
 

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -111,6 +111,13 @@ Is autoscaling using KEDA enabled
 {{- end -}}
 
 {{/*
+Is tracing enabled
+*/}}
+{{- define "seleniumGrid.enableTracing" -}}
+{{- or .Values.tracing.enabled .Values.tracing.enabledWithExistingEndpoint | ternary "true" "" -}}
+{{- end -}}
+
+{{/*
 Common autoscaling spec template
 */}}
 {{- define "seleniumGrid.autoscalingTemplate" -}}
@@ -190,6 +197,8 @@ template:
         image: {{ printf "%s/%s:%s" $imageRegistry .node.imageName $imageTag }}
         imagePullPolicy: {{ .node.imagePullPolicy }}
         env:
+          - name: SE_OTEL_SERVICE_NAME
+            value: {{ .name | quote }}
           - name: SE_NODE_PORT
             value: {{ .node.port | quote }}
         {{- with .node.extraEnvironmentVariables }}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           image: {{ printf "%s/%s:%s" $imageRegistry .Values.components.distributor.imageName $imageTag }}
           imagePullPolicy: {{ .Values.components.distributor.imagePullPolicy }}
           env:
+            - name: SE_OTEL_SERVICE_NAME
+              value: '{{ template "seleniumGrid.distributor.fullname" . }}'
             - name: SE_DISTRIBUTOR_HOST
               value: '{{ template "seleniumGrid.distributor.fullname" . }}.{{ .Release.Namespace }}'
             - name: SE_DISTRIBUTOR_PORT

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -40,6 +40,8 @@ spec:
             - containerPort: {{ .Values.components.eventBus.subscribePort }}
               protocol: TCP
           env:
+            - name: SE_OTEL_SERVICE_NAME
+              value: '{{ template "seleniumGrid.eventBus.fullname" . }}'
             - name: SE_EVENT_BUS_HOST
               value: '{{ template "seleniumGrid.eventBus.fullname" . }}.{{ .Release.Namespace }}'
             - name: SE_EVENT_BUS_PORT

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -91,6 +91,8 @@ spec:
           {{- end }}
         {{- end }}
           env:
+            - name: SE_OTEL_SERVICE_NAME
+              value: '{{ template "seleniumGrid.hub.fullname" . }}'
             - name: SE_HUB_HOST
               value: '{{ template "seleniumGrid.hub.fullname" . }}.{{ .Release.Namespace }}'
             - name: SE_HUB_PORT

--- a/charts/selenium-grid/templates/jaeger-ingress.yaml
+++ b/charts/selenium-grid/templates/jaeger-ingress.yaml
@@ -1,0 +1,51 @@
+{{- if and (and .Values.tracing.enabled (not .Values.tracing.enabledWithExistingEndpoint)) .Values.tracing.ingress.enabled }}
+{{- if and .Values.ingress.className (not (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion)) }}
+  {{- if not (hasKey .Values.ingress.annotations "kubernetes.io/ingress.class") }}
+  {{- $_ := set .Values.ingress.annotations "kubernetes.io/ingress.class" .Values.ingress.className}}
+  {{- end }}
+{{- end }}
+apiVersion: networking.k8s.io/v1
+kind: Ingress
+metadata:
+  name: {{ .Release.Name }}-jaeger-ingress
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- with .Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  {{- with .Values.tracing.ingress.annotations }}
+  annotations:
+    {{- . | toYaml | nindent 4 }}
+  {{- end }}
+spec:
+  {{- if and .Values.ingress.className (semverCompare ">=1.18-0" .Capabilities.KubeVersion.GitVersion) }}
+  ingressClassName: {{ .Values.ingress.className }}
+  {{- end }}
+  {{- if and (or .Values.tls.enabled .Values.tls.ingress.generateTLS) (tpl .Values.ingress.hostname $) (not .Values.ingress.tls) }}
+  tls:
+    - hosts:
+        - {{ tpl .Values.ingress.hostname $ | quote }}
+      secretName: {{ include "seleniumGrid.tls.fullname" . | quote }}
+  {{- else if .Values.ingress.tls }}
+  tls:
+    {{- range .Values.ingress.tls }}
+    - hosts:
+        {{- range .hosts }}
+        - {{ tpl . $ | quote }}
+        {{- end }}
+      secretName: {{ tpl (.secretName) $ | quote }}
+    {{- end }}
+  {{- end }}
+  rules:
+    {{- if $.Values.ingress.hostname }}
+    - host: {{ tpl $.Values.ingress.hostname $ }}
+      http:
+    {{- else }}
+    - http:
+    {{- end }}
+        paths:
+        {{- with .Values.tracing.ingress.paths }}
+          {{- tpl (toYaml . | nindent 10) $ }}
+        {{- end }}
+{{- end }}

--- a/charts/selenium-grid/templates/logging-configmap.yaml
+++ b/charts/selenium-grid/templates/logging-configmap.yaml
@@ -13,3 +13,9 @@ metadata:
     {{- end }}
 data:
   SE_LOG_LEVEL: "{{ default "INFO" .Values.global.seleniumGrid.logLevel }}"
+{{- if (eq (include "seleniumGrid.enableTracing" .) "true") }}
+  SE_ENABLE_TRACING: "true"
+  SE_OTEL_TRACES_EXPORTER: {{ .Values.tracing.exporter | quote }}
+  SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED: {{ .Values.tracing.globalAutoConfigure | quote }}
+  SE_OTEL_EXPORTER_ENDPOINT: {{ tpl .Values.tracing.exporterEndpoint $ | quote }}
+{{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           image: {{ printf "%s/%s:%s" $imageRegistry .Values.components.router.imageName $imageTag }}
           imagePullPolicy: {{ .Values.components.router.imagePullPolicy }}
           env:
+            - name: SE_OTEL_SERVICE_NAME
+              value: '{{ template "seleniumGrid.router.fullname" . }}'
             - name: SE_ROUTER_HOST
               value: '{{ template "seleniumGrid.router.fullname" . }}.{{ .Release.Namespace }}'
             - name: SE_ROUTER_PORT

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           image: {{ printf "%s/%s:%s" $imageRegistry .Values.components.sessionMap.imageName $imageTag }}
           imagePullPolicy: {{ .Values.components.sessionMap.imagePullPolicy }}
           env:
+            - name: SE_OTEL_SERVICE_NAME
+              value: '{{ template "seleniumGrid.sessionMap.fullname" . }}'
             - name: SE_SESSIONS_HOST
               value: '{{ template "seleniumGrid.sessionMap.fullname" . }}.{{ .Release.Namespace }}'
             - name: SE_SESSIONS_PORT

--- a/charts/selenium-grid/templates/session-queuer-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queuer-deployment.yaml
@@ -33,6 +33,8 @@ spec:
           image: {{ printf "%s/%s:%s" $imageRegistry .Values.components.sessionQueue.imageName $imageTag }}
           imagePullPolicy: {{ .Values.components.sessionQueue.imagePullPolicy }}
           env:
+            - name: SE_OTEL_SERVICE_NAME
+              value: '{{ template "seleniumGrid.sessionQueue.fullname" . }}'
             - name: SE_SESSION_QUEUE_HOST
               value: '{{ template "seleniumGrid.sessionQueue.fullname" . }}.{{ .Release.Namespace }}'
             - name: SE_SESSION_QUEUE_PORT

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -492,6 +492,24 @@ hub:
   # Priority class name for selenium-hub pods
   priorityClassName: ""
 
+tracing:
+  enabled: false
+  enabledWithExistingEndpoint: false
+  exporter: otlp
+  exporterEndpoint: 'http://{{ .Release.Name }}-jaeger-collector.{{ .Release.Namespace }}:4317'
+  globalAutoConfigure: true
+  ingress:
+    enabled: true
+    annotations:
+    paths:
+      - backend:
+          service:
+            name: '{{ .Release.Name }}-jaeger-query'
+            port:
+              number: 16686
+        path: &jaegerBasePath "/jaeger"
+        pathType: Prefix
+
 # Keda scaled object configuration
 autoscaling:
   # Enable autoscaling. Implies installing KEDA
@@ -1146,3 +1164,21 @@ ingress-nginx:
   controller:
     admissionWebhooks:
       enabled: false
+
+# Configuration for dependency chart jaeger
+jaeger:
+  provisionDataStore:
+    cassandra: false
+  allInOne:
+    enabled: true
+    extraEnv:
+      - name: QUERY_BASE_PATH
+        value: *jaegerBasePath
+  storage:
+    type: none
+  agent:
+    enabled: false
+  collector:
+    enabled: false
+  query:
+    enabled: false

--- a/docker-compose-v2-tracing.yml
+++ b/docker-compose-v2-tracing.yml
@@ -3,8 +3,8 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose-v2-tracing.yml down`
 version: '2'
 services:
-  jaegar:
-    image: jaegertracing/all-in-one:1.17
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
     ports:
       - "16686:16686"
       - "14250:14250"
@@ -18,7 +18,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-chrome
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
     ports:
       - "6900:5900"
 
@@ -32,7 +33,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-edge
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
     ports:
       - "6901:5900"
 
@@ -46,7 +48,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-firefox
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
     ports:
       - "6902:5900"
 
@@ -57,7 +60,8 @@ services:
       - "4443:4443"
       - "4444:4444"
     depends_on:
-      - jaegar
+      - jaeger
     environment:
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-hub
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250

--- a/docker-compose-v3-full-grid-tracing.yml
+++ b/docker-compose-v3-full-grid-tracing.yml
@@ -3,11 +3,12 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose-v3-full-grid-tracing.yml down`
 version: "3"
 services:
-  jaegar:
-    image: jaegertracing/all-in-one:1.17
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
     ports:
       - "16686:16686"
       - "14250:14250"
+      - "4317:4317"
   selenium-event-bus:
     image: selenium/event-bus:4.17.0-20240123
     container_name: selenium-event-bus
@@ -16,10 +17,11 @@ services:
       - "4443:4443"
       - "5557:5557"
     depends_on:
-      - jaegar
+      - jaeger
     environment:
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-event-bus
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   selenium-sessions:
     image: selenium/sessions:4.17.0-20240123
     container_name: selenium-sessions
@@ -32,7 +34,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-sessions
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   selenium-session-queue:
     image: selenium/session-queue:4.17.0-20240123
     container_name: selenium-session-queue
@@ -40,7 +43,8 @@ services:
       - "5559:5559"
     environment:
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-session-queue
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   selenium-distributor:
     image: selenium/distributor:4.17.0-20240123
     container_name: selenium-distributor
@@ -59,7 +63,8 @@ services:
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-distributor
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   selenium-router:
     image: selenium/router:4.17.0-20240123
     container_name: selenium-router
@@ -76,8 +81,9 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=true      
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-router
+      - SE_ENABLE_TRACING=true
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   chrome:
     image: selenium/node-chrome:4.17.0-20240123
     shm_size: 2gb
@@ -88,7 +94,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-chrome      
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   edge:
     image: selenium/node-edge:4.17.0-20240123
     shm_size: 2gb
@@ -98,8 +105,9 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=true      
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-edge
+      - SE_ENABLE_TRACING=true
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
   firefox:
     image: selenium/node-firefox:4.17.0-20240123
     shm_size: 2gb
@@ -110,4 +118,5 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-firefox      
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250

--- a/docker-compose-v3-tracing.yml
+++ b/docker-compose-v3-tracing.yml
@@ -3,11 +3,12 @@
 # To stop the execution, hit Ctrl+C, and then `docker-compose -f docker-compose-v3-tracing.yml down`
 version: "3"
 services:
-  jaegar:
-    image: jaegertracing/all-in-one:1.17
+  jaeger:
+    image: jaegertracing/all-in-one:1.54
     ports:
       - "16686:16686"
       - "14250:14250"
+      - "4317:4317"
   chrome:
     image: selenium/node-chrome:4.17.0-20240123
     shm_size: 2gb
@@ -18,7 +19,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-chrome
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
 
   edge:
     image: selenium/node-edge:4.17.0-20240123
@@ -30,7 +32,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-edge
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
 
   firefox:
     image: selenium/node-firefox:4.17.0-20240123
@@ -42,7 +45,8 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-firefox
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250
 
   selenium-hub:
     image: selenium/hub:4.17.0-20240123
@@ -52,7 +56,8 @@ services:
       - "4443:4443"
       - "4444:4444"
     depends_on:
-      - jaegar
+      - jaeger
     environment:
       - SE_ENABLE_TRACING=true
-      - JAVA_OPTS=-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-hub
+      - SE_OTEL_TRACES_EXPORTER=otlp #or jaeger
+      - SE_OTEL_EXPORTER_ENDPOINT=http://jaeger:4317 #or http://jaeger:14250

--- a/tests/charts/ci/base-auth-ingress-values.yaml
+++ b/tests/charts/ci/base-auth-ingress-values.yaml
@@ -5,11 +5,10 @@ global:
 
 ingress:
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/app-root: &gridAppRoot "/selenium"
-  ingressClassName: nginx
+  className: nginx
   hostname: ""
   paths:
     - path: /selenium(/|$)(.*)

--- a/tests/charts/ci/base-tracing-values.yaml
+++ b/tests/charts/ci/base-tracing-values.yaml
@@ -6,10 +6,6 @@ hub:
       value: "5"
     - name: SE_REJECT_UNSUPPORTED_CAPS
       value: "false"
-    - name: SE_ENABLE_TRACING
-      value: "true"
-    - name: SE_JAVA_OPTS
-      value: "-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://{{ .Release.Name }}-jaeger-all-in-one-headless:14250 -Dotel.resource.attributes=service.name=selenium -Dotel.java.global-autoconfigure.enabled=true"
 
 components:
   extraEnvironmentVariables:
@@ -19,7 +15,3 @@ components:
       value: "5"
     - name: SE_REJECT_UNSUPPORTED_CAPS
       value: "false"
-    - name: SE_ENABLE_TRACING
-      value: "true"
-    - name: SE_JAVA_OPTS
-      value: "-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://{{ .Release.Name }}-jaeger-all-in-one-headless:14250 -Dotel.resource.attributes=service.name=selenium -Dotel.java.global-autoconfigure.enabled=true"

--- a/tests/charts/config/ct.yaml
+++ b/tests/charts/config/ct.yaml
@@ -6,6 +6,7 @@ chart-dirs:
 chart-repos:
   - kedacore=https://kedacore.github.io/charts
   - ingressNginx=https://kubernetes.github.io/ingress-nginx
+  - jaegertracing=https://jaegertracing.github.io/helm-charts
 upgrade: false
 helm-extra-args: --timeout 600s
 check-version-increment: false

--- a/tests/charts/make/chart_cluster_setup.sh
+++ b/tests/charts/make/chart_cluster_setup.sh
@@ -15,6 +15,9 @@ SELENIUM_GRID_HOST=${SELENIUM_GRID_HOST:-"localhost"}
 SELENIUM_GRID_PORT=${SELENIUM_GRID_PORT:-"80"}
 WAIT_TIMEOUT=${WAIT_TIMEOUT:-"90s"}
 SKIP_CLEANUP=${SKIP_CLEANUP:-"false"} # For debugging purposes, retain the cluster after the test run
+KUBERNETES_VERSION=${KUBERNETES_VERSION:-$(curl -L -s https://dl.k8s.io/release/stable.txt)}
+CNI=${CNI:-"calico"} # auto, calico, cilium
+CONTAINER_RUNTIME=${CONTAINER_RUNTIME:-"docker"} # docker, containerd, cri-o
 
 # Function to clean up for retry step on workflow
 cleanup() {
@@ -53,7 +56,7 @@ elif [ "${CLUSTER}" = "minikube" ]; then
   sudo chmod 777 /tmp
   export CHANGE_MINIKUBE_NONE_USER=true
   sudo -SE minikube start --vm-driver=none --cpus ${CPUs} --memory ${MEMORY} \
-  --kubernetes-version=$(curl -L -s https://dl.k8s.io/release/stable.txt) --network-plugin=cni --cni=calico
+  --kubernetes-version=${KUBERNETES_VERSION} --network-plugin=cni --cni=${CNI} --container-runtime=${CONTAINER_RUNTIME}
   sudo chown -R $USER $HOME/.kube $HOME/.minikube
 fi
 

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -26,6 +26,7 @@ SKIP_CLEANUP=${SKIP_CLEANUP:-"false"} # For debugging purposes, retain the clust
 CHART_CERT_PATH=${CHART_CERT_PATH:-"${CHART_PATH}/certs/selenium.pem"}
 SSL_CERT_DIR=${SSL_CERT_DIR:-"/etc/ssl/certs"}
 VIDEO_TAG=${VIDEO_TAG:-"latest"}
+SE_ENABLE_TRACING=${SE_ENABLE_TRACING:-"false"}
 
 cleanup() {
   if [ "${SKIP_CLEANUP}" = "false" ]; then
@@ -65,6 +66,7 @@ HELM_COMMAND_SET_IMAGES=" \
 --set global.seleniumGrid.nodesImageTag=${VERSION} \
 --set global.seleniumGrid.videoImageTag=${VIDEO_TAG} \
 --set autoscaling.scaledOptions.pollingInterval=${AUTOSCALING_POLL_INTERVAL} \
+--set tracing.enabled=${SE_ENABLE_TRACING} \
 "
 
 if [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ]; then

--- a/tests/charts/refValues/sample-aws.yaml
+++ b/tests/charts/refValues/sample-aws.yaml
@@ -11,11 +11,10 @@ global:
 ingress:
   enabled: true
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/app-root: &gridAppRoot "/selenium"
-  ingressClassName: nginx
+  className: nginx
   hostname: "aws.ndviet.org" # Replace with your hostname
   paths:
     - path: /selenium(/|$)(.*)

--- a/tests/charts/refValues/simplex-minikube.yaml
+++ b/tests/charts/refValues/simplex-minikube.yaml
@@ -22,11 +22,10 @@ tls:
 ingress:
   enabled: true
   annotations:
-    kubernetes.io/ingress.class: nginx
     nginx.ingress.kubernetes.io/use-regex: "true"
     nginx.ingress.kubernetes.io/rewrite-target: /$2
     nginx.ingress.kubernetes.io/app-root: &gridAppRoot "/selenium"
-  ingressClassName: nginx
+  className: nginx
   hostname: ""
   paths:
     - path: /selenium(/|$)(.*)


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
feat: enable tracing observability in docker-compose and helm chart

### Motivation and Context
Instead of passing arguments for OpenTelemetry via ENV var `JAVA_OPTS` (or `SE_JAVA_OPTS`), it would be difficult to manage in case appending to an existing value. Create new ENV vars with prefix `SE_OTEL_` for tracing configs

Before:
`JAVA_OPTS="-Dotel.traces.exporter=jaeger -Dotel.exporter.jaeger.endpoint=http://jaegar:14250 -Dotel.resource.attributes=service.name=selenium-node-firefox"`

After:
`SE_OTEL_TRACES_EXPORTER` (default is `otlp`) - pass value to `-Dotel.traces.exporter=`
`SE_OTEL_EXPORTER_ENDPOINT=http://jaegar:4317` - pass value to `-Dotel.exporter.${name}.endpoint=`
In each component, by default, there is ENV `SE_OTEL_SERVICE_NAME` set its component name for argument `-Dotel.resource.attributes=service.name=`

Separate ENV vars for tracing configs also support better in helm chart template

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
