### PR TITLE
build: retry workflow and retry test on CircleCI

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -150,11 +150,35 @@ jobs:
       - run:
           name: "Build Docker images"
           command: |
-            PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build
+            N=3
+            while [ $N -gt 0 ]; do
+              PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build || true
+              if [ $? -eq 0 ]; then
+                echo "Build images passed"
+                exit 0
+              else
+                echo "Build failed. Retrying..."
+                N=$((N-1))
+                sleep 10
+              fi
+            done
+            exit 1
       - run:
           name: "Test Docker images"
           command: |
-            USE_RANDOM_USER_ID=${USE_RANDOM_USER} PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make ${TEST_STRATEGY}
+            N=3
+            while [ $N -gt 0 ]; do
+              USE_RANDOM_USER_ID=${USE_RANDOM_USER} PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make ${TEST_STRATEGY} || true
+              if [ $? -eq 0 ]; then
+                echo "Tests passed"
+                exit 0
+              else
+                echo "Tests failed. Retrying..."
+                N=$((N-1))
+                sleep 10
+              fi
+            done
+            exit 1
 
   kubernetes-test:
     parameters:
@@ -208,7 +232,19 @@ jobs:
       - run:
           name: "Build Docker images"
           command: |
-            PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build
+            N=3
+            while [ $N -gt 0 ]; do
+              PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make build || true
+              if [ $? -eq 0 ]; then
+                echo "Build images passed"
+                exit 0
+              else
+                echo "Build failed. Retrying..."
+                N=$((N-1))
+                sleep 10
+              fi
+            done
+            exit 1
       - run:
           name: "Build Helm charts"
           command: |
@@ -219,12 +255,21 @@ jobs:
       - run:
           name: "Test Selenium Grid on Kubernetes"
           command: |
-            PLATFORMS=${PLATFORMS} NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} \
-            TEST_EXISTING_KEDA=${TEST_EXISTING_KEDA} TEST_UPGRADE_CHART=false make chart_test_autoscaling_${TEST_STRATEGY}
-      - run:
-          name: "Check video integrity"
-          command: |
-            make test_video_integrity
+            N=3
+            while [ $N -gt 0 ]; do
+              PLATFORMS=${PLATFORMS} NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} \
+              TEST_EXISTING_KEDA=${TEST_EXISTING_KEDA} TEST_UPGRADE_CHART=false make chart_test_autoscaling_${TEST_STRATEGY} \
+              && make test_video_integrity || true
+              if [ $? -eq 0 ]; then
+                echo "Tests passed"
+                exit 0
+              else
+                echo "Tests failed. Retrying..."
+                N=$((N-1))
+                sleep 10
+              fi
+            done
+            exit 1
       - run:
           name: "Clean-up Kubernetes environment"
           command: |

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -9,6 +9,12 @@ on:
         type: boolean
         default: false
   workflow_dispatch:
+    inputs:
+      rerunFailedOnly:
+        description: 'Rerun only failed jobs'
+        required: false
+        type: boolean
+        default: true
   push:
     paths-ignore:
       - '**.md'
@@ -17,6 +23,12 @@ on:
       - '**.md'
 
 permissions: write-all
+
+env:
+  GH_CLI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RUN_ID: ${{ github.run_id }}
+  RERUN_FAILED_ONLY: ${{ github.event.inputs.rerunFailedOnly || true }}
+  RUN_ATTEMPT: ${{ github.run_attempt }}
 
 jobs:
   docker-test:
@@ -28,3 +40,27 @@ jobs:
     uses: ./.github/workflows/helm-chart-test.yml
     with:
       release: ${{ inputs.release == 'true' }}
+
+  rerun-workflow-when-failure:
+    needs:
+      - docker-test
+      - helm-chart-test
+    if: failure() && ( github.run_attempt < 3 )
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install gh
+      - name: Authenticate GitHub CLI
+        run: |
+          echo "$GH_CLI_TOKEN" | gh auth login --with-token
+      - name: Rerun workflow when failure
+        run: |
+          echo "Rerun workflow ID $RUN_ID in attempt #$(($RUN_ATTEMPT + 1))"
+          gh workflow run rerun-failed.yml \
+            --repo $GITHUB_REPOSITORY \
+            --raw-field runId=$RUN_ID \
+            --raw-field rerunFailedOnly=$RERUN_FAILED_ONLY

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -157,7 +157,8 @@ jobs:
           timeout_minutes: 30
           max_attempts: 3
           command: |
-            NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} TEST_EXISTING_KEDA=${TEST_EXISTING_KEDA} TEST_UPGRADE_CHART=false make chart_test_autoscaling_${{ matrix.test-strategy }}
+            NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} TEST_EXISTING_KEDA=${TEST_EXISTING_KEDA} TEST_UPGRADE_CHART=false make chart_test_autoscaling_${{ matrix.test-strategy }} \
+            && make test_video_integrity
       - name: Test chart upgrade
         if: (matrix.test-upgrade == true)
         run: |
