### PR TITLE
K8s: Update ScaledJob scaling strategy to `eager` as default

### DIFF
--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -79,7 +79,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | serviceAccount.create | bool | `true` | Create a service account for all components. If using an external service account, set to false and provide its name in `nameOverride` below |
 | serviceAccount.nameOverride | string | `nil` | Override to use an external service account |
 | serviceAccount.annotations | object | `{}` | Annotations for the service account |
-| rbacRole | object | `{"annotations":{},"create":true,"nameOverride":null,"rules":[{"apiGroups":["keda.sh"],"resources":["scaledjobs"],"verbs":["get","list","patch","update","delete"]},{"apiGroups":["keda.sh"],"resources":["scaledobjects"],"verbs":["get","list","patch","update","delete"]},{"apiGroups":["keda.sh"],"resources":["triggerauthentication"],"verbs":["get","list","patch","update","delete"]},{"apiGroups":["autoscaling"],"resources":["horizontalpodautoscalers"],"verbs":["get","list","patch","update","delete"]}]}` | RBAC settings for patching finalizers KEDA scaled resources |
+| rbacRole | object | `{"annotations":{},"create":true,"nameOverride":null,"rules":[{"apiGroups":["keda.sh"],"resources":["scaledjobs"],"verbs":["get","list","patch","update","delete"]},{"apiGroups":["keda.sh"],"resources":["scaledobjects"],"verbs":["get","list","patch","update","delete"]},{"apiGroups":["keda.sh"],"resources":["triggerauthentications"],"verbs":["get","list","patch","update","delete"]},{"apiGroups":["autoscaling"],"resources":["horizontalpodautoscalers"],"verbs":["get","list","patch","update","delete"]}]}` | RBAC settings for patching finalizers KEDA scaled resources |
 | rbacRole.create | bool | `true` | Enable to create RBAC role to access few KEDA resources. If using an external role, set to false and provide its name in `nameOverride` below |
 | rbacRole.nameOverride | string | `nil` | Override resource name or provide an external role name |
 | rbacRoleBinding | object | `{"annotations":{},"create":true,"nameOverride":null,"roleRef":{"apiGroup":"rbac.authorization.k8s.io","kind":"Role"},"subjects":[{"kind":"ServiceAccount"}]}` | RBAC role binding settings for patching finalizers KEDA scaled resources |
@@ -326,8 +326,8 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | autoscaling.enabled | bool | `false` | Enable autoscaling. Implies installing KEDA |
 | autoscaling.enableWithExistingKEDA | bool | `false` | Enable autoscaling without automatically installing KEDA |
 | autoscaling.scalingType | string | `"job"` | Which type of KEDA scaling to use: job or deployment |
-| autoscaling.authenticationRef | object | `{"annotations":{"helm.sh/hook":"post-install,post-upgrade,post-rollback","helm.sh/hook-weight":"-2"},"name":""}` | Specify an external KEDA TriggerAuthentication resource is used for scaler triggers config. Apply for all browser nodes |
-| autoscaling.useCachedMetrics | bool | `true` | Enables caching of metric values during polling interval (as specified in .spec.pollingInterval). |
+| autoscaling.authenticationRef | object | `{"annotations":{"helm.sh/hook":"post-install,post-upgrade,post-rollback","helm.sh/hook-weight":"0"},"name":""}` | Specify an external KEDA TriggerAuthentication resource is used for scaler triggers config. Apply for all browser nodes |
+| autoscaling.useCachedMetrics | bool | `false` | Enables caching of metric values during polling interval (as specified in .spec.pollingInterval). |
 | autoscaling.metricType | string | `"Value"` | The type of metric that should be used (Override the default: AverageValue in KEDA) |
 | autoscaling.annotations | object | `{"helm.sh/hook":"post-install,post-upgrade,post-rollback","helm.sh/hook-weight":"1"}` | Annotations for KEDA resources: ScaledObject and ScaledJob |
 | autoscaling.patchObjectFinalizers.nameOverride | string | `nil` | Override the name of the patch job |
@@ -341,7 +341,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | autoscaling.scaledOptions.minReplicaCount | int | `0` | Minimum number of replicas |
 | autoscaling.scaledOptions.maxReplicaCount | int | `8` | Maximum number of replicas |
 | autoscaling.scaledOptions.pollingInterval | int | `10` | Polling interval in seconds |
-| autoscaling.scaledJobOptions.scalingStrategy.strategy | string | `"accurate"` | Scaling strategy for KEDA ScaledJob |
+| autoscaling.scaledJobOptions.scalingStrategy.strategy | string | `"eager"` | Scaling strategy for KEDA ScaledJob - https://keda.sh/docs/latest/reference/scaledjob-spec/#scalingstrategy |
 | autoscaling.scaledJobOptions.successfulJobsHistoryLimit | int | `0` | Number of Completed jobs should be kept |
 | autoscaling.scaledJobOptions.failedJobsHistoryLimit | int | `0` | Number of Failed jobs should be kept (for troubleshooting purposes) |
 | autoscaling.scaledJobOptions.jobTargetRef | object | `{"backoffLimit":0,"completions":1,"parallelism":1}` | Specify job target ref for KEDA ScaledJob |

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -249,7 +249,9 @@ triggers:
     authenticationRef:
       name: {{ template "seleniumGrid.autoscaling.authenticationRef.fullname" $ }}
     useCachedMetrics: {{ $.Values.autoscaling.useCachedMetrics }}
