### PR TITLE
chart(update): Node deployment replicas use minReplicaCount in autoscaling

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -79,54 +79,72 @@ workflows:
           use-random-user: true
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: false
+          enable-managed-downloads: false
       - docker-test:
           name: "Docker test - Use random user (false)"
           test-strategy: test
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: false
+          enable-managed-downloads: false
       - docker-test:
           name: "Docker test - Video recording"
           test-strategy: test_video
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: true
       - docker-test:
           name: "Docker test - Video recording dynamic file name"
           test-strategy: test_video_dynamic_name
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: true
       - docker-test:
           name: "Docker test - Video recording standalone"
           test-strategy: test_video_standalone
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: true
       - docker-test:
           name: "Docker test - Dynamic Grid"
           test-strategy: test_node_docker
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: false
       - docker-test:
           name: "Docker test - Dynamic Grid Standalone"
           test-strategy: test_standalone_docker
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: true
       - docker-test:
           name: "Docker test - Parallel execution"
           test-strategy: test_parallel
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: true
       - docker-test:
           name: "Docker test - Node relay commands"
           test-strategy: test_node_relay
           use-random-user: false
           platforms: linux/arm64
           machine-type: ubuntu2204arm64
+          firefox-install-lang-package: true
+          enable-managed-downloads: true
 
 executors:
   ubuntu2204arm64:
@@ -149,6 +167,10 @@ jobs:
         type: string
       use-random-user:
         type: boolean
+      firefox-install-lang-package:
+        type: boolean
+      enable-managed-downloads:
+        type: boolean
     executor: << parameters.machine-type >>
     environment:
       NAMESPACE: selenium
@@ -156,6 +178,8 @@ jobs:
       PLATFORMS: << parameters.platforms >>
       TEST_STRATEGY: << parameters.test-strategy >>
       USE_RANDOM_USER: << parameters.use-random-user >>
+      TEST_FIREFOX_INSTALL_LANG_PACKAGE: << parameters.firefox-install-lang-package >>
+      SELENIUM_ENABLE_MANAGED_DOWNLOADS: << parameters.enable-managed-downloads >>
     steps:
       - run:
           name: "Prepare workflow environment variables"
@@ -195,7 +219,9 @@ jobs:
           command: |
             N=3
             while [ $N -gt 0 ]; do
-              output=$(eval "USE_RANDOM_USER_ID=${USE_RANDOM_USER} PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make ${TEST_STRATEGY}")
+              output=$(eval "USE_RANDOM_USER_ID=${USE_RANDOM_USER} PLATFORMS=${PLATFORMS} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} \
+              TEST_FIREFOX_INSTALL_LANG_PACKAGE=${TEST_FIREFOX_INSTALL_LANG_PACKAGE} SELENIUM_ENABLE_MANAGED_DOWNLOADS=${SELENIUM_ENABLE_MANAGED_DOWNLOADS} \
+              make ${TEST_STRATEGY}")
               status=$?
               if [ $status -eq 0 ]; then
                 echo "Tests passed"

--- a/Makefile
+++ b/Makefile
@@ -629,7 +629,7 @@ test_firefox_download_lang_packs:
 
 test_firefox: test_firefox_download_lang_packs
 	PLATFORMS=$(PLATFORMS) VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) BASE_RELEASE=$(BASE_RELEASE) BASE_VERSION=$(BASE_VERSION) BINDING_VERSION=$(BINDING_VERSION) SKIP_BUILD=true \
-	TEST_FIREFOX_INSTALL_LANG_PACKAGE=true ./tests/bootstrap.sh NodeFirefox
+	TEST_FIREFOX_INSTALL_LANG_PACKAGE=$(or $(TEST_FIREFOX_INSTALL_LANG_PACKAGE), "true") ./tests/bootstrap.sh NodeFirefox
 
 test_firefox_standalone:
 	PLATFORMS=$(PLATFORMS) VERSION=$(TAG_VERSION) NAMESPACE=$(NAMESPACE) BASE_RELEASE=$(BASE_RELEASE) BASE_VERSION=$(BASE_VERSION) BINDING_VERSION=$(BINDING_VERSION) SKIP_BUILD=true ./tests/bootstrap.sh StandaloneFirefox
@@ -848,7 +848,7 @@ test_node_docker: hub standalone_docker standalone_chrome standalone_firefox sta
 			envsubst < $${config_file} > ./videos/config.toml ; \
 			DOCKER_DEFAULT_PLATFORM=$(PLATFORMS) docker compose -f $${docker_compose_file} up --remove-orphans --no-log-prefix --build --exit-code-from tests ; \
 			if [ $$? -ne 0 ]; then exit 1; fi ; \
