### PR TITLE
feat(chart): add support for revisionhistorylimit

### DIFF
--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -18,6 +18,7 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (not .Values.autoscaling.enableWithExistingKEDA) }}
   replicas: {{ .Values.chromeNode.replicas }}
   {{end}}
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.chromeNode.fullname" . }}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.distributor.fullname" . }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -18,6 +18,7 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (not .Values.autoscaling.enableWithExistingKEDA) }}
   replicas: {{ .Values.edgeNode.replicas }}
   {{end}}
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.edgeNode.fullname" . }}

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.eventBus.fullname" . }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -18,6 +18,7 @@ spec:
   {{- if and (not .Values.autoscaling.enabled) (not .Values.autoscaling.enableWithExistingKEDA) }}
   replicas: {{ .Values.firefoxNode.replicas }}
   {{end}}
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.firefoxNode.fullname" . }}

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -16,6 +16,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.hub.fullname" . }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.router.fullname" . }}

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.sessionMap.fullname" . }}

--- a/charts/selenium-grid/templates/session-queue-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queue-deployment.yaml
@@ -13,6 +13,7 @@ metadata:
     {{- end }}
 spec:
   replicas: 1
+  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
       app: {{ template "seleniumGrid.sessionQueue.fullname" . }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -847,7 +847,7 @@ chromeNode:
     sessionBrowserName: "chrome"
     platformName: "linux"
     # browserVersion: '91.0' # Optional. Only required when supporting multiple versions of browser in your Selenium Grid.
-    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}' # Optional
+    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
 
   # It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1006,7 +1006,7 @@ firefoxNode:
     browserName: "firefox"
     sessionBrowserName: "firefox"
     platformName: "linux"
-    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}' # Optional
+    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
 
   # It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1165,7 +1165,7 @@ edgeNode:
     browserName: "MicrosoftEdge"
     sessionBrowserName: "msedge"
     platformName: "linux"
-    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}' # Optional
+    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
 
   # It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -27,6 +27,8 @@ global:
     defaultComponentLivenessProbe: exec
     # probe logs output can be retrieved using `kubectl logs`
     stdoutProbeLog: false
+    # specify how many old ReplicaSets for this Deployment you want to retain. The rest will be garbage-collected in the background.
+    revisionHistoryLimit: 10
 
 tls:
   # Name of external secret containing the TLS certificate and key
@@ -273,7 +275,6 @@ secrets:
 
 # Configuration for isolated components (applied only if `isolateComponents: true`)
 components:
-
   # Configuration for router component
   router:
     # imageRegistry: selenium
@@ -626,7 +627,7 @@ tracing:
   enabled: false
   enabledWithExistingEndpoint: false
   exporter: otlp
-  exporterEndpoint: 'http://{{ .Release.Name }}-jaeger-collector.{{ .Release.Namespace }}:4317'
+  exporterEndpoint: "http://{{ .Release.Name }}-jaeger-collector.{{ .Release.Namespace }}:4317"
   globalAutoConfigure: true
   ingress:
     enabled: true
@@ -634,7 +635,7 @@ tracing:
     paths:
       - backend:
           service:
-            name: '{{ .Release.Name }}-jaeger-query'
+            name: "{{ .Release.Name }}-jaeger-query"
             port:
               number: 16686
         path: &jaegerBasePath "/jaeger"
@@ -842,11 +843,11 @@ chromeNode:
   # scaledObjectOptions:
   hpa:
     url: '{{ template "seleniumGrid.graphqlURL" . }}'
-    browserName: 'chrome'
-    sessionBrowserName: 'chrome'
-    platformName: 'linux'
+    browserName: "chrome"
+    sessionBrowserName: "chrome"
+    platformName: "linux"
     # browserVersion: '91.0' # Optional. Only required when supporting multiple versions of browser in your Selenium Grid.