+  {{- if eq $.Values.autoscaling.scalingType "deployment" }}
     metricType: {{ $.Values.autoscaling.metricType }}
+  {{- end }}
 {{- end }}
 {{- end -}}
 

--- a/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
@@ -35,8 +35,8 @@ spec:
             - |
               echo "Cleaning up ScaledObjects, ScaledJobs and HPAs for {{ .Release.Name }} when upgrading or disabling autoscaling."
               kubectl get ScaledObjects,ScaledJobs,TriggerAuthentication -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} -o=json | jq '.metadata.finalizers = null' | kubectl apply -f - || true ;
-              kubectl delete ScaledObjects,ScaledJobs,TriggerAuthentication -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait || true ;
-              kubectl delete hpa -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait || true ;
+              kubectl delete ScaledObjects,ScaledJobs,TriggerAuthentication -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait false || true ;
+              kubectl delete hpa -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait false || true ;
         {{- with $.Values.autoscaling.patchObjectFinalizers.resources }}
           resources: {{ toYaml . | nindent 12 }}
         {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -156,7 +156,7 @@ rbacRole:
     - apiGroups:
         - keda.sh
       resources:
-        - triggerauthentication
+        - triggerauthentications
       verbs: [get, list, patch, update, delete]
     - apiGroups:
         - autoscaling
@@ -835,15 +835,17 @@ autoscaling:
     name: ""
     annotations:
       "helm.sh/hook": post-install,post-upgrade,post-rollback
-      "helm.sh/hook-weight": "-2"
+      # TriggerAuthentication is used by ScaledObject/ScaledJob, hence weight should be less than those hooks
+      "helm.sh/hook-weight": "0"
   # Configuration for ScaledObject triggers https://keda.sh/docs/latest/reference/scaledobject-spec/#triggers
   # -- Enables caching of metric values during polling interval (as specified in .spec.pollingInterval).
-  useCachedMetrics: true
+  useCachedMetrics: false
   # -- The type of metric that should be used (Override the default: AverageValue in KEDA)
   metricType: Value
   # -- Annotations for KEDA resources: ScaledObject and ScaledJob
   annotations:
     "helm.sh/hook": post-install,post-upgrade,post-rollback
+    # Ensure the weight should be higher than TriggerAuthentication hook
     "helm.sh/hook-weight": "1"
   patchObjectFinalizers:
     # -- Override the name of the patch job
@@ -856,6 +858,7 @@ autoscaling:
     annotations:
       "helm.sh/hook": post-install,post-upgrade,post-rollback,pre-delete
       "helm.sh/hook-delete-policy": hook-succeeded,before-hook-creation
+      # This should be run before all other hooks (since delete action is called), so use a negative weight
       "helm.sh/hook-weight": "-1"
     # -- Define an external service account name contains permissions to patch KEDA scaled resources
     serviceAccount: ""
@@ -882,9 +885,9 @@ autoscaling:
   # Options for KEDA ScaledJobs (only used when scalingType is set to "job"). See https://keda.sh/docs/latest/concepts/scaling-jobs/#scaledjob-spec
   scaledJobOptions:
     scalingStrategy:
-      # Offer the strategy default with scaler calculation updated in https://github.com/SeleniumHQ/docker-selenium/tree/trunk/.keda/README.md
-      # -- Scaling strategy for KEDA ScaledJob
-      strategy: accurate
+      # Use `eager` strategy for utilizing all available slots up to the maxReplicaCount, ensuring that waiting request are processed as quickly as possible.
+      # -- Scaling strategy for KEDA ScaledJob - https://keda.sh/docs/latest/reference/scaledjob-spec/#scalingstrategy
+      strategy: eager
     # -- Number of Completed jobs should be kept
     successfulJobsHistoryLimit: 0
     # -- Number of Failed jobs should be kept (for troubleshooting purposes)


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Follow KEDA docs - https://keda.sh/docs/2.16/reference/scaledjob-spec/#scalingstrategy
>  The `eager` strategy comes to the rescue. It addresses this issue by utilizing all available slots up to the maxReplicaCount, ensuring that waiting messages are processed as quickly as possible.

It is expected to overcome in case `default` could be missed number of replicas while incoming requests between, or overrate scales in `accurate` .

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Updated the default scaling strategy for KEDA ScaledJob to `eager` to ensure efficient processing of waiting messages.
- Modified RBAC role settings to correctly reference `triggerauthentications`.
- Adjusted the default configuration for `useCachedMetrics` to `false`.
- Enhanced the patch-keda job by optimizing `kubectl delete` commands with `--wait false`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Add conditional logic for metricType in helpers template</code>&nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

- Added conditional logic for `metricType` based on `scalingType`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2466/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>patch-keda-objects-job.yaml</strong><dd><code>Optimize kubectl delete commands in patch-keda job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml

- Modified `kubectl delete` commands to use `--wait false`.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2466/files#diff-45939f6d4fb5ad9a484c9afd9221bf408cf9e2c0afa2a5198cdfdb4a2d937a24">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Update configuration documentation for RBAC and scaling strategy</code></dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<li>Updated RBAC role to include <code>triggerauthentications</code>.<br> <li> Changed default scaling strategy to <code>eager</code>.<br> <li> Modified default settings for <code>useCachedMetrics</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2466/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update values for RBAC, caching, and scaling strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Updated RBAC resources to <code>triggerauthentications</code>.<br> <li> Changed <code>useCachedMetrics</code> default to <code>false</code>.<br> <li> Set scaling strategy to <code>eager</code>.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2466/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+9/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information