-			if [ "$$SKIP_CHECK_DOWNLOADS_VOLUME" != "true" ] && [ -d "$$DOWNLOADS_DIR" ] && [ $$(ls -1q $$DOWNLOADS_DIR | wc -l) -eq 0 ]; then \
+			if [ "$$SKIP_CHECK_DOWNLOADS_VOLUME" != "true" ] && [ "$$SELENIUM_ENABLE_MANAGED_DOWNLOADS" != "true" ] && [ -d "$$DOWNLOADS_DIR" ] && [ $$(ls -1q $$DOWNLOADS_DIR | wc -l) -eq 0 ]; then \
 					echo "Mounted downloads directory is empty. Downloaded files could not be retrieved!" ; \
 					exit 1 ; \
 			fi ; \
@@ -922,7 +922,7 @@ chart_test_autoscaling_deployment_https:
 chart_test_autoscaling_deployment:
 	PLATFORMS=$(PLATFORMS) TEST_EXISTING_KEDA=true RELEASE_NAME=selenium CHART_ENABLE_TRACING=true TEST_PATCHED_KEDA=false \
 	SECURE_CONNECTION_SERVER=true SECURE_USE_EXTERNAL_CERT=true SERVICE_TYPE_NODEPORT=true SELENIUM_GRID_PROTOCOL=https SELENIUM_GRID_HOST=$$(hostname -i) SELENIUM_GRID_PORT=31444 \
-	SELENIUM_GRID_AUTOSCALING_MIN_REPLICA=1 \
+	SELENIUM_GRID_AUTOSCALING_MIN_REPLICA=0 SET_MAX_REPLICAS=3 TEST_DELAY_AFTER_TEST=2 SELENIUM_GRID_MONITORING=false  \
 	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) KEDA_BASED_NAME=$(KEDA_BASED_NAME) KEDA_BASED_TAG=$(KEDA_BASED_TAG) NAMESPACE=$(NAMESPACE) BINDING_VERSION=$(BINDING_VERSION) \
 	TEMPLATE_OUTPUT_FILENAME="k8s_prefixSelenium_enableTracing_secureServer_externalCerts_nodePort_autoScaling_scaledObject_existingKEDA_subPath.yaml" \
 	./tests/charts/make/chart_test.sh DeploymentAutoscaling

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -1,6 +1,6 @@
 # selenium-grid
 
