### PR TITLE
Update _helpers.tpl to adress missing resource limits in pre-puller init containers for firefox,edge,...

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -306,6 +306,9 @@ template:
       - name: "pre-puller-{{ .name }}"
         image: {{ printf "%s/%s:%s" $nodeImageRegistry .node.imageName $nodeImageTag }}
         command: ["bash", "-c", "'true'"]
+      {{- with .node.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+      {{- end }}
     {{- if $.Values.videoRecorder.enabled }}
       - name: "pre-puller-{{ $.Values.videoRecorder.name }}"
         image: {{ printf "%s/%s:%s" $videoImageRegistry $.Values.videoRecorder.imageName $videoImageTag }}

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -313,6 +313,9 @@ template:
       - name: "pre-puller-{{ $.Values.videoRecorder.name }}"
         image: {{ printf "%s/%s:%s" $videoImageRegistry $.Values.videoRecorder.imageName $videoImageTag }}
         command: ["bash", "-c", "'true'"]
+      {{- with .node.resources }}
+        resources: {{- toYaml . | nindent 10 }}
+      {{- end }}
     {{- end }}
     {{- with .node.initContainers }}
       {{- toYaml . | nindent 6 }}


### PR DESCRIPTION
### **User description**
Fixes to have pre-puller initContainer with resource limits.

Created to fix https://github.com/SeleniumHQ/docker-selenium/issues/2398




### Description
Is already in the title. Resource Limit in the newly added pre-puller init container is missing resource limits.

### Motivation and Context
If a kubernetes enforces resource limits it is not possible do rolle out changes with the init containers.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Added resource limits to the pre-puller init containers in the Kubernetes configuration.
- Utilized the `.node.resources` field to ensure that resource specifications are applied, addressing issues in environments enforcing resource limits.
- This change fixes the inability to roll out changes when resource limits are enforced by Kubernetes.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Add resource limits to pre-puller init containers</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Added resource limits to the pre-puller init containers.<br> <li> Utilized <code>.node.resources</code> to define resource specifications.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2399/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**:
>Comment `/help` on the PR to get a list of all available PR-Agent tools and their descriptions

