### PR TITLE
chart: Deployment scale metricType should be Value instead of AverageValue

### DIFF
--- a/NodeChromium/Dockerfile
+++ b/NodeChromium/Dockerfile
@@ -9,7 +9,7 @@ USER root
 # Install Chromium
 ARG CHROMIUM_VERSION="latest"
 ARG CHROMIUM_DEB_SITE="http://deb.debian.org/debian"
-RUN echo "deb ${CHROMIUM_DEB_SITE}/ sid main" >> /etc/apt/sources.list \
+RUN echo "deb ${CHROMIUM_DEB_SITE}/ stable main" >> /etc/apt/sources.list \
   && wget -qO- https://ftp-master.debian.org/keys/archive-key-12.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-keyring.gpg \
   && wget -qO- https://ftp-master.debian.org/keys/archive-key-12-security.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-security-keyring.gpg \
   && apt-get update -qqy \

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -327,6 +327,8 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | autoscaling.enableWithExistingKEDA | bool | `false` | Enable autoscaling without automatically installing KEDA |
 | autoscaling.scalingType | string | `"job"` | Which type of KEDA scaling to use: job or deployment |
 | autoscaling.authenticationRef | object | `{"annotations":{"helm.sh/hook":"post-install,post-upgrade,post-rollback","helm.sh/hook-weight":"-2"},"name":""}` | Specify an external KEDA TriggerAuthentication resource is used for scaler triggers config. Apply for all browser nodes |
+| autoscaling.useCachedMetrics | bool | `true` | Enables caching of metric values during polling interval (as specified in .spec.pollingInterval). |
+| autoscaling.metricType | string | `"Value"` | The type of metric that should be used (Override the default: AverageValue in KEDA) |
 | autoscaling.annotations | object | `{"helm.sh/hook":"post-install,post-upgrade,post-rollback","helm.sh/hook-weight":"1"}` | Annotations for KEDA resources: ScaledObject and ScaledJob |
 | autoscaling.patchObjectFinalizers.nameOverride | string | `nil` | Override the name of the patch job |
 | autoscaling.patchObjectFinalizers.enabled | bool | `true` | Enable patching finalizers for KEDA scaled resources. Workaround for Hook post-upgrade selenium-grid/templates/x-node-hpa.yaml failed: object is being deleted: scaledobjects.keda.sh "x" already exists |

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -240,14 +240,16 @@ Common autoscaling spec template
 triggers:
   - type: selenium-grid
     metadata:
+    {{- with .node.hpa }}
+      {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- if not .nodeMaxSessions }}
       nodeMaxSessions: {{ $nodeMaxSessions | quote }}
-  {{- with .node.hpa }}
-    {{- tpl (toYaml .) $ | nindent 6 }}
-  {{- end }}
-  {{- if not .node.hpa.authenticationRef }}
+      {{- end }}
+    {{- end }}
     authenticationRef:
       name: {{ template "seleniumGrid.autoscaling.authenticationRef.fullname" $ }}
-  {{- end }}
+    useCachedMetrics: {{ $.Values.autoscaling.useCachedMetrics }}
+    metricType: {{ $.Values.autoscaling.metricType }}
 {{- end }}
 {{- end -}}
 

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -836,6 +836,11 @@ autoscaling:
     annotations:
       "helm.sh/hook": post-install,post-upgrade,post-rollback
       "helm.sh/hook-weight": "-2"
+  # Configuration for ScaledObject triggers https://keda.sh/docs/latest/reference/scaledobject-spec/#triggers
+  # -- Enables caching of metric values during polling interval (as specified in .spec.pollingInterval).
+  useCachedMetrics: true
+  # -- The type of metric that should be used (Override the default: AverageValue in KEDA)
+  metricType: Value
   # -- Annotations for KEDA resources: ScaledObject and ScaledJob
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback

