### PR TITLE
Correctly apply fix for high ulimit

### DIFF
--- a/NodeBase/start-novnc.sh
+++ b/NodeBase/start-novnc.sh
@@ -7,12 +7,14 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ] ; then
     if [ "${START_NO_VNC:-$SE_START_NO_VNC}" = true ] ; then
 
       # Guard against unreasonably high nofile limits. See https://github.com/SeleniumHQ/docker-selenium/issues/2045
-      ULIMIT=${SE_VNC_ULIMIT:-100000}
-      if [[ ${ULIMIT} -ge 100000 ]]; then
-        echo "Trying to update the open file descriptor limit from $(ulimit -n) to ${ULIMIT}."
-        ulimit -Sv ${ULIMIT}
+      # Try to set a new limit if the current limit is too high, or the user explicitly specified a custom limit
+      TOO_HIGH_ULIMIT=100000
+      if [[ $(ulimit -n) -gt $TOO_HIGH_ULIMIT || ! -z "${SE_VNC_ULIMIT}" ]]; then
+        NEW_ULIMIT=${SE_VNC_ULIMIT:-${TOO_HIGH_ULIMIT}}
+        echo "Trying to update the open file descriptor limit from $(ulimit -n) to ${NEW_ULIMIT}."
+        ulimit -n ${NEW_ULIMIT}
         if [ $? -eq 0 ]; then
-          echo "Successfully update the open file descriptor limit."
+          echo "Successfully updated the open file descriptor limit."
         else
           echo "The open file descriptor limit could not be updated."
         fi


### PR DESCRIPTION
## **User description**
### Description

Commit c70621735d71c9862c5c030bca7152d6bb9b829c changed the ulimit workaround so that it no longer works correctly:

* `-Sv` modifies virtual memory, not file descriptors
* The if check doesn't take the current ulimit into consideration, though it succeeds anyways

### Motivation and Context

Should fix #2154. I myself am again able to connect to vnc.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
bug_fix


___

## **Description**
- Corrected the logic and command for updating the open file descriptor limit in both `start-novnc.sh` and `start-vnc.sh` scripts.
- The scripts now check if the current limit is greater than a defined high limit or if a custom limit is specified, then attempt to update it.
- Fixed the use of `ulimit -n` for setting the new limit, replacing the incorrect `ulimit -Sv`.
- Improved feedback messages to accurately reflect the outcome of the limit update attempt.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start-novnc.sh</strong><dd><code>Fix File Descriptor Limit Update in start-novnc.sh</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
NodeBase/start-novnc.sh

<li>Corrected the logic to update the open file descriptor limit based on <br>a new or existing high limit.<br> <li> Fixed the command to change the limit (<code>ulimit -n</code>) and adjusted the <br>condition to check the current limit.<br> <li> Improved the echo statements for success and failure of updating the <br>limit.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2192/files#diff-af57e606744eebd8871cc47d3487377f4ceab8acc2abac2236d7b6fa41ceaf44">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>start-vnc.sh</strong><dd><code>Correct File Descriptor Limit Adjustment in start-vnc.sh</code>&nbsp; </dd></summary>
<hr>
      
NodeBase/start-vnc.sh

<li>Updated the logic for setting a new file descriptor limit if the <br>current is too high or a custom limit is specified.<br> <li> Changed the <code>ulimit</code> command to correctly modify the file descriptor <br>limit.<br> <li> Enhanced the output messages for clarity on success or failure of <br>limit update.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2192/files#diff-0dc21857d7f8bf7c04f278a449432133894507b870bbe534f0d1dc675e59840e">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

