### PR TITLE
update: Rollback FFmpeg v6.1.1

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -17,9 +17,9 @@ BUILD_ARGS := $(BUILD_ARGS)
 MAJOR := $(word 1,$(subst ., ,$(TAG_VERSION)))
 MINOR := $(word 2,$(subst ., ,$(TAG_VERSION)))
 MAJOR_MINOR_PATCH := $(word 1,$(subst -, ,$(TAG_VERSION)))
-FFMPEG_TAG_VERSION := $(or $(FFMPEG_TAG_VERSION),$(FFMPEG_TAG_VERSION),ffmpeg-7.0)
-FFMPEG_BASED_NAME := $(or $(FFMPEG_BASED_NAME),$(FFMPEG_BASED_NAME),ndviet)
-FFMPEG_BASED_TAG := $(or $(FFMPEG_BASED_TAG),$(FFMPEG_BASED_TAG),7.0-ubuntu2204)
+FFMPEG_TAG_VERSION := $(or $(FFMPEG_TAG_VERSION),$(FFMPEG_TAG_VERSION),ffmpeg-6.1.1)
+FFMPEG_BASED_NAME := $(or $(FFMPEG_BASED_NAME),$(FFMPEG_BASED_NAME),linuxserver)
+FFMPEG_BASED_TAG := $(or $(FFMPEG_BASED_TAG),$(FFMPEG_BASED_TAG),version-6.1.1-cli)
 PLATFORMS := $(or $(PLATFORMS),$(PLATFORMS),linux/amd64)
 
 all: hub \
@@ -476,9 +476,9 @@ test_video: video hub chrome firefox edge
 	done
 	# Using ffmpeg to verify file integrity
 	# https://superuser.com/questions/100288/how-can-i-check-the-integrity-of-a-video-file-avi-mpeg-mp4
-	docker run -u $$(id -u) -v $$(pwd):$$(pwd) -w $$(pwd) $(FFMPEG_BASED_NAME)/ffmpeg:$(FFMPEG_BASED_TAG) -v error -i ./tests/videos/chrome_video.mp4 -f null - 2>error.log
-	docker run -u $$(id -u) -v $$(pwd):$$(pwd) -w $$(pwd) $(FFMPEG_BASED_NAME)/ffmpeg:$(FFMPEG_BASED_TAG) -v error -i ./tests/videos/firefox_video.mp4 -f null - 2>error.log
-	docker run -u $$(id -u) -v $$(pwd):$$(pwd) -w $$(pwd) $(FFMPEG_BASED_NAME)/ffmpeg:$(FFMPEG_BASED_TAG) -v error -i ./tests/videos/edge_video.mp4 -f null - 2>error.log
+	docker run -u $$(id -u) -v $$(pwd):$$(pwd) -w $$(pwd) --entrypoint="" $(FFMPEG_BASED_NAME)/ffmpeg:$(FFMPEG_BASED_TAG) ffmpeg -v error -i ./tests/videos/chrome_video.mp4 -f null - 2>error.log
+	docker run -u $$(id -u) -v $$(pwd):$$(pwd) -w $$(pwd) --entrypoint="" $(FFMPEG_BASED_NAME)/ffmpeg:$(FFMPEG_BASED_TAG) ffmpeg -v error -i ./tests/videos/firefox_video.mp4 -f null - 2>error.log
+	docker run -u $$(id -u) -v $$(pwd):$$(pwd) -w $$(pwd) --entrypoint="" $(FFMPEG_BASED_NAME)/ffmpeg:$(FFMPEG_BASED_TAG) ffmpeg -v error -i ./tests/videos/edge_video.mp4 -f null - 2>error.log
 
 test_node_docker: hub standalone_docker standalone_chrome standalone_firefox standalone_edge video
 	sudo rm -rf ./tests/tests

