### PR TITLE
chart(add): Set pod/container name to node stereotypes

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -27,7 +27,7 @@ workflows:
           name: "K8s test - Autoscaling Deployments"
           platforms: linux/arm64
           machine-type: ubuntu2204arm64large
-          k8s-version: 'v1.27.15'
+          k8s-version: 'v1.27.16'
           test-strategy: deployment
           cluster: 'minikube'
           helm-version: 'v3.12.3'
@@ -37,7 +37,7 @@ workflows:
           name: "K8s test - Autoscaling Jobs - HTTPS"
           platforms: linux/arm64
           machine-type: ubuntu2204arm64large
-          k8s-version: 'v1.28.11'
+          k8s-version: 'v1.28.12'
           test-strategy: job_https
           cluster: 'minikube'
           helm-version: 'v3.13.3'
@@ -47,7 +47,7 @@ workflows:
           name: "K8s test - Autoscaling Jobs - Ingress hostname"
           platforms: linux/arm64
           machine-type: ubuntu2204arm64large
-          k8s-version: 'v1.29.6'
+          k8s-version: 'v1.29.7'
           test-strategy: job_hostname
           cluster: 'minikube'
           helm-version: 'v3.14.4'
@@ -57,10 +57,10 @@ workflows:
           name: "K8s test - Autoscaling Deployments - HTTPS"
           platforms: linux/arm64
           machine-type: ubuntu2204arm64large
-          k8s-version: 'v1.30.2'
+          k8s-version: 'v1.30.3'
           test-strategy: deployment_https
           cluster: 'minikube'
-          helm-version: 'v3.15.2'
+          helm-version: 'v3.15.3'
           test-existing-keda: false
           test-upgrade: true
       - docker-test:

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -46,28 +46,28 @@ jobs:
             helm-version: 'v3.11.3'
             test-existing-keda: true
             test-upgrade: true
-          - k8s-version: 'v1.27.15'
+          - k8s-version: 'v1.27.16'
             test-strategy: deployment
             cluster: 'minikube'
             helm-version: 'v3.12.3'
             test-existing-keda: true
             test-upgrade: true
-          - k8s-version: 'v1.28.11'
+          - k8s-version: 'v1.28.12'
             test-strategy: job_https
             cluster: 'minikube'
             helm-version: 'v3.13.3'
             test-existing-keda: true
             test-upgrade: true
-          - k8s-version: 'v1.29.6'
+          - k8s-version: 'v1.29.7'
             test-strategy: job_hostname
             cluster: 'minikube'
             helm-version: 'v3.14.4'
             test-existing-keda: false
             test-upgrade: true
-          - k8s-version: 'v1.30.2'
+          - k8s-version: 'v1.30.3'
             test-strategy: deployment_https
             cluster: 'minikube'
-            helm-version: 'v3.15.2'
+            helm-version: 'v3.15.3'
             test-existing-keda: false
             test-upgrade: true
     env:

--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -64,7 +64,7 @@ fi
 
 # 'browserName' is mandatory for default stereotype
 if [[ -z "${SE_NODE_STEREOTYPE}" ]] && [[ -n "${SE_NODE_BROWSER_NAME}" ]]; then
-SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE__BROWSER_BINARY_LOCATION}}"
+SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE__BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
 else
 SE_NODE_STEREOTYPE="${SE_NODE_STEREOTYPE}"
 fi

--- a/Standalone/generate_config
+++ b/Standalone/generate_config
@@ -37,7 +37,7 @@ SE_NODE_BROWSER_VERSION=$(short_version $(cat /opt/selenium/browser_version))
 SE__BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
 
 if [[ -z "$SE_NODE_STEREOTYPE" ]]; then
-SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE__BROWSER_BINARY_LOCATION}}"
+SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE__BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
 else
 SE_NODE_STEREOTYPE="$SE_NODE_STEREOTYPE"
 fi

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -250,6 +250,10 @@ template:
         image: {{ printf "%s/%s:%s" $imageRegistry .node.imageName $imageTag }}
         imagePullPolicy: {{ .node.imagePullPolicy }}
         env:
+          - name: SE_NODE_CONTAINER_NAME
+            valueFrom:
+              fieldRef:
+                fieldPath: metadata.name
         {{- if empty .node.dshmVolumeSizeLimit }}
           - name: SE_BROWSER_ARGS_DISABLE_DSHM
             value: "--disable-dev-shm-usage"

