### PR TITLE
[test]: fix node relay tests

### DIFF
--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -66,6 +66,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@main
       - name: Set up containerd image store feature
+        if: matrix.test-strategy != 'test_node_relay'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 10

--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -6,8 +6,8 @@ ARG VERSION
 ARG RELEASE=selenium-${VERSION}
 ARG AUTHORS=SeleniumHQ
 # Default value should be aligned with upstream Selenium (https://github.com/SeleniumHQ/selenium/blob/trunk/java/maven_deps.bzl)
-ARG OPENTELEMETRY_VERSION=1.36.0
-ARG GRPC_VERSION=1.62.2
+ARG OPENTELEMETRY_VERSION=1.38.0
+ARG GRPC_VERSION=1.64.0
 ARG CS_VERSION=2.1.10
 
 #Arguments to define the user running Selenium

--- a/Makefile
+++ b/Makefile
@@ -568,7 +568,7 @@ test_parallel: hub chrome firefox edge chromium
 					echo NODE_CHROME=chromium >> .env ; \
 			fi; \
 			echo TEST_PLATFORMS=$(PLATFORMS) >> .env ; \
-			docker compose --profile $(PLATFORMS) -f docker-compose-v3-test-parallel.yml up --no-log-prefix --exit-code-from tests ; \
+			DOCKER_DEFAULT_PLATFORM=$(PLATFORMS) docker compose --profile $(PLATFORMS) -f docker-compose-v3-test-parallel.yml up --no-log-prefix --exit-code-from tests ; \
 	done
 
 test_video_dynamic_name:
@@ -578,7 +578,6 @@ test_video_dynamic_name:
 # This should run on its own CI job. There is no need to combine it with the other tests.
 # Its main purpose is to check that a video file was generated.
 test_video: video hub chrome firefox edge chromium
-	# Running a few tests with docker compose to generate the videos
 	sudo rm -rf ./tests/tests
 	sudo rm -rf ./tests/videos; mkdir -p ./tests/videos
 	if [ "$(PLATFORMS)" = "linux/amd64" ]; then \
@@ -614,12 +613,12 @@ test_video: video hub chrome firefox edge chromium
 					echo VIDEO_FILE_NAME=$${VIDEO_FILE_NAME:-"firefox_video.mp4"} >> .env ; \
 					echo VIDEO_FILE_NAME_SUFFIX=$${VIDEO_FILE_NAME_SUFFIX:-"true"} >> .env ; \
 			fi ; \
-			docker compose -f docker-compose-v3-test-video.yml up --abort-on-container-exit ; \
+			DOCKER_DEFAULT_PLATFORM=$(PLATFORMS) docker compose -f docker-compose-v3-test-video.yml up --abort-on-container-exit ; \
 	done
 	make test_video_integrity
 
 test_node_relay: hub node_base standalone_firefox
-	sudo rm -rf ./tests/tests
+	sudo rm -rf ./tests/tests ./tests/videos; mkdir -p ./tests/videos ; \
 	if [ "$(PLATFORMS)" = "linux/amd64" ]; then \
 			list_nodes="Android NodeFirefox" ; \
 	else \
@@ -641,24 +640,29 @@ test_node_relay: hub node_base standalone_firefox
 			echo TEST_NODE_RELAY=$$node >> .env ; \
 			echo UID=$$(id -u) >> .env ; \
 			echo BINDING_VERSION=$(BINDING_VERSION) >> .env ; \
-			PROFILE="relay_standalone" ; \
 			if [ $$node = "Android" ] ; then \
-					echo BROWSER=firefox >> .env && \
-					PROFILE="relay_appium" ; \
+					echo BROWSER=firefox >> .env \
+					&& echo BROWSER_NAME=firefox >> .env ; \
 			fi ; \
 			if [ $$node = "NodeChrome" ] ; then \
-					echo BROWSER=chrome >> .env ; \
+					echo BROWSER=chrome >> .env \
+					&& BROWSER_NAMEchrome >> .env ; \
 			fi ; \
 			if [ $$node = "NodeChromium" ] ; then \
-					echo BROWSER=chromium >> .env ; \
+					echo BROWSER=chromium >> .env \
+					&& echo BROWSER_NAME=chrome >> .env ; \
 			fi ; \
 			if [ $$node = "NodeEdge" ] ; then \
-					echo BROWSER=edge >> .env ; \
+					echo BROWSER=edge >> .env \
+					&& echo BROWSER_NAME=MicrosoftEdge >> .env ; \
 			fi ; \
 			if [ $$node = "NodeFirefox" ] ; then \
-					echo BROWSER=firefox >> .env ; \
+					echo BROWSER=firefox >> .env \
+					&& echo BROWSER_NAME=firefox >> .env ; \
 			fi ; \
