### PR TITLE
chart: Allow overwrite config videoRecorder in each node

### DIFF
--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -396,6 +396,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | chromeNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
 | chromeNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | chromeNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
+| chromeNode.videoRecorder | object | `{}` | Override specific video recording settings for chrome node |
 | firefoxNode.enabled | bool | `true` | Enable firefox nodes |
 | firefoxNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long living pods false - for provisioning your own custom type such as Jobs |
 | firefoxNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |
@@ -446,6 +447,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | firefoxNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
 | firefoxNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | firefoxNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
+| firefoxNode.videoRecorder | object | `{}` | Override specific video recording settings for firefox node |
 | edgeNode.enabled | bool | `true` | Enable edge nodes |
 | edgeNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long living pods false - for provisioning your own custom type such as Jobs |
 | edgeNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |
@@ -496,6 +498,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | edgeNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
 | edgeNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | edgeNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
+| edgeNode.videoRecorder | object | `{}` | Override specific video recording settings for edge node |
 | videoRecorder.enabled | bool | `false` | Enable video recording in all browser nodes |
 | videoRecorder.name | string | `"video"` | Container name is set to resource specs |
 | videoRecorder.imageRegistry | string | `nil` | Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter) |

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -30,6 +30,7 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
 {{- $_ =  set $podScope "node" .Values.chromeNode -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.chromeNode.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
+++ b/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
@@ -23,7 +23,8 @@ spec:
   {{- $podScope := deepCopy . -}}
   {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
   {{- $_ =  set $podScope "node" .Values.chromeNode -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.chromeNode.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -30,6 +30,7 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
 {{- $_ =  set $podScope "node" .Values.edgeNode -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.edgeNode.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/edge-node-scaledjob.yaml
@@ -23,7 +23,8 @@ spec:
   {{- $podScope := deepCopy . -}}
   {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
   {{- $_ =  set $podScope "node" .Values.edgeNode -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.edgeNode.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -30,6 +30,7 @@ spec:
 {{- $podScope := deepCopy . -}}
 {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
 {{- $_ =  set $podScope "node" .Values.firefoxNode -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.firefoxNode.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
@@ -23,7 +23,8 @@ spec:
   {{- $podScope := deepCopy . -}}
   {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
   {{- $_ =  set $podScope "node" .Values.firefoxNode -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.firefoxNode.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -1082,6 +1082,8 @@ chromeNode:
   # It means it will add a new container to the deployment itself.
   # It should be set using the --set-json option
   sidecars: []
+  # -- Override specific video recording settings for chrome node
+  videoRecorder: {}
 
 # Configuration for firefox nodes
 firefoxNode:
@@ -1262,6 +1264,8 @@ firefoxNode:
   # It means it will add a new container to the deployment itself.
   # It should be set using the --set-json option
   sidecars: []
+  # -- Override specific video recording settings for firefox node
+  videoRecorder: {}
 
 # Configuration for edge nodes
 edgeNode:
@@ -1442,7 +1446,10 @@ edgeNode:
   # It means it will add a new container to the deployment itself.
   # It should be set using the --set-json option
   sidecars: []
+  # -- Override specific video recording settings for edge node
+  videoRecorder: {}
 
+# Video recording configuration for all browser nodes. Can be overridden by each browser node
 videoRecorder:
   # -- Enable video recording in all browser nodes
   enabled: false

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -131,6 +131,9 @@ firefoxNode:
 edgeNode:
   annotations:
     "restartOnUpdate": "true"
+  videoRecorder:
+    uploader:
+      enabled: false
 
 videoRecorder:
   enabled: true

--- a/tests/charts/templates/render/dummy_solution.yaml
+++ b/tests/charts/templates/render/dummy_solution.yaml
@@ -119,6 +119,9 @@ selenium-grid:
 
   edgeNode:
     affinity: *affinity
+    videoRecorder:
+      uploader:
+        enabled: false
 
   videoRecorder:
     enabled: true

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -207,6 +207,10 @@ class ChartTemplateTests(unittest.TestCase):
                         video_container = container
                     if container['name'] == 's3':
                         uploader_container = container
+                # Test for case override upload config in Edge node
+                if doc['metadata']['name'] == '{0}selenium-edge-node'.format(RELEASE_NAME):
+                    self.assertTrue(uploader_container is None, "Video uploader should be disabled in Edge node config")
+                    continue
                 list_volume_mounts = None
                 if uploader_container is not None:
                     list_volume_mounts = uploader_container['volumeMounts']


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
In the Helm chart, the config key `videoRecorder` holds all configs needed for the video recorder in all nodes.
Now, in each Node, it has the capability to overwrite the common videoRecorder configs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests


___

### **Description**
- Introduced the ability to override video recorder configurations on a per-node basis in the Selenium Grid Helm chart.
- Updated templates and values to support node-specific video recorder settings using `mergeOverwrite`.
- Added tests to ensure that video uploader configurations can be overridden, specifically disabling it for Edge nodes.
- Updated documentation to reflect the new configuration options for node-specific video recorder settings.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Add test for Edge node video uploader configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/test.py

<li>Added test case for overriding upload config in Edge node.<br> <li> Ensured video uploader is disabled in Edge node config.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-313e81a96e34d08dcd821e7a1223f59ffce689433658ae3999a26fc7f6dcb343">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dummy.yaml</strong><dd><code>Update dummy configuration for Edge node video uploader</code>&nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/render/dummy.yaml

- Disabled video uploader for Edge node in dummy configuration.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-5aaf14c24dad808759277c90e4431d7f17c31b2a6bd7c8def5ba8361b73de5a9">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>dummy_solution.yaml</strong><dd><code>Update dummy solution for Edge node video uploader</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/render/dummy_solution.yaml

<li>Disabled video uploader for Edge node in dummy solution configuration.<br> <br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-076f5cdbdf212cb19276dd9a4a63001d747537595d7966188a5155dc2aeaaca2">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>7 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Allow node-specific video recorder configuration overrides</code></dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Changed video recorder configuration to allow node-specific overrides.<br> <li> Updated references from <code>videoRecorder</code> to <code>recorder</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+24/-24</a>&nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-deployment.yaml</strong><dd><code>Enable Chrome node-specific video recorder configuration</code>&nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-deployment.yaml

<li>Enabled node-specific video recorder configuration for Chrome nodes.<br> <li> Used <code>mergeOverwrite</code> for video recorder settings.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-34c2065883f6f9ebf3df5c03b4478e44842d87f953577465088c705a17b2fa46">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-scaledjobs.yaml</strong><dd><code>Enable Chrome scaled jobs node-specific video recorder configuration</code></dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-scaledjobs.yaml

<li>Enabled node-specific video recorder configuration for Chrome scaled <br>jobs.<br> <li> Used <code>mergeOverwrite</code> for video recorder settings.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-d7dac3df6778fd7822c244f0dbe3baba0fd192f4723750e65a1f889504a2d763">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge-node-deployment.yaml</strong><dd><code>Enable Edge node-specific video recorder configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-deployment.yaml

<li>Enabled node-specific video recorder configuration for Edge nodes.<br> <li> Used <code>mergeOverwrite</code> for video recorder settings.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-507359f2b12a0dd188309d744bad913359324cfd194bb6358a6f231929e38b28">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>edge-node-scaledjob.yaml</strong><dd><code>Enable Edge scaled jobs node-specific video recorder configuration</code></dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-scaledjob.yaml

<li>Enabled node-specific video recorder configuration for Edge scaled <br>jobs.<br> <li> Used <code>mergeOverwrite</code> for video recorder settings.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-b9b151402d2339683d56e768fcdd8c045189ec768b6c056963e314e9b8ce830b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox-node-deployment.yaml</strong><dd><code>Enable Firefox node-specific video recorder configuration</code></dd></summary>
<hr>

charts/selenium-grid/templates/firefox-node-deployment.yaml

<li>Enabled node-specific video recorder configuration for Firefox nodes.<br> <li> Used <code>mergeOverwrite</code> for video recorder settings.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-4bbf0083baf253864d6c4874b6bc46e72fb649211a687034e8cba10da5ac6b2a">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    

<tr>
  <td>
    <details>
      <summary><strong>firefox-node-scaledjob.yaml</strong><dd><code>Enable Firefox scaled jobs node-specific video recorder configuration</code></dd></summary>
<hr>

charts/selenium-grid/templates/firefox-node-scaledjob.yaml

<li>Enabled node-specific video recorder configuration for Firefox scaled <br>jobs.<br> <li> Used <code>mergeOverwrite</code> for video recorder settings.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-ed4af9ad1d3dc2bde5e13a24b34c7a2c9d54649767f7a5ec5e59c48fac33ea6b">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Document node-specific video recorder configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<li>Documented node-specific video recorder configuration overrides.<br> <li> Added entries for <code>videoRecorder</code> in node configurations.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add node-specific video recorder configuration in values</code>&nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Added <code>videoRecorder</code> configuration for each node type.<br> <li> Allowed overriding of video recording settings per node.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2445/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>                    
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information