### PR TITLE
fix(chart): job to patch scaledobject stuck in deleting

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -51,7 +51,11 @@ jobs:
         env:
           AUTHORS: ${{ vars.AUTHORS || 'SeleniumHQ' }}
       - name: Build Docker images
-        run: VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 12
+          max_attempts: 3
+          command: VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build
       - name: Count image layers
         run: VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make count_image_layers
       - name: Test Docker images

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -116,7 +116,11 @@ jobs:
           echo "CHART_PACKAGE_PATH=$(cat /tmp/selenium_chart_version)" >> $GITHUB_ENV
           echo "CHART_FILE_NAME=$(basename $(cat /tmp/selenium_chart_version))" >> $GITHUB_ENV
       - name: Build Docker images
-        run: NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 12
+          max_attempts: 3
+          command: NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build
       - name: Setup Kubernetes cluster
         uses: nick-invision/retry@master
         with:

--- a/.github/workflows/test-video.yml
+++ b/.github/workflows/test-video.yml
@@ -67,11 +67,15 @@ jobs:
         env:
           AUTHORS: ${{ vars.AUTHORS || 'SeleniumHQ' }}
       - name: Pre-build to reduce logs in test phase
-        run: |
-          VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make hub
-          VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make chrome
-          VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make firefox
-          VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make edge
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 12
+          max_attempts: 3
+          command: |
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make hub
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make chrome
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make firefox
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make edge
       - name: Set test parameters
         if: (github.event_name == 'schedule' || github.event_name == 'workflow_dispatch')
         run: |

--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -55,7 +55,7 @@ RUN  echo "deb http://archive.ubuntu.com/ubuntu jammy main universe\n" > /etc/ap
     gnupg2 \
     libnss3-tools \
   && mkdir -p /etc/apt/keyrings \
-  && apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 843C48A565F8F04B \
+  && apt-key adv --keyserver hkps://keyserver.ubuntu.com:443 --recv-keys 843C48A565F8F04B || apt-key adv --keyserver keyserver.ubuntu.com --recv-keys 843C48A565F8F04B \
   && wget -qO - https://packages.adoptium.net/artifactory/api/gpg/key/public | tee /etc/apt/keyrings/adoptium.asc >dev/null \
   && echo "deb [signed-by=/etc/apt/keyrings/adoptium.asc] https://packages.adoptium.net/artifactory/deb $(awk -F= '/^VERSION_CODENAME/{print$2}' /etc/os-release) main" | tee /etc/apt/sources.list.d/adoptium.list >dev/null \
   && apt-get -qqy update \

--- a/charts/selenium-grid/templates/_nameHelpers.tpl
+++ b/charts/selenium-grid/templates/_nameHelpers.tpl
@@ -39,6 +39,13 @@ app.kubernetes.io/component: {{ printf "selenium-grid-%s" .Chart.AppVersion }}
 helm.sh/chart: {{ include "seleniumGrid.chart" . }}
 {{- end -}}
 
+{{/*
+Autoscaling labels
+*/}}
+{{- define "seleniumGrid.autoscalingLabels" -}}
+component.autoscaling: "true"
+{{- end -}}
+
 {{- define "seleniumGrid.component.name" -}}
 {{- $component := index . 0 }}
 {{- $root := index . 1 }}
