### PR TITLE
Do not print secrets such as registration secret and router password to console on selenium grid hub and router startup

### DIFF
--- a/Hub/start-selenium-grid-hub.sh
+++ b/Hub/start-selenium-grid-hub.sh
@@ -70,7 +70,7 @@ if [ "${SE_ENABLE_TLS}" = "true" ]; then
 fi
 
 if [ ! -z "$SE_REGISTRATION_SECRET" ]; then
-  echo "Appending Selenium options: --registration-secret ${SE_REGISTRATION_SECRET}"
+  echo "Appending Selenium options: --registration-secret ***"
   SE_OPTS="$SE_OPTS --registration-secret ${SE_REGISTRATION_SECRET}"
 fi
 
@@ -85,7 +85,7 @@ if [ ! -z "$SE_ROUTER_USERNAME" ]; then
 fi
 
 if [ ! -z "$SE_ROUTER_PASSWORD" ]; then
-  echo "Appending Selenium options: --password ${SE_ROUTER_PASSWORD}"
+  echo "Appending Selenium options: --password ***"
   SE_OPTS="$SE_OPTS --password ${SE_ROUTER_PASSWORD}"
 fi
 

--- a/Router/start-selenium-grid-router.sh
+++ b/Router/start-selenium-grid-router.sh
@@ -102,7 +102,7 @@ if [ "${SE_ENABLE_TLS}" = "true" ]; then
 fi
 
 if [ ! -z "$SE_REGISTRATION_SECRET" ]; then
-  echo "Appending Selenium options: --registration-secret ${SE_REGISTRATION_SECRET}"
+  echo "Appending Selenium options: --registration-secret ***"
   SE_OPTS="$SE_OPTS --registration-secret ${SE_REGISTRATION_SECRET}"
 fi
 
@@ -117,7 +117,7 @@ if [ ! -z "$SE_ROUTER_USERNAME" ]; then
 fi
 
 if [ ! -z "$SE_ROUTER_PASSWORD" ]; then
-  echo "Appending Selenium options: --password ${SE_ROUTER_PASSWORD}"
+  echo "Appending Selenium options: --password ***"
   SE_OPTS="$SE_OPTS --password ${SE_ROUTER_PASSWORD}"
 fi
 


### PR DESCRIPTION
### **User description**
### Description

When using the start-selenium-grid-hub.sh or start-selenium-grid-router.sh script the router password and registration secret got printed to the console. For testing usage this is (semi) fine. But when using Selenium Docker Images in a production environment, printing secrets to the console is a security issue. Therefore, all secrets printed to the console are replaced with '***' in this change.

### Motivation and Context

* Use docker-selenium in production environment without security concerns

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.


___

### **PR Type**
Bug fix


___

### **Description**
- Masked sensitive information such as `SE_REGISTRATION_SECRET` and `SE_ROUTER_PASSWORD` in console output for both Selenium Grid Hub and Router startup scripts.
- Enhances security by preventing sensitive data from being exposed in production environments.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start-selenium-grid-hub.sh</strong><dd><code>Mask sensitive information in console output for Hub</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Hub/start-selenium-grid-hub.sh

<li>Masked the <code>SE_REGISTRATION_SECRET</code> when printing to console.<br> <li> Masked the <code>SE_ROUTER_PASSWORD</code> when printing to console.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2359/files#diff-9aa93031edb177db1d5e76fd9aa6b72cb4e540c5e2d9803aceb82bdb62c17446">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>start-selenium-grid-router.sh</strong><dd><code>Mask sensitive information in console output for Router</code>&nbsp; &nbsp; </dd></summary>
<hr>

Router/start-selenium-grid-router.sh

<li>Masked the <code>SE_REGISTRATION_SECRET</code> when printing to console.<br> <li> Masked the <code>SE_ROUTER_PASSWORD</code> when printing to console.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2359/files#diff-49e49d9819b9ccb5e9f1237c00742183dd23bcfa9ecdeb3164d018d4a9db8823">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