@@ -178,10 +179,6 @@ jobs:
           name: ${{ env.ARTIFACT_NAME }}-artifacts
           path: ./tests/tests/
           if-no-files-found: ignore
-      - name: Check video integrity
-        if: always()
-        run: |
-          make test_video_integrity
       - name: Upload test video artifacts
         if: always()
         uses: actions/upload-artifact@main

--- a/.github/workflows/rerun-failed.yml
+++ b/.github/workflows/rerun-failed.yml
@@ -1,0 +1,41 @@
+name: Rerun Workflows
+
+on:
+  workflow_dispatch:
+    inputs:
+      runId:
+        description: 'The ID of workflow to rerun'
+        required: true
+        type: string
+      rerunFailedOnly:
+        description: 'Rerun only failed jobs'
+        required: false
+        type: boolean
+        default: true
+
+env:
+  GH_CLI_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+  RUN_ID: ${{ github.event.inputs.runId }}
+  RERUN_FAILED_ONLY: ${{ github.event.inputs.rerunFailedOnly }}
+
+jobs:
+  rerun_workflow:
+    name: Rerun ${{ github.event.inputs.runId }}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+      - name: Install GitHub CLI
+        run: |
+          sudo apt update
+          sudo apt install gh
+      - name: Authenticate GitHub CLI
+        run: |
+          echo "${GH_CLI_TOKEN}" | gh auth login --with-token
+      - name: "Rerun workflow ${{ env.RUN_ID }}"
+        run: |
+          if [ "${RERUN_FAILED_ONLY}" = "true" ]; then
+            gh run rerun ${RUN_ID} --failed --repo ${GITHUB_REPOSITORY}
+          else
+            gh run rerun ${RUN_ID} --repo ${GITHUB_REPOSITORY}
+          fi


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
build: retry workflow and retry test on CircleCI

### Motivation and Context
Recently, a test for Relay Node was added to guard against regression issues and also demonstrate for [docs](https://www.selenium.dev/documentation/grid/configuration/toml_options/#relaying-commands-to-a-service-endpoint-that-supports-webdriver) and [this](https://appium.io/docs/en/2.0/guides/grid/). The test required infra includes Selenium Grid (Hub, Node to relay commands), and docker-android (3rd-party project with container includes Appium server and Android emulator, it also required nested virtualization `/dev/kvm` to boot up the emulator).

This introduces a flaky test, mostly due to the emulator in container boot-up failed e.g `Exception: Message: Could not start a new session. Could not start a new session. Error while creating session with the service http://emulator:4723. Could not start a new session. Response code 500. Message: An unknown server-side error occurred while processing the command. Original error: Could not find a connected Android device in 20000ms`

Even after adding a retry step, it still failed. However, it might pass when triggering the rerun of the failed job in another host runner. 
So, add one more step at the end of the build-test workflow to listen to the overall status, and then, via GitHub CLI, dispatch trigger rerun workflow to Rerun failed jobs from the input runId of the failed workflow (until the max attempts allowed are reached). It would automate the below action on the UI.
<img width="998" alt="image" src="https://github.com/user-attachments/assets/5a64834d-94b7-44e6-ac28-c90acfcc180e">

On Circle CI workflow (for ARM64 images), update steps build (sometimes failed due to interrupted package from the artifactory) and test with retry before giving up and mark it as failed.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Added retry logic for building Docker images and running tests in CircleCI configuration.
- Enhanced GitHub Actions to include rerun logic for failed workflows.
- Integrated video integrity checks within the test command in the Helm chart test workflow.
- Created a new workflow for rerunning failed jobs using GitHub CLI.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.yml</strong><dd><code>Add retry logic for build and test steps in CircleCI</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.circleci/config.yml

<li>Added retry logic for building Docker images and running tests.<br> <li> Implemented retries for Kubernetes test steps.<br> <li> Enhanced test steps to include video integrity checks within retry <br>logic.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2311/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47">+54/-9</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>build-test.yml</strong><dd><code>Add rerun logic for failed workflows in GitHub Actions</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/build-test.yml

<li>Added inputs for rerunning only failed jobs.<br> <li> Set environment variables for GitHub CLI authentication.<br> <li> Added job to rerun workflow on failure.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2311/files#diff-063ca77e012f959eba648db60e6868875fd1e70e5f5ac081193d848f8d61ef32">+36/-0</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helm-chart-test.yml</strong><dd><code>Integrate video integrity check within test command</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/helm-chart-test.yml

<li>Included video integrity check within the test command.<br> <li> Removed redundant video integrity check step.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2311/files#diff-4a8a322b12899fb1d6c3c11d85f3f42b3486d64a25e6a3cd20e521bc94140897">+2/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>rerun-failed.yml</strong><dd><code>Create workflow for rerunning failed jobs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/rerun-failed.yml

<li>Created new workflow for rerunning failed jobs.<br> <li> Added GitHub CLI steps for rerunning workflows.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2311/files#diff-ef4e022ae979b8343d2762453ab222c8227816d1c24463609804c61af8fe722f">+41/-0</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