-			docker compose --profile $${PROFILE} -f docker-compose-v3-test-node-relay.yml up --no-log-prefix --exit-code-from tests ; \
+			export $$(cat .env | xargs) ; \
+			envsubst < relay_config.toml > ./videos/relay_config.toml ; \
+			DOCKER_DEFAULT_PLATFORM=$(PLATFORMS) docker compose --profile $$node -f docker-compose-v3-test-node-relay.yml up --no-log-prefix --exit-code-from tests ; \
 			if [ $$? -ne 0 ]; then exit 1; fi ; \
 	done
 
@@ -701,7 +705,7 @@ test_node_docker: hub standalone_docker standalone_chrome standalone_firefox sta
 			fi ; \
 			export $$(cat .env | xargs) ; \
 			envsubst < config.toml > ./videos/config.toml ; \
-			docker compose -f docker-compose-v3-test-node-docker.yaml up --no-log-prefix --exit-code-from tests ; \
+			DOCKER_DEFAULT_PLATFORM=$(PLATFORMS) docker compose -f docker-compose-v3-test-node-docker.yaml up --no-log-prefix --exit-code-from tests ; \
 			if [ $$? -ne 0 ]; then exit 1; fi ; \
 			if [ -d "$$DOWNLOADS_DIR" ] && [ $$(ls -1q $$DOWNLOADS_DIR | wc -l) -eq 0 ]; then \
 					echo "Mounted downloads directory is empty. Downloaded files could not be retrieved!" ; \

--- a/tests/docker-compose-v3-test-node-relay.yml
+++ b/tests/docker-compose-v3-test-node-relay.yml
@@ -1,37 +1,12 @@
-version: "3"
 services:
-  node-relay-emulator:
-    profiles:
-      - relay_appium
-    image: ${NAMESPACE}/node-base:${TAG}
-    container_name: node-relay-emulator
-    shm_size: 2gb
-    depends_on:
-      - selenium-hub
-      - appium-emulator
-    environment:
-      - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_EVENT_BUS_PUBLISH_PORT=4442
-      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_LOG_LEVEL=${LOG_LEVEL}
-      - SE_NODE_SESSION_TIMEOUT=${SESSION_TIMEOUT}
-      - SE_NODE_RELAY_URL=http://appium-emulator:4723
-      - SE_NODE_RELAY_PROTOCOL_VERSION=HTTP/1.1
-      - SE_NODE_RELAY_MAX_SESSIONS=1
-      - SE_NODE_RELAY_PLATFORM_NAME=Android
-      - SE_NODE_RELAY_PLATFORM_VERSION=${ANDROID_PLATFORM_API}
-      - SE_NODE_RELAY_BROWSER_NAME=chrome
-      - SE_NODE_RELAY_WEB_VNC=ws://appium-emulator:6080/websockify
-
   node-relay-standalone:
     image: ${NAMESPACE}/node-base:${TAG}
-    container_name: node-relay-standalone
     shm_size: 2gb
     depends_on:
       - selenium-hub
-      - standalone-receiver
+      - standalone
     volumes:
-      - ./relay_config.toml:/opt/selenium/config.toml
+      - ./videos/relay_config.toml:/opt/selenium/config.toml
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
@@ -39,9 +14,12 @@ services:
       - SE_LOG_LEVEL=${LOG_LEVEL}
       - GENERATE_CONFIG=false
 
+  standalone:
+    image: ${NAMESPACE}/standalone-${BROWSER}:${TAG}
+    shm_size: 2gb
+
   selenium-hub:
     image: ${NAMESPACE}/hub:${TAG}
-    container_name: selenium-hub
     environment:
       - SE_LOG_LEVEL=${LOG_LEVEL}
       - SE_SESSION_REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
@@ -51,7 +29,7 @@ services:
       - "4444:4444"
 
   tests:
-    image: docker-selenium-tests:latest
+    image: docker-selenium-tests:${TAG}
     build:
       context: ./
       dockerfile: ./Dockerfile
@@ -67,16 +45,32 @@ services:
       - TEST_DELAY_AFTER_TEST=${TEST_DELAY_AFTER_TEST}
     command: ["./bootstrap.sh", "${NODE}"]
 
-  standalone-receiver:
-    image: ${NAMESPACE}/standalone-${BROWSER}:${TAG}
-    shm_size: 2gb
-    container_name: standalone-receiver
-
-  appium-emulator:
+  node-relay-emulator:
     profiles:
-      - relay_appium
-    platform: linux/amd64
-    image: ${ANDROID_BASED_NAME}/${ANDROID_BASED_IMAGE}:latest
+      - Android
+    image: ${NAMESPACE}/node-base:${TAG}
+    shm_size: 2gb
+    depends_on:
+      - selenium-hub
+      - emulator
+    environment:
+      - SE_EVENT_BUS_HOST=selenium-hub
+      - SE_EVENT_BUS_PUBLISH_PORT=4442
+      - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
+      - SE_LOG_LEVEL=${LOG_LEVEL}
+      - SE_NODE_SESSION_TIMEOUT=${SESSION_TIMEOUT}
+      - SE_NODE_RELAY_URL=http://emulator:4723
+      - SE_NODE_RELAY_PROTOCOL_VERSION=HTTP/1.1
+      - SE_NODE_RELAY_MAX_SESSIONS=1
+      - SE_NODE_RELAY_PLATFORM_NAME=Android
+      - SE_NODE_RELAY_PLATFORM_VERSION=${ANDROID_PLATFORM_API}
+      - SE_NODE_RELAY_BROWSER_NAME=chrome
+      - SE_NODE_RELAY_WEB_VNC=ws://emulator:6080/websockify
+
+  emulator:
+    profiles:
+      - Android
+    image: ${ANDROID_BASED_NAME}/${ANDROID_BASED_IMAGE}:${TAG}
     shm_size: 2gb
     build:
       args:
@@ -85,7 +79,6 @@ services:
         ANDROID_BASED_TAG: ${ANDROID_BASED_TAG}
         CHROME_DRIVER_URL: https://chromedriver.storage.googleapis.com/113.0.5672.63/chromedriver_linux64.zip
       dockerfile: ./Dockerfile.emulator
-    container_name: appium-emulator
     environment:
       - EMULATOR_DEVICE=Nexus 5
       - WEB_VNC=true
@@ -96,6 +89,3 @@ services:
       - EMULATOR_NAME=emulator-5554
     devices:
       - /dev/kvm
-    ports:
-      - "6080:6080"
-      - "4723:4723"

--- a/tests/relay_config.toml
+++ b/tests/relay_config.toml
@@ -10,10 +10,8 @@ drain-after-session-count = 0
 max-sessions = 1
 
 [relay]
-url = "http://standalone-receiver:4444/wd/hub"
+url = "http://standalone:4444/wd/hub"
 status-endpoint = "/status"
 configs = [
-    '1', '{"browserName":"firefox","platformName":"linux"}',
-    '1', '{"browserName":"chrome","platformName":"linux"}',
-    '1', '{"browserName":"MicrosoftEdge","platformName":"linux"}'
+    '1', '{"browserName":"${BROWSER_NAME}","platformName":"linux"}'
 ]


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Tests, Enhancement


___

### **Description**
- Added conditional setup for containerd image store in GitHub Actions workflow to skip for `test_node_relay` strategy.
- Updated OpenTelemetry and gRPC versions in the Dockerfile.
- Enhanced Docker Compose commands in the Makefile by adding `DOCKER_DEFAULT_PLATFORM` and fixing browser name assignments.
- Reorganized services and profiles in the Docker Compose file for node relay tests, including updated volume mounts and service dependencies.
- Simplified relay configuration in `relay_config.toml` by using dynamic browser name variables.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-test.yml</strong><dd><code>Conditional setup for containerd image store in GitHub Actions </code><br><code>workflow.</code></dd></summary>
<hr>
      
.github/workflows/docker-test.yml

<li>Added condition to skip containerd image store setup for <br><code>test_node_relay</code> strategy.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2269/files#diff-baa08c0b7cb0ae6357ecf7ecaa2d7aff0bfa417e10e1ec6fbc29232cb0166da7">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Dependencies
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update OpenTelemetry and gRPC versions in Dockerfile.</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
Base/Dockerfile

<li>Updated <code>OPENTELEMETRY_VERSION</code> to 1.38.0.<br> <li> Updated <code>GRPC_VERSION</code> to 1.64.0.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2269/files#diff-c7235ebbda8248c044e6b13da481ae97f4a21846ed2341a056b6b873abaa482b">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Enhance Docker Compose commands and environment setup in Makefile.</code></dd></summary>
<hr>
      
Makefile

<li>Added <code>DOCKER_DEFAULT_PLATFORM</code> to Docker Compose commands.<br> <li> Enhanced <code>test_node_relay</code> to include video directory setup and <br>environment variable export.<br> <li> Fixed browser name environment variable assignments.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2269/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+17/-13</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-test-node-relay.yml</strong><dd><code>Reorganize services and profiles in Docker Compose for node relay </code><br><code>tests.</code></dd></summary>
<hr>
      
tests/docker-compose-v3-test-node-relay.yml

<li>Reorganized services and profiles.<br> <li> Updated volume mount path for relay configuration.<br> <li> Changed service names and dependencies.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2269/files#diff-696f51c969c021fb13a49475ca5b17b73d90e71a2f04a206fee75e91097d0f50">+30/-40</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>relay_config.toml</strong><dd><code>Simplify relay configuration with dynamic browser name.</code>&nbsp; &nbsp; </dd></summary>
<hr>
      
tests/relay_config.toml

<li>Updated relay URL to use <code>standalone</code> service.<br> <li> Simplified browser configurations using <code>BROWSER_NAME</code> variable.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2269/files#diff-c65effbaf4a2e266b59f5e3b74f21bbca4e009659af9eae137fa8309106011b7">+2/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