-![Version: 0.36.2](https://img.shields.io/badge/Version-0.36.2-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.25.0-20241010](https://img.shields.io/badge/AppVersion-4.25.0--20241010-informational?style=flat-square)
+![Version: 0.36.3](https://img.shields.io/badge/Version-0.36.3-informational?style=flat-square) ![Type: application](https://img.shields.io/badge/Type-application-informational?style=flat-square) ![AppVersion: 4.25.0-20241010](https://img.shields.io/badge/AppVersion-4.25.0--20241010-informational?style=flat-square)
 
 A Helm chart for creating a Selenium Grid Server in Kubernetes
 
@@ -21,7 +21,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | https://jaegertracing.github.io/helm-charts | jaeger | 3.3.1 |
 | https://kedacore.github.io/charts | keda | 2.15.1 |
 | https://kubernetes.github.io/ingress-nginx | ingress-nginx | 4.11.3 |
-| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack | 65.1.1 |
+| https://prometheus-community.github.io/helm-charts | kube-prometheus-stack | 65.2.0 |
 
 ## Values
 
@@ -42,7 +42,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | global.seleniumGrid.revisionHistoryLimit | int | `10` | Specify how many old ReplicaSets for this Deployment you want to retain. The rest will be garbage-collected in the background. |
 | global.seleniumGrid.structuredLogs | bool | `false` | Whether to enable structured logging |
 | global.seleniumGrid.httpLogs | bool | `false` | Enable http logging. Tracing should be enabled to log http logs. |
-| global.seleniumGrid.updateStrategy.type | string | `"Recreate"` | Specify update strategy for all components, can be overridden individually |
+| global.seleniumGrid.updateStrategy.type | string | `"RollingUpdate"` | Specify update strategy for all components, can be overridden individually |
 | global.seleniumGrid.updateStrategy.rollingUpdate | object | `{"maxSurge":1,"maxUnavailable":0}` | Specify for strategy RollingUpdate |
 | global.seleniumGrid.affinity | object | `{}` | Specify affinity for all components, can be overridden individually |
 | global.seleniumGrid.topologySpreadConstraints | list | `[]` | Specify topologySpreadConstraints for all components, can be overridden individually |

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -2,7 +2,7 @@ apiVersion: v2
 name: selenium-grid
 description: A Helm chart for creating a Selenium Grid Server in Kubernetes
 type: application
-version: 0.36.2
+version: 0.36.3
 appVersion: 4.25.0-20241010
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png
 dependencies:
@@ -19,7 +19,7 @@ dependencies:
   name: jaeger
   condition: tracing.enabled, jaeger.enabled
 - repository: https://prometheus-community.github.io/helm-charts
-  version: 65.1.1
+  version: 65.2.0
   name: kube-prometheus-stack
   condition: monitoring.enabled, prometheus-stack.enabled
 maintainers:

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -17,9 +17,11 @@ metadata:
 spec:
   strategy:
     {{- template "seleniumGrid.updateStrategy" (list $.Values.chromeNode $.Values.global.seleniumGrid) }}
-  {{- if and (not .Values.autoscaling.enabled) (not .Values.autoscaling.enableWithExistingKEDA) }}
+  {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
   replicas: {{ .Values.chromeNode.replicas }}
-  {{end}}
+  {{- else }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.chromeNode.scaledOptions).minReplicaCount }}
+  {{ end }}
   revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -17,9 +17,11 @@ metadata:
 spec:
   strategy:
     {{- template "seleniumGrid.updateStrategy" (list $.Values.edgeNode $.Values.global.seleniumGrid) }}
-  {{- if and (not .Values.autoscaling.enabled) (not .Values.autoscaling.enableWithExistingKEDA) }}
+  {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
   replicas: {{ .Values.edgeNode.replicas }}
-  {{end}}
+  {{- else }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.edgeNode.scaledOptions).minReplicaCount }}
+  {{ end }}
   revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -17,9 +17,11 @@ metadata:
 spec:
   strategy:
     {{- template "seleniumGrid.updateStrategy" (list $.Values.firefoxNode $.Values.global.seleniumGrid) }}
-  {{- if and (not .Values.autoscaling.enabled) (not .Values.autoscaling.enableWithExistingKEDA) }}
+  {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
   replicas: {{ .Values.firefoxNode.replicas }}
-  {{end}}
+  {{- else }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.firefoxNode.scaledOptions).minReplicaCount }}
+  {{ end }}
   revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -34,7 +34,7 @@ global:
     httpLogs: false
     updateStrategy:
       # -- Specify update strategy for all components, can be overridden individually
-      type: Recreate
+      type: RollingUpdate
       # type: RollingUpdate
       # -- Specify for strategy RollingUpdate
       rollingUpdate:

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -99,7 +99,6 @@ class SeleniumGenericTests(unittest.TestCase):
         driver = self.driver
         driver.get('https://the-internet.herokuapp.com/download')
         file_name = 'some-file.txt'
