### PR TITLE
Use empty strings as defaults for some empty values

### DIFF
--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -113,8 +113,8 @@ nodeConfigMap:
   # Directory where the extra scripts are mounted to
   extraScriptsDirectory: "/opt/selenium"
   extraScripts:
-    nodePreStop.sh:
-    nodeProbe.sh:
+    nodePreStop.sh: ""
+    nodeProbe.sh: ""
   # Name of volume mount is used to mount scripts in the ConfigMap
   scriptVolumeMountName:
   # Automatic browser leftovers cleanup stuck browser processes, tmp files
@@ -136,8 +136,8 @@ recorderConfigMap:
   extraScriptsDirectory: "/opt/bin"
   # List of extra scripts to be mounted to the container. Format as `filename: content`
   extraScripts:
-  #  video.sh:
-  #  video_graphQLQuery.sh:
+  #  video.sh: ""
+  #  video_graphQLQuery.sh: ""
   # Name of volume mount is used to mount scripts in the ConfigMap
   scriptVolumeMountName:
   videoVolumeMountName: videos
@@ -154,7 +154,7 @@ uploaderConfigMap:
   extraScriptsDirectory: "/opt/bin"
   # List of extra scripts to be mounted to the container. Format as `filename: content`
   extraScripts:
-    upload.sh:
+    upload.sh: ""
   # Extra files stored in Secret to be mounted to the container.
   secretFiles:
     upload.conf: "[sample]"


### PR DESCRIPTION
## **User description**
### Description
Use empty strings as default values for object fields that templates iterate over.

### Motivation and Context
Maybe it's a Helm bug, but the following code produces different results depending on the values of the ".nodeConfigMap.extraScripts" fields:
```
{{- range $fileName, $value := $.Values.nodeConfigMap.extraScripts }}
- name: {{ tpl (default (include "seleniumGrid.node.configmap.fullname" $) $.Values.nodeConfigMap.scriptVolumeMountName) $ }}
  mountPath: {{ $.Values.nodeConfigMap.extraScriptsDirectory }}/{{ $fileName }}
  subPath: {{ $fileName }}
{{- end }}

```
1. Installing selenium-grid chart itself, values are `nil`: correct output
2. Installing selenium-grid chart itself, values are `""`: correct output
3. Installing a chart containing selenium-grid chart as a dependency, values are `nil`: the block above produces empty output, looks like it performs no iterations
4. Installing a chart containing selenium-grid chart as a dependency, values are `""`: correct output

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


___

## **Type**
bug_fix


___

## **Description**
- This PR addresses an issue where Helm templates would not iterate over certain ConfigMap fields when they were `nil`, by setting their default values to empty strings.
- Specifically, it modifies `nodeConfigMap.extraScripts`, `recorderConfigMap.extraScripts`, and `uploaderConfigMap.extraScripts` in the `values.yaml` file of the selenium-grid chart to have empty string defaults for scripts like `nodePreStop.sh`, `nodeProbe.sh`, `video.sh`, `video_graphQLQuery.sh`, and `upload.sh`.
- This change ensures consistent behavior when the selenium-grid chart is installed directly or as a dependency of another chart, regardless of whether the values are `nil` or empty strings.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Set Default Empty String Values for ConfigMap Scripts</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/values.yaml

<li>Set default values for <code>nodeConfigMap.extraScripts</code>, <br><code>recorderConfigMap.extraScripts</code>, and <code>uploaderConfigMap.extraScripts</code> to <br>empty strings.<br> <li> Ensured that scripts like <code>nodePreStop.sh</code>, <code>nodeProbe.sh</code>, <code>video.sh</code>, <br><code>video_graphQLQuery.sh</code>, and <code>upload.sh</code> have empty string defaults to <br>avoid iteration issues in Helm templates.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2176/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