--- a/tests/charts/make/chart_setup_env.sh
+++ b/tests/charts/make/chart_setup_env.sh
@@ -119,7 +119,10 @@ kubectl version --client
 echo "==============================="
 
 echo "Installing Helm for AMD64 / ARM64"
-HELM_VERSION=${HELM_VERSION:-"v3.15.2"}
+HELM_VERSION=${HELM_VERSION:-"latest"}
+if [ "${HELM_VERSION}" = "latest" ]; then
+    HELM_VERSION=$(curl -s https://api.github.com/repos/helm/helm/releases/latest | grep tag_name | cut -d '"' -f 4)
+fi
 curl -fsSL -o helm.tar.gz https://get.helm.sh/helm-${HELM_VERSION}-linux-$(dpkg --print-architecture).tar.gz
 mkdir -p helm
 tar -xf helm.tar.gz --strip-components 1 -C helm


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
chart(add): Set pod/container name to node stereotypes

### Motivation and Context
`se:containerName` is added by default to Node stereotypes via env var `SE_NODE_CONTAINER_NAME`
This is useful in few scenarios as below:
1. In Kubernetes deployment, we can track the node is running in which pod name by setting `metadata.name` to the env var. For example:
```yaml
        env:
          - name: SE_NODE_CONTAINER_NAME
            valueFrom:
              fieldRef:
                fieldPath: metadata.name
```

Via Grid UI can see stereotypes

![image](https://github.com/user-attachments/assets/5eb67826-fe5c-4c82-b88f-983232bad051)

Session capabilities can see:

![image](https://github.com/user-attachments/assets/5c4bfad3-1ff1-4767-8dc6-ad2cd4650096)

Via this strategy, each Node sets an unique name in the Node stereotypes. Then Node stereotypes will be merged to Session capabilities. In your test, you can get the capability value and print in test logs to see if the session was running in which Node

```python
self.driver = webdriver.Remote(
                options=options,
                command_executor=SELENIUM_GRID_URL,
                client_config=CLIENT_CONFIG
            )
print(self.driver.capabilities['se:containerName'])
```

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Dynamically fetch the latest Helm version if `HELM_VERSION` is set to "latest" in `chart_setup_env.sh`.
- Added `SE_NODE_CONTAINER_NAME` environment variable to Kubernetes node configuration, setting it to the pod metadata name.
- Updated Kubernetes and Helm versions in CircleCI configuration for various test workflows.
- Updated Kubernetes and Helm versions in GitHub Actions for Helm chart tests.
- Included `se:containerName` in the default node stereotype configuration in `NodeBase/generate_config` and `Standalone/generate_config`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chart_setup_env.sh</strong><dd><code>Dynamically fetch the latest Helm version if specified</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/make/chart_setup_env.sh

<li>Updated Helm version handling to fetch the latest version dynamically.<br> <li> Added logic to determine the latest Helm version if <code>HELM_VERSION</code> is <br>set to "latest".<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2323/files#diff-c30ef0620922a867b3cc6b774127ee5898120d40ca2831ab98d2e5036ac510c9">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Add SE_NODE_CONTAINER_NAME environment variable to Kubernetes nodes</code></dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Added environment variable <code>SE_NODE_CONTAINER_NAME</code> to Kubernetes node <br>configuration.<br> <li> Set <code>SE_NODE_CONTAINER_NAME</code> to Kubernetes pod metadata name.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2323/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Include container name in default node stereotype</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/generate_config

<li>Added <code>se:containerName</code> to the default node stereotype configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2323/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Include container name in default node stereotype</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Standalone/generate_config

<li>Added <code>se:containerName</code> to the default node stereotype configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2323/files#diff-dbfea8e89862249087918cf19250edbbe7f6ec4666fdaee5958bcf58cdd89557">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>config.yml</strong><dd><code>Update Kubernetes and Helm versions in CircleCI config</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.circleci/config.yml

- Updated Kubernetes and Helm versions for various test workflows.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2323/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>helm-chart-test.yml</strong><dd><code>Update Kubernetes and Helm versions in GitHub Actions</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/helm-chart-test.yml

- Updated Kubernetes and Helm versions for Helm chart tests.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2323/files#diff-4a8a322b12899fb1d6c3c11d85f3f42b3486d64a25e6a3cd20e521bc94140897">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

