### PR TITLE
update: browserleftoverscleanup conf start using env var

### DIFF
--- a/NodeChrome/chrome-cleanup.conf
+++ b/NodeChrome/chrome-cleanup.conf
@@ -3,11 +3,11 @@
 ; Priority 0 - xvfb & fluxbox, 5 - x11vnc, 10 - noVNC, 15 - selenium-node
 
 [program:browserleftoverscleanup]
-priority=0
+priority=20
 command=bash -c "if [ ${SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP} = "true" ]; then /opt/bin/chrome-cleanup.sh; fi"
-autostart=true
-exitcodes=0
-autorestart=unexpected
+autostart=%(ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP)s
+autorestart=%(ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP)s
+stopsignal=INT
 
 ;Logs
 redirect_stderr=false

--- a/NodeEdge/edge-cleanup.conf
+++ b/NodeEdge/edge-cleanup.conf
@@ -3,11 +3,11 @@
 ; Priority 0 - xvfb & fluxbox, 5 - x11vnc, 10 - noVNC, 15 - selenium-node
 
 [program:browserleftoverscleanup]
-priority=0
+priority=20
 command=bash -c "if [ ${SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP} = "true" ]; then /opt/bin/edge-cleanup.sh; fi"
-autostart=true
-exitcodes=0
-autorestart=unexpected
+autostart=%(ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP)s
+autorestart=%(ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP)s
+stopsignal=INT
 
 ;Logs
 redirect_stderr=false

--- a/NodeFirefox/firefox-cleanup.conf
+++ b/NodeFirefox/firefox-cleanup.conf
@@ -3,11 +3,11 @@
 ; Priority 0 - xvfb & fluxbox, 5 - x11vnc, 10 - noVNC, 15 - selenium-node
 
 [program:browserleftoverscleanup]
-priority=0
+priority=20
 command=bash -c "if [ ${SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP} = "true" ]; then /opt/bin/firefox-cleanup.sh; fi"
-autostart=true
-exitcodes=0
-autorestart=unexpected
+autostart=%(ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP)s
+autorestart=%(ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP)s
+stopsignal=INT
 
 ;Logs
 redirect_stderr=false


### PR DESCRIPTION
## **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
Resolve confused logs even this feat is not enabled

```bash
firefox-1     | 2024-04-29T13:36:39.008880005Z 2024-04-29 13:36:39,008 INFO exited: browserleftoverscleanup (exit status 0; not expected)
firefox-1     | 2024-04-29T13:36:40.233644881Z 2024-04-29 13:36:40,233 INFO spawned: 'browserleftoverscleanup' with pid 104
firefox-1     | 2024-04-29T13:36:40.262890714Z 2024-04-29 13:36:40,262 INFO exited: browserleftoverscleanup (exit status 0; not expected)
firefox-1     | 2024-04-29T13:36:43.036568882Z 2024-04-29 13:36:43,036 INFO exited: browserleftoverscleanup (exit status 0; not expected)
firefox-1     | 2024-04-29T13:36:46.051412883Z 2024-04-29 13:36:46,051 INFO spawned: 'browserleftoverscleanup' with pid 196
firefox-1     | 2024-04-29T13:36:46.082746592Z 2024-04-29 13:36:46,082 INFO exited: browserleftoverscleanup (exit status 0; not expected)
firefox-1     | 2024-04-29T13:36:47.087824384Z 2024-04-29 13:36:47,087 INFO gave up: browserleftoverscleanup entered FATAL state, too many start retries too quickly
...
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
enhancement, configuration changes


___

## **Description**
- Updated the cleanup configuration files for Chrome, Edge, and Firefox.
- The `browserleftoverscleanup` program's priority has been increased to 20 for better process management.
- `autostart` and `autorestart` properties are now dynamically set based on the `ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP` environment variable, allowing conditional execution based on environment settings.
- The stop signal for the cleanup process has been standardized to `INT` across all configurations.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome-cleanup.conf</strong><dd><code>Update Chrome Cleanup Configuration for Conditional Execution</code></dd></summary>
<hr>
      
NodeChrome/chrome-cleanup.conf

<li>Increased the priority of the <code>browserleftoverscleanup</code> program from 0 <br>to 20.<br> <li> Changed <code>autostart</code> and <code>autorestart</code> to be controlled by the environment <br>variable <code>ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP</code>.<br> <li> Set the stop signal to <code>INT</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2245/files#diff-6cbfe56ab3510b06fc76a611a1cdb0e9d22b45f208f0ad17f060fb67763a9bf6">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge-cleanup.conf</strong><dd><code>Update Edge Cleanup Configuration for Conditional Execution</code></dd></summary>
<hr>
      
NodeEdge/edge-cleanup.conf

<li>Increased the priority of the <code>browserleftoverscleanup</code> program from 0 <br>to 20.<br> <li> Changed <code>autostart</code> and <code>autorestart</code> to be controlled by the environment <br>variable <code>ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP</code>.<br> <li> Set the stop signal to <code>INT</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2245/files#diff-b4a8f8c9abba0f97a352f482f992dfbf7a9b3bff742dd895ff47c5601d4af4b5">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox-cleanup.conf</strong><dd><code>Update Firefox Cleanup Configuration for Conditional Execution</code></dd></summary>
<hr>
      
NodeFirefox/firefox-cleanup.conf

<li>Increased the priority of the <code>browserleftoverscleanup</code> program from 0 <br>to 20.<br> <li> Changed <code>autostart</code> and <code>autorestart</code> to be controlled by the environment <br>variable <code>ENV_SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP</code>.<br> <li> Set the stop signal to <code>INT</code>.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2245/files#diff-2cc9efa232a7ba20e7c579c56a9151325e7ed00a6406592d875fa1ac83cc8bd1">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

