### PR TITLE
chart(fix): ensure images are pre-pulled and started together in Node

### DIFF
--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -23,6 +23,7 @@ autoscaling:
   scalingType: deployment
 
 basicAuth:
+  enabled: true
   username: sysadmin
   password: strongPassword
 

--- a/tests/charts/templates/render/dummy_solution.yaml
+++ b/tests/charts/templates/render/dummy_solution.yaml
@@ -24,6 +24,7 @@ selenium-grid:
     scalingType: deployment
 
   basicAuth:
+    enabled: true
     username: sysadmin
     password: strongPassword
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes: https://github.com/SeleniumHQ/docker-selenium/issues/2386

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added pre-puller init containers to ensure node and video recorder images are pre-pulled before starting, improving startup reliability.
- Updated image registry and tag handling for better clarity and maintainability.
- Enabled basicAuth by default in both dummy and solution configurations to enhance security settings.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Add pre-puller init containers for image pre-pulling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Added pre-puller init containers for node and video recorder images.<br> <li> Ensured images are pre-pulled before starting containers.<br> <li> Updated image registry and tag variables for clarity.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2387/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+16/-8</a>&nbsp; &nbsp; </td>

</tr>                    
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dummy.yaml</strong><dd><code>Enable basicAuth in dummy configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/render/dummy.yaml

- Enabled basicAuth by default in the configuration.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2387/files#diff-5aaf14c24dad808759277c90e4431d7f17c31b2a6bd7c8def5ba8361b73de5a9">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dummy_solution.yaml</strong><dd><code>Enable basicAuth in dummy solution configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/render/dummy_solution.yaml

- Enabled basicAuth by default in the solution configuration.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2387/files#diff-076f5cdbdf212cb19276dd9a4a63001d747537595d7966188a5155dc2aeaaca2">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