--- a/NodeDocker/config.toml
+++ b/NodeDocker/config.toml
@@ -14,7 +14,7 @@ configs = [
 # socat -4 TCP-LISTEN:2375,fork UNIX-CONNECT:/var/run/docker.sock
 url = "http://127.0.0.1:2375"
 # Docker image used for video recording
-video-image = "selenium/video:ffmpeg-7.0-20240425"
+video-image = "selenium/video:ffmpeg-6.1.1-20240425"
 
 # Uncomment the following section if you are running the node on a separate VM
 # Fill out the placeholders with appropriate values

--- a/README.md
+++ b/README.md
@@ -512,7 +512,7 @@ ___
 
 ## Video recording
 
-Tests execution can be recorded by using the `selenium/video:ffmpeg-7.0-20240425`
+Tests execution can be recorded by using the `selenium/video:ffmpeg-6.1.1-20240425`
 Docker image. One container is needed per each container where a browser is running. This means if you are
 running 5 Nodes/Standalone containers, you will need 5 video containers, the mapping is 1-1.
 
@@ -522,6 +522,10 @@ Currently, the only way to do this mapping is manually (either starting the cont
 The video Docker image we provide is based on the ffmpeg Ubuntu image provided by the 
 [jrottenberg/ffmpeg](https://github.com/jrottenberg/ffmpeg) project, thank you for providing this image and
 simplifying our work :tada:
+
+From image tag based `4.20.0` onwards, the video Docker image is based on the FFmpeg Ubuntu image provided by
+[linuxserver/docker-ffmpeg](https://github.com/linuxserver/docker-ffmpeg) project since the image is available for multi-platform.
+Thank you for simplifying our project and helping us move forward with multiple architecture support.
 
 **Notes**:
 - If you have questions or feedback, please use the community contact points shown [here](https://www.selenium.dev/support/). 
@@ -539,7 +543,7 @@ This example shows how to start the containers manually:
 ``` bash
 $ docker network create grid
 $ docker run -d -p 4444:4444 -p 6900:5900 --net grid --name selenium --shm-size="2g" selenium/standalone-chrome:4.20.0-20240425
-$ docker run -d --net grid --name video -v /tmp/videos:/videos selenium/video:ffmpeg-7.0-20240425
+$ docker run -d --net grid --name video -v /tmp/videos:/videos selenium/video:ffmpeg-6.1.1-20240425
 # Run your tests
 $ docker stop video && docker rm video
 $ docker stop selenium && docker rm selenium
@@ -559,7 +563,7 @@ Besides the video recording mentioned above, you can enable the upload functiona
 version: "3"
 services:
   chrome_video:
-    image: selenium/video:nightly
+    image: selenium/video:ffmpeg-6.1.1-20240425
     depends_on:
       - chrome
     environment:
@@ -630,7 +634,7 @@ host-config-keys = ["Dns", "DnsOptions", "DnsSearch", "ExtraHosts", "Binds"]
 # Linux: varies from machine to machine, please mount /var/run/docker.sock. If this does not work, please create an issue.
 url = "http://127.0.0.1:2375"
 # Docker image used for video recording
-video-image = "selenium/video:ffmpeg-7.0-20240425"
+video-image = "selenium/video:ffmpeg-6.1.1-20240425"
 
 # Uncomment the following section if you are running the node on a separate VM
 # Fill out the placeholders with appropriate values
@@ -765,7 +769,7 @@ configs = [
 # Linux: varies from machine to machine, please mount /var/run/docker.sock. If this does not work, please create an issue.
 url = "http://127.0.0.1:2375"
 # Docker image used for video recording
-video-image = "selenium/video:ffmpeg-7.0-20240425"
+video-image = "selenium/video:ffmpeg-6.1.1-20240425"
 
 # Uncomment the following section if you are running the node on a separate VM
 # Fill out the placeholders with appropriate values

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -299,20 +299,20 @@ ingress-nginx:
 ### Configuration global
 For now, global configuration supported is:
 
-| Parameter                                       | Default               | Description                               |
-|-------------------------------------------------|-----------------------|-------------------------------------------|
-| `global.K8S_PUBLIC_IP`                          | `""`                  | Public IP of the host running K8s         |
-| `global.seleniumGrid.imageRegistry`             | `selenium`            | Distribution registry to pull images      |
-| `global.seleniumGrid.imageTag`                  | `4.20.0-20240425`     | Image tag for all selenium components     |
-| `global.seleniumGrid.nodesImageTag`             | `4.20.0-20240425`     | Image tag for browser's nodes             |
-| `global.seleniumGrid.videoImageTag`             | `ffmpeg-7.0-20240425` | Image tag for browser's video recorder    |
-| `global.seleniumGrid.imagePullSecret`           | `""`                  | Pull secret to be used for all images     |
-| `global.seleniumGrid.imagePullSecret`           | `""`                  | Pull secret to be used for all images     |
-| `global.seleniumGrid.affinity`                  | `{}`                  | Affinity assigned globally                |
-| `global.seleniumGrid.logLevel`                  | `INFO`                | Set log level for all components          |
-| `global.seleniumGrid.defaultNodeStartupProbe`   | `exec`                | Default startup probe method in Nodes     |
-| `global.seleniumGrid.defaultNodeLivenessProbe`  | `exec`                | Default liveness probe method in Nodes    |
-| `global.seleniumGrid.stdoutProbeLog`            | `true`                | Enable probe logs output in kubectl logs  |
+| Parameter                                      | Default                 | Description                              |
+|------------------------------------------------|-------------------------|------------------------------------------|
+| `global.K8S_PUBLIC_IP`                         | `""`                    | Public IP of the host running K8s        |
+| `global.seleniumGrid.imageRegistry`            | `selenium`              | Distribution registry to pull images     |
+| `global.seleniumGrid.imageTag`                 | `4.20.0-20240425`       | Image tag for all selenium components    |
+| `global.seleniumGrid.nodesImageTag`            | `4.20.0-20240425`       | Image tag for browser's nodes            |
+| `global.seleniumGrid.videoImageTag`            | `ffmpeg-6.1.1-20240425` | Image tag for browser's video recorder   |
+| `global.seleniumGrid.imagePullSecret`          | `""`                    | Pull secret to be used for all images    |
+| `global.seleniumGrid.imagePullSecret`          | `""`                    | Pull secret to be used for all images    |
+| `global.seleniumGrid.affinity`                 | `{}`                    | Affinity assigned globally               |
+| `global.seleniumGrid.logLevel`                 | `INFO`                  | Set log level for all components         |
+| `global.seleniumGrid.defaultNodeStartupProbe`  | `exec`                  | Default startup probe method in Nodes    |
+| `global.seleniumGrid.defaultNodeLivenessProbe` | `exec`                  | Default liveness probe method in Nodes   |
+| `global.seleniumGrid.stdoutProbeLog`           | `true`                  | Enable probe logs output in kubectl logs |
 
 #### Configuration `global.K8S_PUBLIC_IP`
 
@@ -845,7 +845,7 @@ This table contains the configuration parameters of the chart and their default 
 | `videoRecorder.enabled`                       | `false`                                     | Enable video recorder for node                                                                                             |
 | `videoRecorder.imageRegistry`                 | `nil`                                       | Distribution registry to pull the image (this overwrites `.global.seleniumGrid.imageRegistry` value)                       |
 | `videoRecorder.imageName`                     | `video`                                     | Selenium video recorder image name                                                                                         |
-| `videoRecorder.imageTag`                      | `ffmpeg-7.0-20240425`                       | Image tag of video recorder                                                                                                |
+| `videoRecorder.imageTag`                      | `ffmpeg-6.1.1-20240425`                     | Image tag of video recorder                                                                                                |
 | `videoRecorder.imagePullPolicy`               | `IfNotPresent`                              | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)                             |
 | `videoRecorder.uploader.enabled`              | `false`                                     | Enable the uploader for videos                                                                                             |
 | `videoRecorder.uploader.destinationPrefix`    | ``                                          | Destination for uploading video file. It is following `rclone` config                                                      |

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -11,7 +11,7 @@ global:
     # Image tag for browser's nodes
     nodesImageTag: 4.20.0-20240425
     # Image tag for browser's video recorder
-    videoImageTag: ffmpeg-7.0-20240425
+    videoImageTag: ffmpeg-6.1.1-20240425
     # kubectl image is used to execute kubectl commands in utility jobs
     kubectlImage: bitnami/kubectl:latest
     # Pull secret for all components, can be overridden individually
@@ -1107,7 +1107,7 @@ videoRecorder:
   # Image of video recorder
   imageName: video
   # Image of video recorder
-  # imageTag: ffmpeg-7.0-20240425
+  # imageTag: ffmpeg-6.1.1-20240425
   # Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images)
   imagePullPolicy: IfNotPresent
   # Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)

--- a/docker-compose-v3-video-upload.yml
+++ b/docker-compose-v3-video-upload.yml
@@ -35,7 +35,7 @@ services:
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
 
   chrome_video:
-    image: selenium/video:ffmpeg-7.0-20240425
+    image: selenium/video:ffmpeg-6.1.1-20240425
     depends_on:
       - chrome
     environment:
@@ -56,7 +56,7 @@ services:
       - RCLONE_CONFIG_S3_NO_CHECK_BUCKET=true
 
   edge_video:
-    image: selenium/video:ffmpeg-7.0-20240425
+    image: selenium/video:ffmpeg-6.1.1-20240425
     depends_on:
       - edge
     environment:
@@ -77,7 +77,7 @@ services:
       - RCLONE_CONFIG_S3_NO_CHECK_BUCKET=true
 
   firefox_video:
-    image: selenium/video:ffmpeg-7.0-20240425
+    image: selenium/video:ffmpeg-6.1.1-20240425
     depends_on:
       - firefox
     environment:

--- a/docker-compose-v3-video.yml
+++ b/docker-compose-v3-video.yml
@@ -34,7 +34,7 @@ services:
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
 
   chrome_video:
-    image: selenium/video:ffmpeg-7.0-20240425
+    image: selenium/video:ffmpeg-6.1.1-20240425
     volumes:
       - /tmp/videos:/videos
     depends_on:
@@ -44,7 +44,7 @@ services:
       - FILE_NAME=chrome_video.mp4
 
   edge_video:
-    image: selenium/video:ffmpeg-7.0-20240425
+    image: selenium/video:ffmpeg-6.1.1-20240425
     volumes:
       - /tmp/videos:/videos
     depends_on:
@@ -54,7 +54,7 @@ services:
       - FILE_NAME=edge_video.mp4
 
   firefox_video:
-    image: selenium/video:ffmpeg-7.0-20240425
+    image: selenium/video:ffmpeg-6.1.1-20240425
     volumes:
       - /tmp/videos:/videos
     depends_on:

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -68,14 +68,18 @@ class SeleniumGenericTests(unittest.TestCase):
 
     def test_play_video(self):
         driver = self.driver
-        driver.get('https://hls-js.netlify.com/demo/')
+        driver.get('https://docs.flowplayer.com/tools/stream-tester')
         wait = WebDriverWait(driver, WEB_DRIVER_WAIT_TIMEOUT)
-        video = wait.until(
-            EC.element_to_be_clickable((By.TAG_NAME, 'video'))
+        play_button = wait.until(
+            EC.element_to_be_clickable((By.TAG_NAME, 'flowplayer-play-icon'))
         )
-        video.click()
+        play_button.click()
+        video = driver.find_element(By.TAG_NAME, 'video')
         wait.until(
             lambda d: d.find_element(By.TAG_NAME, 'video').get_property('currentTime')
+        )
+        wait.until(
+            lambda d: d.find_element(By.TAG_NAME, 'video').get_property('paused') == False
         )
         paused = video.get_property('paused')
         self.assertFalse(paused)


### PR DESCRIPTION
## **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
update: Rollback FFmpeg v6.1.1

### Motivation and Context
- With the video docker image built on top of FFmpeg 7.0, there was a report that the video file integrity failed. The video has file size but could not be opened and viewed.
- From image tag based `4.20.0` onwards, the video Docker image is based on the FFmpeg Ubuntu image provided by
[linuxserver/docker-ffmpeg](https://github.com/linuxserver/docker-ffmpeg) project since the image is available for multi-platform. Thank you for simplifying our project and helping us move forward with multiple architecture support.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

## **Type**
Bug fix, Enhancement


___

## **Description**
- Rolled back FFmpeg version to 6.1.1 across various configurations and Docker Compose files due to issues with video file integrity.
- Updated video testing in Selenium tests to use Flowplayer and enhanced video play status checks.
- Updated documentation and Helm chart values to reflect the changes in FFmpeg version.
- Added acknowledgment for the linuxserver/docker-ffmpeg project in the README.



___



## **Changes walkthrough**
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Update video testing to use Flowplayer and enhance checks</code></dd></summary>
<hr>
      
tests/SeleniumTests/__init__.py

<li>Updated the video test to use a new video player (Flowplayer) and <br>added checks for video play status.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-9e40695776a7c3afc35b1bf6d31682fe8ca531271c4a883063aa428b3915387f">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Bug fix
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Rollback FFmpeg version in Makefile and adjust Docker commands</code></dd></summary>
<hr>
      
Makefile

<li>Changed FFmpeg version back to 6.1.1 and updated the Docker run <br>command to include an entrypoint adjustment.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.toml</strong><dd><code>Update Docker image tag for video recording in config</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
NodeDocker/config.toml

<li>Updated the Docker image tag for video recording to use FFmpeg version <br>6.1.1.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-32d9556efe470bfd59209ca30019c237f3127b269b6231ed96660baeec720153">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update Helm chart values for FFmpeg version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/values.yaml

- Updated the video image tag in Helm chart values to FFmpeg 6.1.1.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-video-upload.yml</strong><dd><code>Update Docker Compose for video upload with FFmpeg version</code></dd></summary>
<hr>
      
docker-compose-v3-video-upload.yml

- Updated the Docker image for video services to FFmpeg 6.1.1.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-088b010a8a9a5ce17247d6fe973bbdf16af1364b9744a9ca64e9b3d083cfe0fb">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-video.yml</strong><dd><code>Update Docker Compose for video services with FFmpeg version</code></dd></summary>
<hr>
      
docker-compose-v3-video.yml

- Updated the Docker image for video services to FFmpeg 6.1.1.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-811fb2e56a7dc4dbc7032b66840a601cf37e402163cb63a948e595efae52e13f">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Documentation update for FFmpeg version rollback</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
README.md

<li>Updated documentation to reflect the rollback to FFmpeg version 6.1.1.<br> <li> Added acknowledgment for the linuxserver/docker-ffmpeg project.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update Helm chart README with new FFmpeg version</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/README.md

<li>Updated the global configuration and video recorder image tags to <br>FFmpeg 6.1.1.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2247/files#diff-fc10bcbda83e36362ecb788d804050f34349dd654dfedca83d53ad34b0f19e08">+15/-15</a>&nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> ✨ **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