@@ -180,4 +187,25 @@ Server ConfigMap fullname
 */}}
 {{- define "seleniumGrid.server.configmap.fullname" -}}
 {{- tpl (default (include "seleniumGrid.component.name" (list "selenium-server-config" $)) .Values.serverConfigMap.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Patch scaledObjects finalizers job fullname
+*/}}
+{{- define "seleniumGrid.keda.patchObjectsJob.fullname" -}}
+{{- printf "%s-%s" .Release.Name "patch-scaledobjects-finalizers" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Patch scaled objects RoleBinding fullname
+*/}}
+{{- define "seleniumGrid.keda.roleBinding.fullname" -}}
+{{- printf "%s-%s" .Release.Name "patch-keda-rb" | trunc 63 | trimSuffix "-" -}}
+{{- end -}}
+
+{{/*
+Patch scaled objects Role fullname
+*/}}
+{{- define "seleniumGrid.keda.role.fullname" -}}
+{{- printf "%s-%s" .Release.Name "patch-keda-role" | trunc 63 | trimSuffix "-" -}}
 {{- end -}}

--- a/charts/selenium-grid/templates/chrome-node-hpa.yaml
+++ b/charts/selenium-grid/templates/chrome-node-hpa.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     deploymentName: {{ template "seleniumGrid.chromeNode.fullname" . }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
     {{- with .Values.chromeNode.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
+++ b/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
@@ -12,6 +12,7 @@ metadata:
     app: {{ template "seleniumGrid.chromeNode.fullname" . }}
     app.kubernetes.io/name: {{ template "seleniumGrid.chromeNode.fullname" . }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
     {{- with .Values.chromeNode.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/selenium-grid/templates/edge-node-hpa.yaml
+++ b/charts/selenium-grid/templates/edge-node-hpa.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     deploymentName: {{ template "seleniumGrid.edgeNode.fullname" . }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
     {{- with .Values.edgeNode.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/selenium-grid/templates/edge-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/edge-node-scaledjob.yaml
@@ -12,6 +12,7 @@ metadata:
     app: {{ template "seleniumGrid.edgeNode.fullname" . }}
     app.kubernetes.io/name: {{ template "seleniumGrid.edgeNode.fullname" . }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
     {{- with .Values.edgeNode.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-hpa.yaml
+++ b/charts/selenium-grid/templates/firefox-node-hpa.yaml
@@ -11,6 +11,7 @@ metadata:
   labels:
     deploymentName: {{ template "seleniumGrid.firefoxNode.fullname" . }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
     {{- with .Values.firefoxNode.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
@@ -12,6 +12,7 @@ metadata:
     app: {{ template "seleniumGrid.firefoxNode.fullname" . }}
     app.kubernetes.io/name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
     {{- with .Values.firefoxNode.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}

--- a/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
@@ -1,0 +1,35 @@
+{{- if eq (include "seleniumGrid.useKEDA" $) "true" }}
+apiVersion: batch/v1
+kind: Job
+metadata:
+  name: {{ template "seleniumGrid.keda.patchObjectsJob.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
+  annotations:
+    "helm.sh/hook-delete-policy": hook-succeeded
+    "helm.sh/resource-policy": delete
+    {{- with $.Values.autoscaling.annotations }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+  labels:
+    deploymentName: {{ template "seleniumGrid.keda.patchObjectsJob.fullname" $ }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $.Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  template:
+    metadata:
+      name: {{ template "seleniumGrid.keda.patchObjectsJob.fullname" $ }}
+    spec:
+      activeDeadlineSeconds: 120
+      serviceAccountName: {{ template "seleniumGrid.serviceAccount.fullname" $ }}
+      serviceAccount: {{ template "seleniumGrid.serviceAccount.fullname" $ }}
+      containers:
+        - name: {{ template "seleniumGrid.keda.patchObjectsJob.fullname" $ }}
+          image: {{ $.Values.global.seleniumGrid.kubectlImage }}
+          command:
+            - "bin/bash"
+            - "-c"
+            - "kubectl get ScaledObjects,ScaledJobs -n {{ .Release.Namespace }} -l component.autoscaling=true -o=json | jq '.metadata.finalizers = null' | kubectl apply -f -"
+      restartPolicy: Never
+{{- end }}

--- a/charts/selenium-grid/templates/patch-keda/patch-keda-rb.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-rb.yaml
@@ -1,0 +1,20 @@
+{{- if eq (include "seleniumGrid.useKEDA" $) "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: {{ template "seleniumGrid.keda.roleBinding.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    deploymentName: {{ template "seleniumGrid.keda.roleBinding.fullname" $ }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $.Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+subjects:
+  - kind: ServiceAccount
+    name: {{ template "seleniumGrid.serviceAccount.fullname" $ }}
+roleRef:
+  kind: Role
+  name: {{ template "seleniumGrid.keda.role.fullname" $ }}
+  apiGroup: rbac.authorization.k8s.io
+{{- end }}

--- a/charts/selenium-grid/templates/patch-keda/patch-keda-role.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-role.yaml
@@ -1,0 +1,37 @@
+{{- if eq (include "seleniumGrid.useKEDA" $) "true" }}
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: {{ template "seleniumGrid.keda.role.fullname" $ }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    deploymentName: {{ template "seleniumGrid.keda.role.fullname" $ }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $.Values.customLabels }}
+      {{- toYaml . | nindent 4 }}
+    {{- end }}
+rules:
+  - apiGroups:
+      - keda.sh
+    resources:
+      - scaledjobs
+      - scaledjobs/finalizers
+      - scaledjobs/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - keda.sh
+    resources:
+      - scaledobjects
+      - scaledobjects/finalizers
+      - scaledobjects/status
+    verbs:
+      - '*'
+  - apiGroups:
+      - keda.sh
+    resources:
+      - triggerauthentications
+      - triggerauthentications/status
+    verbs:
+      - '*'
+{{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -12,6 +12,8 @@ global:
     nodesImageTag: 4.19.1-20240402
     # Image tag for browser's video recorder
     videoImageTag: ffmpeg-7.0-20240402
+    # kubectl image is used to execute kubectl commands in utility jobs
+    kubectlImage: bitnami/kubectl:latest
     # Pull secret for all components, can be overridden individually
     imagePullSecret: ""
     # Log level for all components. Possible values describe here: https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging
@@ -546,7 +548,7 @@ autoscaling:
   scalingType: job
   # Annotations for KEDA resources: ScaledObject and ScaledJob
   annotations:
-    "helm.sh/hook": post-install
+    "helm.sh/hook": post-install,post-upgrade,post-rollback,pre-delete
   # Options for KEDA scaled resources (keep only common options used for both ScaledJob and ScaledObject)
   scaledOptions:
     minReplicaCount: 0
@@ -1185,7 +1187,7 @@ customLabels: {}
 # Configuration for dependency chart keda
 keda:
   additionalAnnotations:
-    "helm.sh/hook": pre-install
+    "helm.sh/hook": pre-install,pre-upgrade,pre-rollback,post-delete
   http:
     timeout: 60000
   webhooks:
@@ -1221,19 +1223,19 @@ prometheus-stack:
   defaultRules:
     create: true
     annotations:
-      "helm.sh/hook": post-install
+      "helm.sh/hook": post-install,post-upgrade,post-rollback,pre-delete
   alertmanager:
     enabled: true
     annotations:
-      "helm.sh/hook": post-install
+      "helm.sh/hook": post-install,post-upgrade,post-rollback,pre-delete
   grafana:
     enabled: true
     adminPassword: admin
     forceDeployDatasources: true
     forceDeployDashboards: true
     annotations:
-      "helm.sh/hook": post-install
+      "helm.sh/hook": post-install,post-upgrade,post-rollback,pre-delete
   prometheus:
     enabled: true
     annotations:
-      "helm.sh/hook": post-install
+      "helm.sh/hook": post-install,post-upgrade,post-rollback,pre-delete

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -97,19 +97,19 @@ HELM_COMMAND_SET_IMAGES=" \
 --set global.seleniumGrid.logLevel=${LOG_LEVEL} \
 "
 
-if [ "${TEST_EXISTING_KEDA}" = "true" ]; then
+if [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ] && [ "${TEST_EXISTING_KEDA}" = "true" ]; then
   HELM_COMMAND_SET_IMAGES="${HELM_COMMAND_SET_IMAGES} \
   --set autoscaling.enabled=false \
   --set autoscaling.enableWithExistingKEDA=true \
   "
-else
+elif [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ] && [ "${TEST_EXISTING_KEDA}" = "true" ]; then
   HELM_COMMAND_SET_IMAGES="${HELM_COMMAND_SET_IMAGES} \
   --set autoscaling.enabled=true \
   --set autoscaling.enableWithExistingKEDA=false \
   "
 fi
 
-if [ -n "${SET_MAX_REPLICAS}" ]; then
+if [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ] && [ -n "${SET_MAX_REPLICAS}" ]; then
   HELM_COMMAND_SET_IMAGES="${HELM_COMMAND_SET_IMAGES} \
   --set autoscaling.scaledOptions.maxReplicaCount=${SET_MAX_REPLICAS} \
   "
@@ -151,7 +151,6 @@ fi
 
 if [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ]; then
   HELM_COMMAND_SET_AUTOSCALING=" \
-  --set autoscaling.enableWithExistingKEDA=${SELENIUM_GRID_AUTOSCALING} \
   --set autoscaling.scaledOptions.minReplicaCount=${SELENIUM_GRID_AUTOSCALING_MIN_REPLICA} \
   "
 fi


### PR DESCRIPTION
## **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Fix: https://github.com/SeleniumHQ/docker-selenium/issues/2196

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, bug_fix


___

## **Description**
- Introduced retry strategies in GitHub Actions workflows to improve build reliability.
- Enhanced Dockerfile to use a more reliable keyserver with a fallback option.
- Added multiple Helm templates for managing autoscaling with KEDA, including jobs, roles, and role bindings.
- Modified chart test scripts to conditionally enable autoscaling features based on environment settings.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>chart_test.sh</strong><dd><code>Enhance autoscaling conditions in chart test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
tests/charts/make/chart_test.sh

<li>Added condition to enable autoscaling only if <br><code>SELENIUM_GRID_AUTOSCALING</code> is true.<br> <li> Adjusted Helm command settings based on autoscaling and existing KEDA <br>configurations.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-811a856b3f51ff08b956e27feb70420c8a8341e610a40eecb06d30c6ffe7f9bc">+3/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_nameHelpers.tpl</strong><dd><code>Add new Helm template helpers for autoscaling and KEDA</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/templates/_nameHelpers.tpl

<li>Added new template definitions for autoscaling labels and various <br>Kubernetes resources related to KEDA.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-81a82f068405c6e0c78f9c712e58508ee92d328bcd4329cfdb7f7c3b25c11282">+28/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build-test.yml</strong><dd><code>Implement retry strategy in build-test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/build-test.yml

<li>Replaced direct <code>make build</code> command with a retry strategy using <br><code>nick-invision/retry</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helm-chart-test.yml</strong><dd><code>Apply retry strategy in helm-chart-test workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/helm-chart-test.yml

<li>Applied retry strategy for Docker image building in Helm chart <br>testing.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-4a8a322b12899fb1d6c3c11d85f3f42b3486d64a25e6a3cd20e521bc94140897">+5/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>test-video.yml</strong><dd><code>Introduce retry strategy in test-video workflow</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
.github/workflows/test-video.yml

<li>Introduced retry strategy for pre-building Docker images to reduce <br>logs in test phase.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-cb40382956a68b06b7b6b0fa48f13cfc7cbfceffb2541bd36ccfffdd9b05b91b">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update keyserver URL with fallback in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Base/Dockerfile

<li>Modified keyserver URL and added fallback for key retrieval in <br>Dockerfile.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-c7235ebbda8248c044e6b13da481ae97f4a21846ed2341a056b6b873abaa482b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>patch-keda-objects-job.yaml</strong><dd><code>Add job template for patching KEDA objects</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml

<li>Created a new job template to patch KEDA objects, ensuring clean <br>deletion.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-45939f6d4fb5ad9a484c9afd9221bf408cf9e2c0afa2a5198cdfdb4a2d937a24">+35/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>patch-keda-rb.yaml</strong><dd><code>Introduce RoleBinding template for KEDA</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/templates/patch-keda/patch-keda-rb.yaml

<li>Introduced a new RoleBinding template for KEDA related permissions.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-dfeb227a7e731dd4faa690595559622b5e4d1552c869ea34483be49ea190255f">+20/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>patch-keda-role.yaml</strong><dd><code>Add Role template for KEDA resource management</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/templates/patch-keda/patch-keda-role.yaml

<li>Added a new Role template to manage permissions for KEDA resources.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2222/files#diff-0fedfd0d40f2cb051dc3e25d16c5de784d20b5c9a5c436becd3a6e8261dd8a1a">+37/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