--- a/tests/SmokeTests/__init__.py
+++ b/tests/SmokeTests/__init__.py
@@ -11,10 +11,14 @@ SELENIUM_GRID_HOST = os.environ.get('SELENIUM_GRID_HOST', 'localhost')
 SELENIUM_GRID_PORT = os.environ.get('SELENIUM_GRID_PORT', '4444')
 SELENIUM_GRID_USERNAME = os.environ.get('SELENIUM_GRID_USERNAME', '')
 SELENIUM_GRID_PASSWORD = os.environ.get('SELENIUM_GRID_PASSWORD', '')
+CHART_CERT_PATH = os.environ.get('CHART_CERT_PATH', None)
 SELENIUM_GRID_AUTOSCALING = os.environ.get('SELENIUM_GRID_AUTOSCALING', 'false')
 SELENIUM_GRID_AUTOSCALING_MIN_REPLICA = os.environ.get('SELENIUM_GRID_AUTOSCALING_MIN_REPLICA', 0)
 HUB_CHECKS_MAX_ATTEMPTS = os.environ.get('HUB_CHECKS_MAX_ATTEMPTS', 3)
 HUB_CHECKS_INTERVAL = os.environ.get('HUB_CHECKS_INTERVAL', 10)
+
+if CHART_CERT_PATH:
+  os.environ['REQUESTS_CA_BUNDLE'] = CHART_CERT_PATH
 
 class SmokeTests(unittest.TestCase):
     def smoke_test_container(self, port):
@@ -53,7 +57,7 @@ class SmokeTests(unittest.TestCase):
     def client_verify_cert(self, port):
         grid_url_status = '%s://%s:%s/status' % (SELENIUM_GRID_PROTOCOL, SELENIUM_GRID_HOST, port)
         cert_path = os.environ.get("REQUESTS_CA_BUNDLE")
-        response = requests.get(grid_url_status, verify=cert_path)
+        response = requests.get(grid_url_status, verify=cert_path, auth=HTTPBasicAuth(SELENIUM_GRID_USERNAME, SELENIUM_GRID_PASSWORD))
 
 class GridTest(SmokeTests):
     def test_grid_is_up(self):


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Following KEDA docs - https://keda.sh/docs/2.16/reference/scaledobject-spec/#triggers, adjust configs in default chart values for ScaledObject
- `useCachedMetrics: false`
- `metricType:""` (keep as empty, not set)

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Updated the autoscaling configuration to include `useCachedMetrics` and `metricType` options, enhancing the scaling logic.
- Changed the Debian source in the `NodeChromium` Dockerfile from `sid` to `stable` for better stability.
- Improved the smoke tests by setting default environment variables to `None` and adding HTTP basic authentication for requests.
- Updated documentation to reflect new autoscaling options in the configuration.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>__init__.py</strong><dd><code>Update environment variables and add authentication for requests</code></dd></summary>
<hr>

tests/SmokeTests/__init__.py

<li>Changed default environment variable values to <code>None</code>.<br> <li> Added <code>CHART_CERT_PATH</code> environment variable.<br> <li> Updated <code>requests.get</code> to include HTTP basic authentication.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2465/files#diff-6520381fba53133fa2a295057467ca85aee647dcc3a6388bf66de3b5b1a1a246">+6/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Enhance autoscaling triggers with additional configurations</code></dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Added <code>useCachedMetrics</code> and <code>metricType</code> to autoscaling triggers.<br> <li> Ensured <code>nodeMaxSessions</code> is set if not provided.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2465/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+7/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Update Debian source to stable in Dockerfile</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeChromium/Dockerfile

- Changed Debian source from `sid` to `stable`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2465/files#diff-ddc70cdbe415111d77d5eadd39b842ca541bd0f0a9ecb04fceb7597f2f09d598">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Add documentation for new autoscaling options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

- Documented `useCachedMetrics` and `metricType` options.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2465/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add new autoscaling configuration options</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Added <code>useCachedMetrics</code> and <code>metricType</code> to autoscaling configuration.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2465/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information