### PR TITLE
Helm chart: Manage TLS Certificate Externally

### DIFF
--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -606,9 +606,9 @@ Selenium Grid supports secure communication between components. Refer to the [in
 
 #### Secure Communication
 
-In the chart, there is directory [certs](./certs) contains the default certificate, private key (as PKCS8 format), and Java Keystore (JKS) to teach Java about secure connection (since we are using a non-standard CA) for your trial, local testing purpose. You can generate your own self-signed certificate put them in that default directory by using script [cert.sh](./certs/cert.sh) with adjust needed information. The certificate, private key, truststore are mounted to the components via `Secret`.
+In the chart, there is directory [certs](./certs) contains the default certificate, private key (as PKCS8 format), and Java Keystore (JKS) to teach Java about secure connection (since we are using a non-standard CA) for your trial, local testing purpose. You can generate your own self-signed certificate put them in that default directory by using script [cert.sh](./certs/cert.sh) with adjust needed information. The certificate, private key, truststore are mounted to the components via `Secret`. 
 
-There are multiple ways to configure your certificate, private key, truststore to the components. You can choose one of them or combine them.
+There are multiple ways to configure your certificate, private key, truststore to the components. You can choose one of them or combine them. 
 
 - Use the default directory [certs](./certs). Rename your own files to be same as the default files and replace them. Give `--set tls.enabled=true` to enable secure communication.
 
@@ -646,6 +646,25 @@ There are multiple ways to configure your certificate, private key, truststore t
     --set-string tls.trustStorePassword=your_truststore_password
     ```
 
+- Creating the secret yourself and passing the name as a reference into the chart. For example: 
+    
+    Run the certificate generator and create a secret, replacing `SECRET_NAME` and `NAMESPACE`: 
+
+    ```shell
+    ./cert.sh
+
+    base64 -d selenium.pkcs8.base64 > selenium.pkcs8
+
+    kubectl -n NAMESPACE create secret generic SECRET_NAME --from-file=selenium.pem --from-file=selenium.jks --from-file=selenium.pkcs8
+    ```
+
+    Update the external secret name: 
+    ```yaml
+    tls:
+      enabled: true
+      externalSecretName: "SECRET_NAME"
+    ```
+
 If you start NGINX ingress controller inline with Selenium Grid chart, you can configure the default certificate of NGINX ingress controller to use the same certificate as Selenium Grid. For example:
 
 ```yaml
@@ -658,6 +677,7 @@ ingress-nginx:
     extraArgs:
       default-ssl-certificate: '$(POD_NAMESPACE)/selenium-tls-secret'
 ```
+
 
 #### Node Registration
 

--- a/charts/selenium-grid/templates/_nameHelpers.tpl
+++ b/charts/selenium-grid/templates/_nameHelpers.tpl
@@ -144,7 +144,11 @@ Common secrets cross components
 Secret TLS fullname
 */}}
 {{- define "seleniumGrid.tls.fullname" -}}
+{{- if .Values.tls.externalSecretName }}
+{{- tpl ( .Values.tls.externalSecretName ) $ | trunc 63 | trimSuffix "-" -}}
+{{- else }}
 {{- tpl (default (include "seleniumGrid.component.name" (list "selenium-tls-secret" $)) .Values.tls.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- end }}
 {{- end -}}
 
 {{/*

--- a/charts/selenium-grid/templates/tls-cert-secret.yaml
+++ b/charts/selenium-grid/templates/tls-cert-secret.yaml
@@ -1,3 +1,4 @@
+{{- if not .Values.tls.externalSecretName }}
 apiVersion: v1
 kind: Secret
 metadata:
@@ -26,4 +27,5 @@ data:
   {{ .Values.serverConfigMap.privateKeyFile }}: {{ default (include "seleniumGrid.tls.getDefaultFile" (list .Values.tls.defaultFile.privateKey $)) .Values.tls.privateKey | b64enc }}
   {{ .Values.serverConfigMap.certificateFile }}: {{ default (include "seleniumGrid.tls.getDefaultFile" (list .Values.tls.defaultFile.certificate $)) .Values.tls.certificate | b64enc }}
   {{ .Values.serverConfigMap.trustStoreFile }}: {{ default (include "seleniumGrid.tls.getDefaultFile" (list .Values.tls.defaultFile.trustStore $)) .Values.tls.trustStore | b64enc }}
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -52,6 +52,7 @@ tls:
   registrationSecret:
     enabled: false
     value: "HappyTesting"
+  externalSecretName:
 
 # Basic auth settings for Selenium Grid
 basicAuth:


### PR DESCRIPTION
### **User description**
### Description
The [tls-cert-secret.yaml](https://github.com/SeleniumHQ/docker-selenium/blob/trunk/charts/selenium-grid/templates/tls-cert-secret.yaml) has limited functionality. 

It only allows self signed cert generation if ingress is enabled, and tls is disabled. Alternatively, you have to pass the values of the certificate in as non-base64 literals, which causes an issue with the `selenium.jks` binary. 


### Motivation and Context
solves #2293 

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Added support for referencing an external TLS secret in the Helm chart.
- Updated the `_nameHelpers.tpl` to conditionally use the external TLS secret name if provided.
- Modified `tls-cert-secret.yaml` to skip secret creation when an external TLS secret name is specified.
- Updated `values.yaml` to include the `externalSecretName` field in the TLS configuration.
- Enhanced README documentation with instructions on how to use an external TLS secret.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_nameHelpers.tpl</strong><dd><code>Add support for external TLS secret reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/templates/_nameHelpers.tpl

<li>Added conditional logic to use an external TLS secret name if <br>provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2294/files#diff-81a82f068405c6e0c78f9c712e58508ee92d328bcd4329cfdb7f7c3b25c11282">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>tls-cert-secret.yaml</strong><dd><code>Conditional secret creation based on external TLS secret</code>&nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/templates/tls-cert-secret.yaml

<li>Added conditional logic to skip secret creation if an external TLS <br>secret name is provided.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2294/files#diff-bbf8b181553049685cb8ca370c80796c475d56ea47e798e3a9e08684f5a50085">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add externalSecretName field to TLS configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/values.yaml

- Added `externalSecretName` field to TLS configuration.



</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2294/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update README with external TLS secret reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>
      
charts/selenium-grid/README.md

<li>Updated documentation to include instructions for using an external <br>TLS secret.<br>


</details>
    

  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2294/files#diff-fc10bcbda83e36362ecb788d804050f34349dd654dfedca83d53ad34b0f19e08">+22/-2</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