-        is_continue = True
         wait = WebDriverWait(driver, 30)
         file_link = wait.until(
             EC.element_to_be_clickable((By.LINK_TEXT, file_name))

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -80,6 +80,9 @@ on_failure() {
     if [ ${RENDER_HELM_TEMPLATE_ONLY} = "true" ]; then
       exit $exit_status
     fi
+    kubectl get pods -A
+    echo "Get all resources in all namespaces"
+    kubectl get all -A >> tests/tests/describe_all_resources_${MATRIX_BROWSER}.txt
     echo "Describe all resources in the ${SELENIUM_NAMESPACE} namespace for debugging purposes"
     kubectl describe all -n ${SELENIUM_NAMESPACE} >> tests/tests/describe_all_resources_${MATRIX_BROWSER}.txt
     kubectl describe pod -n ${SELENIUM_NAMESPACE} >> tests/tests/describe_all_resources_${MATRIX_BROWSER}.txt
@@ -449,11 +452,5 @@ while true; do
     sleep 2
   fi
 done
-
-echo "Get pods status"
-kubectl get pods -n ${SELENIUM_NAMESPACE}
-
-echo "Get all resources in all namespaces"
-kubectl get all -A >> tests/tests/describe_all_resources_${MATRIX_BROWSER}.txt
 
 cleanup

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -278,7 +278,7 @@ class ChartTemplateTests(unittest.TestCase):
                 count_rolling += 1
             if doc['metadata']['name'] in recreate and doc['kind'] == 'Deployment':
                 logger.info(f"Assert updateStrategy is set in resource {doc['metadata']['name']}")
-                self.assertTrue(doc['spec']['strategy']['type'] == 'Recreate', f"Resource {doc['metadata']['name']} doesn't have strategy Recreate")
+                self.assertTrue(doc['spec']['strategy']['type'] == 'RollingUpdate', f"Resource {doc['metadata']['name']} doesn't have strategy RollingUpdate")
                 count_recreate += 1
         self.assertEqual(count_rolling, len(rolling), "No deployment resources found with strategy RollingUpdate")
         self.assertEqual(count_recreate, len(recreate), "No deployment resources found with strategy Recreate")


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
When enabling autoscaling, type: Deployment. In chart template, field `replicas` is not defined in deployment spec, K8s will assume it as 1 by default.
When `autoscaling.scaledOptions.minReplicaCount ` set as 0, we can see 1 Node pod is up then it's Terminating to reach replicas 0/0
Or when `autoscaling.scaledOptions.minReplicaCount ` set > 1, also there is 1 Node pod up from the beginning before it is scaled up to reach the minReplicaCount.
So, when enabling autoscaling && type = Deployment, minReplicaCount is used to set replicas in deployment spec

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Enhanced test scripts to provide more debugging information by retrieving all resources in all namespaces.
- Updated Selenium test to remove an unused variable.
- Modified CI configuration to include parameters for Firefox language package installation and managed downloads.
- Updated Makefile to accommodate new environment variables for Firefox and download configurations.
- Changed default update strategy to `RollingUpdate` in chart configurations.
- Set node deployment replicas based on `minReplicaCount` when autoscaling is enabled for Chrome, Edge, and Firefox nodes.
- Bumped chart version and Prometheus dependency version.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>4 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>chart_test.sh</strong><dd><code>Enhance debugging information in test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/make/chart_test.sh

<li>Added commands to get all resources in all namespaces.<br> <li> Removed redundant commands for getting pod status.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-811a856b3f51ff08b956e27feb70420c8a8341e610a40eecb06d30c6ffe7f9bc">+3/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-deployment.yaml</strong><dd><code>Use minReplicaCount for Chrome node replicas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-deployment.yaml

<li>Set replicas based on <code>minReplicaCount</code> when autoscaling is enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-34c2065883f6f9ebf3df5c03b4478e44842d87f953577465088c705a17b2fa46">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge-node-deployment.yaml</strong><dd><code>Use minReplicaCount for Edge node replicas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-deployment.yaml

<li>Set replicas based on <code>minReplicaCount</code> when autoscaling is enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-507359f2b12a0dd188309d744bad913359324cfd194bb6358a6f231929e38b28">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox-node-deployment.yaml</strong><dd><code>Use minReplicaCount for Firefox node replicas</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/firefox-node-deployment.yaml

<li>Set replicas based on <code>minReplicaCount</code> when autoscaling is enabled.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-4bbf0083baf253864d6c4874b6bc46e72fb649211a687034e8cba10da5ac6b2a">+4/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Miscellaneous</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Clean up unused variable in Selenium test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/SeleniumTests/__init__.py

- Removed unused variable `is_continue`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-9e40695776a7c3afc35b1bf6d31682fe8ca531271c4a883063aa428b3915387f">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Tests</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Update strategy assertion change in test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/test.py

<li>Changed update strategy assertion from <code>Recreate</code> to <code>RollingUpdate</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-313e81a96e34d08dcd821e7a1223f59ffce689433658ae3999a26fc7f6dcb343">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>config.yml</strong><dd><code>Add configuration for Firefox language and downloads in CI</code></dd></summary>
<hr>

.circleci/config.yml

<li>Added parameters for Firefox language package installation and managed <br>downloads.<br> <li> Updated Docker test jobs to include new parameters.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-78a8a19706dbd2a4425dd72bdab0502ed7a2cef16365ab7030a5a0588927bf47">+27/-1</a>&nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update Makefile for Firefox and download configurations</code>&nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<li>Modified test commands to include new environment variables for <br>Firefox and downloads.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Default update strategy set to RollingUpdate</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

- Changed default update strategy to `RollingUpdate`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Update chart version and default strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<li>Updated chart version and Prometheus chart dependency version.<br> <li> Changed default update strategy to <code>RollingUpdate</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>Chart.yaml</strong><dd><code>Bump chart and dependency versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/Chart.yaml

- Updated chart version and Prometheus dependency version.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2430/files#diff-2b5986f61311d561a9497008138d7238cc08e721bd34f673c94e03ba0068a731">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information