### PR TITLE
build: cleanup disk and increase timeout for deploy multi-arch images 

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -37,6 +37,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
       - name: Checkout code
         uses: actions/checkout@main
         with:
@@ -86,7 +91,7 @@ jobs:
       - name: Build images
         uses: nick-invision/retry@master
         with:
-          timeout_minutes: 45
+          timeout_minutes: 90
           max_attempts: 3
           retry_wait_seconds: 60
           command: PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make build

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -25,6 +25,11 @@ jobs:
     runs-on: ubuntu-latest
     permissions: write-all
     steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: false
+          large-packages: false
       - name: Checkout code
         uses: actions/checkout@main
         with:

--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -78,7 +78,7 @@ jobs:
       - name: Build images
         uses: nick-invision/retry@master
         with:
-          timeout_minutes: 45
+          timeout_minutes: 90
           max_attempts: 3
           retry_wait_seconds: 60
           command: PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make build


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
The bulk of multi-arch images are built at the same time, take up a huge amount of space (they might reach the disk limit of the runner), and take a longer time. Adding a pre-step to do advanced cleanup and increase timeout of step

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added a step to free disk space using `jlumbroso/free-disk-space@main` action in both `deploy.yml` and `nightly.yml` workflows.
- Increased the timeout for building multi-arch images from 45 to 90 minutes in both `deploy.yml` and `nightly.yml` workflows.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement
</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>deploy.yml</strong><dd><code>Add disk cleanup and increase timeout for deploy workflow</code></dd></summary>
<hr>
      
.github/workflows/deploy.yml

<li>Added a step to free disk space before deploying Docker images.<br> <li> Increased the timeout for building multi-arch images from 45 to 90 <br>minutes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2289/files#diff-28802fbf11c83a2eee09623fb192785e7ca92a3f40602a517c011b947a1822d3">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>nightly.yml</strong><dd><code>Add disk cleanup and increase timeout for nightly workflow</code></dd></summary>
<hr>
      
.github/workflows/nightly.yml

<li>Added a step to free disk space before nightly builds.<br> <li> Increased the timeout for building multi-arch images from 45 to 90 <br>minutes.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2289/files#diff-0d5658b415099a82c11c03a06ca4ec765b4003a1f4b2f3f1943980a882cf8aa6">+6/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