-    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}' # Optional
 
   # It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -856,7 +857,6 @@ chromeNode:
   # It means it will add a new container to the deployment itself.
   # It should be set using the --set-json option
   sidecars: []
-
 
 # Configuration for firefox nodes
 firefoxNode:
@@ -1003,10 +1003,10 @@ firefoxNode:
   # scaledObjectOptions:
   hpa:
     url: '{{ template "seleniumGrid.graphqlURL" . }}'
-    browserName: 'firefox'
-    sessionBrowserName: 'firefox'
-    platformName: 'linux'
-    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    browserName: "firefox"
+    sessionBrowserName: "firefox"
+    platformName: "linux"
+    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}' # Optional
 
   # It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1162,10 +1162,10 @@ edgeNode:
   # scaledObjectOptions:
   hpa:
     url: '{{ template "seleniumGrid.graphqlURL" . }}'
-    browserName: 'MicrosoftEdge'
-    sessionBrowserName: 'msedge'
-    platformName: 'linux'
-    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    browserName: "MicrosoftEdge"
+    sessionBrowserName: "msedge"
+    platformName: "linux"
+    unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}' # Optional
 
   # It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1218,7 +1218,7 @@ videoRecorder:
     #  RCLONE_CONFIG_GS_ENDPOINT: "https://storage.googleapis.com"
     #  RCLONE_CONFIG_GS_NO_CHECK_BUCKET: "true"
   ports:
-  - 9000
+    - 9000
   resources:
     requests:
       memory: "1Gi"


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added `revisionHistoryLimit` field to the deployment specs of Chrome node, distributor, Edge node, event bus, Firefox node, hub, router, session map, and session queue.
- Added `revisionHistoryLimit` field to global values in `values.yaml`.
- Changed single quotes to double quotes in various fields in `values.yaml`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome-node-deployment.yaml</strong><dd><code>Add revision history limit to Chrome node deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-34c2065883f6f9ebf3df5c03b4478e44842d87f953577465088c705a17b2fa46">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>distributor-deployment.yaml</strong><dd><code>Add revision history limit to distributor deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/distributor-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-fa11594c0f17909a6a414ec2edf6c7f3fb51f279abbb29624c4b1a8c03be1624">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge-node-deployment.yaml</strong><dd><code>Add revision history limit to Edge node deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-507359f2b12a0dd188309d744bad913359324cfd194bb6358a6f231929e38b28">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>event-bus-deployment.yaml</strong><dd><code>Add revision history limit to event bus deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/event-bus-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-5c6d31a6e775b256032e1527e02075ae5305a62be9f0de3988bbbc8f8b1b59d8">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox-node-deployment.yaml</strong><dd><code>Add revision history limit to Firefox node deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/firefox-node-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-4bbf0083baf253864d6c4874b6bc46e72fb649211a687034e8cba10da5ac6b2a">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>hub-deployment.yaml</strong><dd><code>Add revision history limit to hub deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/hub-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-f51202c2bd7c5496905266ca9cb34b863557dfe7226c72c241f67a2aee33c379">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>router-deployment.yaml</strong><dd><code>Add revision history limit to router deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/router-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-6a2f974d7f13388d5f6f73a06bc9f7a2f338b0ce4a6261dafae1f3c0a18c6814">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session-map-deployment.yaml</strong><dd><code>Add revision history limit to session map deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/session-map-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-af584d2d290b3791345f474997a6480e2f1918b9731a5047982ee5c0d9eb10e1">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>session-queue-deployment.yaml</strong><dd><code>Add revision history limit to session queue deployment</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/session-queue-deployment.yaml

- Added `revisionHistoryLimit` field to the deployment spec.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-265c9d150255ef5a016ee51d6dd6396ecc4c26bfe2f1ef19e1c87593a14eccc5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add revision history limit to global values and update quotes</code></dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Added <code>revisionHistoryLimit</code> field to global values.<br> <li> Changed single quotes to double quotes in various fields.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2339/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+17/-17</a>&nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

