### PR TITLE
K8s: Multiple nodes browser in Helm configs

### DIFF
--- a/.keda/scalers/selenium-grid-scaler.md
+++ b/.keda/scalers/selenium-grid-scaler.md
@@ -55,11 +55,11 @@ metadata:
   name: selenium-grid-chrome-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-chrome-node
+    deploymentName: selenium-node-chrome
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-chrome-node
+    name: selenium-node-chrome
   triggers:
     - type: selenium-grid
       metadata:
@@ -78,11 +78,11 @@ metadata:
   name: selenium-grid-firefox-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-firefox-node
+    deploymentName: selenium-node-firefox
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-firefox-node
+    name: selenium-node-firefox
   triggers:
     - type: selenium-grid
       metadata:
@@ -99,11 +99,11 @@ metadata:
   name: selenium-grid-edge-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-edge-node
+    deploymentName: selenium-node-edge
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-edge-node
+    name: selenium-node-edge
   triggers:
     - type: selenium-grid
       metadata:
@@ -121,11 +121,11 @@ metadata:
   name: selenium-grid-chrome-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-chrome-node
+    deploymentName: selenium-node-chrome
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-chrome-node
+    name: selenium-node-chrome
   triggers:
     - type: selenium-grid
       metadata:
@@ -143,11 +143,11 @@ metadata:
   name: selenium-grid-chrome-91-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-chrome-node-91
+    deploymentName: selenium-node-chrome-91
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-chrome-node-91
+    name: selenium-node-chrome-91
   triggers:
     - type: selenium-grid
       metadata:
@@ -163,11 +163,11 @@ metadata:
   name: selenium-grid-chrome-90-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-chrome-node-90
+    deploymentName: selenium-node-chrome-90
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-chrome-node-90
+    name: selenium-node-chrome-90
   triggers:
     - type: selenium-grid
       metadata:
@@ -219,11 +219,11 @@ metadata:
   name: selenium-grid-chrome-scaledobject
   namespace: keda
   labels:
-    deploymentName: selenium-chrome-node
+    deploymentName: selenium-node-chrome
 spec:
   maxReplicaCount: 8
   scaleTargetRef:
-    name: selenium-chrome-node
+    name: selenium-node-chrome
   triggers:
     - type: selenium-grid
       metadata:

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -348,10 +348,10 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | autoscaling.scaledObjectOptions.scaleTargetRef.kind | string | `"Deployment"` | Target reference for KEDA ScaledObject |
 | autoscaling.terminationGracePeriodSeconds | int | `3600` | Define terminationGracePeriodSeconds for scalingType "deployment". Period for `deregisterLifecycle` to gracefully shut down the node before force terminating it |
 | autoscaling.deregisterLifecycle | string | `nil` | Define preStop command to shut down the node gracefully when scalingType is set to "deployment" |
-| crossBrowsers | object | `{"chromeNode":[{"nameOverride":null}],"edgeNode":[{"nameOverride":null}],"firefoxNode":[{"nameOverride":null}]}` | Configuration additional nodes with different versions, capabilities, etc. |
 | crossBrowsers.chromeNode | list | `[{"nameOverride":null}]` | Additional chrome nodes, array of objects with the same structure as `chromeNode` |
 | crossBrowsers.firefoxNode | list | `[{"nameOverride":null}]` | Additional firefox nodes, array of objects with the same structure as `firefoxNode` |
 | crossBrowsers.edgeNode | list | `[{"nameOverride":null}]` | Additional edge nodes, array of objects with the same structure as `edgeNode` |
+| crossBrowsers.relayNode | list | `[{"nameOverride":null}]` | Additional release nodes, array of objects with the same structure as `relayNode` |
 | chromeNode.enabled | bool | `true` | Enable chrome nodes |
 | chromeNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long-living pods false - for provisioning your own custom type such as Jobs |
 | chromeNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -348,6 +348,10 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | autoscaling.scaledObjectOptions.scaleTargetRef.kind | string | `"Deployment"` | Target reference for KEDA ScaledObject |
 | autoscaling.terminationGracePeriodSeconds | int | `3600` | Define terminationGracePeriodSeconds for scalingType "deployment". Period for `deregisterLifecycle` to gracefully shut down the node before force terminating it |
 | autoscaling.deregisterLifecycle | string | `nil` | Define preStop command to shut down the node gracefully when scalingType is set to "deployment" |
+| crossBrowsers | object | `{"chromeNode":[{"nameOverride":null}],"edgeNode":[{"nameOverride":null}],"firefoxNode":[{"nameOverride":null}]}` | Configuration additional nodes with different versions, capabilities, etc. |
+| crossBrowsers.chromeNode | list | `[{"nameOverride":null}]` | Additional chrome nodes, array of objects with the same structure as `chromeNode` |
+| crossBrowsers.firefoxNode | list | `[{"nameOverride":null}]` | Additional firefox nodes, array of objects with the same structure as `firefoxNode` |
+| crossBrowsers.edgeNode | list | `[{"nameOverride":null}]` | Additional edge nodes, array of objects with the same structure as `edgeNode` |
 | chromeNode.enabled | bool | `true` | Enable chrome nodes |
 | chromeNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long-living pods false - for provisioning your own custom type such as Jobs |
 | chromeNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |

--- a/charts/selenium-grid/cross-browsers-values.yaml
+++ b/charts/selenium-grid/cross-browsers-values.yaml
@@ -18,6 +18,23 @@ crossBrowsers:
       hpa:
         browserVersion: '127.0'
   firefoxNode:
+    - nameOverride:
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-130'
+      imageTag: '130.0'
+      hpa:
+        browserVersion: '130.0'
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-129'
+      imageTag: '129.0'
+      hpa:
+        browserVersion: '129.0'
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-128'
+      imageTag: '128.0'
+      hpa:
+        browserVersion: '128.0'
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-127'
+      imageTag: '127.0'
+      hpa:
+        browserVersion: '127.0'
   edgeNode:
     - nameOverride:
     - nameOverride: '{{ $.Release.Name }}-node-edge-130'

--- a/charts/selenium-grid/cross-browsers-values.yaml
+++ b/charts/selenium-grid/cross-browsers-values.yaml
@@ -19,3 +19,20 @@ crossBrowsers:
         browserVersion: '127.0'
   firefoxNode:
   edgeNode:
+    - nameOverride:
+    - nameOverride: '{{ $.Release.Name }}-node-edge-130'
+      imageTag: '130.0'
+      hpa:
+        browserVersion: '130.0'
+    - nameOverride: '{{ $.Release.Name }}-node-edge-129'
+      imageTag: '129.0'
+      hpa:
+        browserVersion: '129.0'
+    - nameOverride: '{{ $.Release.Name }}-node-edge-128'
+      imageTag: '128.0'
+      hpa:
+        browserVersion: '128.0'
+    - nameOverride: '{{ $.Release.Name }}-node-edge-127'
+      imageTag: '127.0'
+      hpa:
+        browserVersion: '127.0'

--- a/charts/selenium-grid/cross-browsers-values.yaml
+++ b/charts/selenium-grid/cross-browsers-values.yaml
@@ -1,5 +1,6 @@
 crossBrowsers:
   chromeNode:
+    # Keep the first iteration with latest version of Chrome
     - nameOverride:
     - nameOverride: '{{ $.Release.Name }}-node-chrome-130'
       imageTag: '130.0'
@@ -13,11 +14,8 @@ crossBrowsers:
       imageTag: '128.0'
       hpa:
         browserVersion: '128.0'
-    - nameOverride: '{{ $.Release.Name }}-node-chrome-127'
-      imageTag: '127.0'
-      hpa:
-        browserVersion: '127.0'
   firefoxNode:
+    # Keep the first iteration with latest version of Firefox
     - nameOverride:
     - nameOverride: '{{ $.Release.Name }}-node-firefox-130'
       imageTag: '130.0'
@@ -31,11 +29,8 @@ crossBrowsers:
       imageTag: '128.0'
       hpa:
         browserVersion: '128.0'
-    - nameOverride: '{{ $.Release.Name }}-node-firefox-127'
-      imageTag: '127.0'
-      hpa:
-        browserVersion: '127.0'
   edgeNode:
+    # Keep the first iteration with latest version of Edge
     - nameOverride:
     - nameOverride: '{{ $.Release.Name }}-node-edge-130'
       imageTag: '130.0'
@@ -49,7 +44,3 @@ crossBrowsers:
       imageTag: '128.0'
       hpa:
         browserVersion: '128.0'
-    - nameOverride: '{{ $.Release.Name }}-node-edge-127'
-      imageTag: '127.0'
-      hpa:
-        browserVersion: '127.0'

--- a/charts/selenium-grid/cross-browsers-values.yaml
+++ b/charts/selenium-grid/cross-browsers-values.yaml
@@ -1,0 +1,21 @@
+crossBrowsers:
+  chromeNode:
+    - nameOverride:
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-130'
+      imageTag: '130.0'
+      hpa:
+        browserVersion: '130.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-129'
+      imageTag: '129.0'
+      hpa:
+        browserVersion: '129.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-128'
+      imageTag: '128.0'
+      hpa:
+        browserVersion: '128.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-127'
+      imageTag: '127.0'
+      hpa:
+        browserVersion: '127.0'
+  firefoxNode:
+  edgeNode:

--- a/charts/selenium-grid/templates/_nameHelpers.tpl
+++ b/charts/selenium-grid/templates/_nameHelpers.tpl
@@ -150,7 +150,9 @@ Edge node fullname
 Relay node fullname
 */}}
 {{- define "seleniumGrid.relayNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-relay" $)) .Values.relayNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- $component := index . 0 }}
+{{- $root := index . 1 }}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-relay" $root)) $component.nameOverride) $root | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/selenium-grid/templates/_nameHelpers.tpl
+++ b/charts/selenium-grid/templates/_nameHelpers.tpl
@@ -139,7 +139,9 @@ Firefox node fullname
 Edge node fullname
 */}}
 {{- define "seleniumGrid.edgeNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-edge" $)) .Values.edgeNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- $component := index . 0 }}
+{{- $root := index . 1 }}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-edge" $root)) $component.nameOverride) $root | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/selenium-grid/templates/_nameHelpers.tpl
+++ b/charts/selenium-grid/templates/_nameHelpers.tpl
@@ -132,7 +132,9 @@ Chrome node fullname
 Firefox node fullname
 */}}
 {{- define "seleniumGrid.firefoxNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-firefox" $)) .Values.firefoxNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- $component := index . 0 }}
+{{- $root := index . 1 }}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-firefox" $root)) $component.nameOverride) $root | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/selenium-grid/templates/_nameHelpers.tpl
+++ b/charts/selenium-grid/templates/_nameHelpers.tpl
@@ -123,28 +123,30 @@ SessionQueue fullname
 Chrome node fullname
 */}}
 {{- define "seleniumGrid.chromeNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-chrome-node" $)) .Values.chromeNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- $component := index . 0 }}
+{{- $root := index . 1 }}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-chrome" $root)) $component.nameOverride) $root | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Firefox node fullname
 */}}
 {{- define "seleniumGrid.firefoxNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-firefox-node" $)) .Values.firefoxNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-firefox" $)) .Values.firefoxNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Edge node fullname
 */}}
 {{- define "seleniumGrid.edgeNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-edge-node" $)) .Values.edgeNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-edge" $)) .Values.edgeNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*
 Relay node fullname
 */}}
 {{- define "seleniumGrid.relayNode.fullname" -}}
-{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-relay-node" $)) .Values.relayNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
+{{- tpl (default (include "seleniumGrid.component.name" (list "selenium-node-relay" $)) .Values.relayNode.nameOverride) $ | trunc 63 | trimSuffix "-" -}}
 {{- end -}}
 
 {{/*

--- a/charts/selenium-grid/templates/chrome-node-deployment.yaml
+++ b/charts/selenium-grid/templates/chrome-node-deployment.yaml
@@ -1,36 +1,40 @@
-{{- if and .Values.chromeNode.enabled ((eq (include "seleniumGrid.useKEDA" .) "true") | ternary (eq .Values.autoscaling.scalingType "deployment") .Values.chromeNode.deploymentEnabled) }}
+{{- range $i, $newNode := .Values.crossBrowsers.chromeNode }}
+{{- $nodeConfig := merge $newNode $.Values.chromeNode -}}
+{{- if and $nodeConfig.enabled ((eq (include "seleniumGrid.useKEDA" $) "true") | ternary (eq $.Values.autoscaling.scalingType "deployment") $nodeConfig.deploymentEnabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "seleniumGrid.chromeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    app: {{ template "seleniumGrid.chromeNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.chromeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- with .Values.chromeNode.labels }}
+    app: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   strategy:
-    {{- template "seleniumGrid.updateStrategy" (list $.Values.chromeNode $.Values.global.seleniumGrid) }}
+    {{- template "seleniumGrid.updateStrategy" (list $nodeConfig $.Values.global.seleniumGrid) }}
   {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
-  replicas: {{ .Values.chromeNode.replicas }}
+  replicas: {{ $nodeConfig.replicas }}
   {{- else }}
-  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.chromeNode.scaledOptions).minReplicaCount }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($nodeConfig.scaledOptions).minReplicaCount }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ $.Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: {{ template "seleniumGrid.chromeNode.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-{{- $podScope := deepCopy . -}}
-{{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
-{{- $_ =  set $podScope "node" .Values.chromeNode -}}
-{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.chromeNode.videoRecorder) -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
+      app: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- $podScope := deepCopy $ -}}
+{{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" (list $nodeConfig $)) -}}
+{{- $_ =  set $podScope "node" $nodeConfig -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-hpa.yaml
+++ b/charts/selenium-grid/templates/chrome-node-hpa.yaml
@@ -1,26 +1,30 @@
-{{- if and .Values.chromeNode.enabled (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "deployment") }}
+{{- range $i, $newNode := .Values.crossBrowsers.chromeNode }}
+{{- $nodeConfig := merge $newNode $.Values.chromeNode -}}
+{{- if and $nodeConfig.enabled (eq (include "seleniumGrid.useKEDA" $) "true") (eq $.Values.autoscaling.scalingType "deployment") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ template "seleniumGrid.chromeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    deploymentName: {{ template "seleniumGrid.chromeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.chromeNode.labels }}
+    deploymentName: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.chromeNode -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
+++ b/charts/selenium-grid/templates/chrome-node-scaledjobs.yaml
@@ -1,30 +1,34 @@
-{{- if and .Values.chromeNode.enabled (include "seleniumGrid.useKEDA" .) (eq .Values.autoscaling.scalingType "job") }}
+{{- range $i, $newNode := .Values.crossBrowsers.chromeNode }}
+{{- $nodeConfig := merge $newNode $.Values.chromeNode -}}
+{{- if and $nodeConfig.enabled (include "seleniumGrid.useKEDA" $) (eq $.Values.autoscaling.scalingType "job") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
-  name: {{ template "seleniumGrid.chromeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    app: {{ template "seleniumGrid.chromeNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.chromeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.chromeNode.labels }}
+    app: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.chromeNode -}}
-  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.chromeNode.videoRecorder) -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.chromeNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/chrome-node-service.yaml
+++ b/charts/selenium-grid/templates/chrome-node-service.yaml
@@ -1,33 +1,35 @@
-{{- if and .Values.chromeNode.enabled .Values.chromeNode.service.enabled }}
+{{- range $i, $newNode := .Values.crossBrowsers.chromeNode }}
+{{- $nodeConfig := merge $newNode $.Values.chromeNode -}}
+{{- if and $nodeConfig.enabled $nodeConfig.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "seleniumGrid.chromeNode.fullname" . }}
+  name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
   namespace: {{ .Release.Namespace }}
   labels:
-    name: {{ template "seleniumGrid.chromeNode.fullname" . }}
+    name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-  {{- with .Values.chromeNode.service.annotations }}
+  {{- with $nodeConfig.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.chromeNode.service.type }}
+  type: {{ $nodeConfig.service.type }}
   selector:
-    app: {{ template "seleniumGrid.chromeNode.fullname" . }}
+    app: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
     app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if and (eq .Values.chromeNode.service.type "LoadBalancer") (.Values.chromeNode.service.loadBalancerIP) }}
-  loadBalancerIP: {{ .Values.chromeNode.service.loadBalancerIP }}
+  {{- if and (eq $nodeConfig.service.type "LoadBalancer") ($nodeConfig.service.loadBalancerIP) }}
+  loadBalancerIP: {{ $nodeConfig.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: tcp-chrome
       protocol: TCP
-      port: {{ .Values.chromeNode.port }}
-      targetPort: {{ .Values.chromeNode.port }}
-      {{- if and (eq $.Values.chromeNode.service.type "NodePort") .Values.chromeNode.nodePort }}
-      nodePort: {{ .Values.chromeNode.nodePort }}
+      port: {{ $nodeConfig.port }}
+      targetPort: {{ $nodeConfig.port }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") $nodeConfig.nodePort }}
+      nodePort: {{ $nodeConfig.nodePort }}
       {{- end }}
-  {{- with .Values.chromeNode.service.ports }}
+  {{- with $nodeConfig.service.ports }}
     {{- range . }}
     - name: {{ .name }}
       port: {{ .port }}
@@ -35,9 +37,11 @@ spec:
       {{- if .protocol }}
       protocol: {{ .protocol }}
       {{- end }}
-      {{- if and (eq $.Values.chromeNode.service.type "NodePort") .nodePort }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
     {{- end }}
   {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-deployment.yaml
+++ b/charts/selenium-grid/templates/edge-node-deployment.yaml
@@ -1,36 +1,40 @@
-{{- if and .Values.edgeNode.enabled ((eq (include "seleniumGrid.useKEDA" .) "true") | ternary (eq .Values.autoscaling.scalingType "deployment") .Values.edgeNode.deploymentEnabled) }}
+{{- range $i, $newNode := .Values.crossBrowsers.edgeNode }}
+{{- $nodeConfig := merge $newNode $.Values.edgeNode -}}
+{{- if and $nodeConfig.enabled ((eq (include "seleniumGrid.useKEDA" $) "true") | ternary (eq $.Values.autoscaling.scalingType "deployment") $nodeConfig.deploymentEnabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    app: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- with .Values.edgeNode.labels }}
+    app: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   strategy:
-    {{- template "seleniumGrid.updateStrategy" (list $.Values.edgeNode $.Values.global.seleniumGrid) }}
+    {{- template "seleniumGrid.updateStrategy" (list $nodeConfig $.Values.global.seleniumGrid) }}
   {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
-  replicas: {{ .Values.edgeNode.replicas }}
+  replicas: {{ $nodeConfig.replicas }}
   {{- else }}
-  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.edgeNode.scaledOptions).minReplicaCount }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($nodeConfig.scaledOptions).minReplicaCount }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ $.Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: {{ template "seleniumGrid.edgeNode.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-{{- $podScope := deepCopy . -}}
-{{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
-{{- $_ =  set $podScope "node" .Values.edgeNode -}}
-{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.edgeNode.videoRecorder) -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
+      app: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- $podScope := deepCopy $ -}}
+{{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" (list $nodeConfig $)) -}}
+{{- $_ =  set $podScope "node" $nodeConfig -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-hpa.yaml
+++ b/charts/selenium-grid/templates/edge-node-hpa.yaml
@@ -1,26 +1,30 @@
-{{- if and .Values.edgeNode.enabled (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "deployment") }}
+{{- range $i, $newNode := .Values.crossBrowsers.edgeNode }}
+{{- $nodeConfig := merge $newNode $.Values.edgeNode -}}
+{{- if and $nodeConfig.enabled (eq (include "seleniumGrid.useKEDA" $) "true") (eq $.Values.autoscaling.scalingType "deployment") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    deploymentName: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.edgeNode.labels }}
+    deploymentName: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.edgeNode -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/edge-node-scaledjob.yaml
@@ -1,30 +1,34 @@
-{{- if and .Values.edgeNode.enabled (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") }}
+{{- range $i, $newNode := .Values.crossBrowsers.edgeNode }}
+{{- $nodeConfig := merge $newNode $.Values.edgeNode -}}
+{{- if and $nodeConfig.enabled (eq (include "seleniumGrid.useKEDA" $) "true") (eq $.Values.autoscaling.scalingType "job") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
-  name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    app: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.edgeNode.labels }}
+    app: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.edgeNode -}}
-  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.edgeNode.videoRecorder) -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.edgeNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/edge-node-service.yaml
+++ b/charts/selenium-grid/templates/edge-node-service.yaml
@@ -1,33 +1,35 @@
-{{- if and .Values.edgeNode.enabled .Values.edgeNode.service.enabled }}
+{{- range $i, $newNode := .Values.crossBrowsers.edgeNode }}
+{{- $nodeConfig := merge $newNode $.Values.edgeNode -}}
+{{- if and $nodeConfig.enabled $nodeConfig.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    name: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-  {{- with .Values.edgeNode.service.annotations }}
+    name: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+  {{- with $nodeConfig.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.edgeNode.service.type }}
+  type: {{ $nodeConfig.service.type }}
   selector:
-    app: {{ template "seleniumGrid.edgeNode.fullname" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if and (eq .Values.edgeNode.service.type "LoadBalancer") (.Values.edgeNode.service.loadBalancerIP) }}
-  loadBalancerIP: {{ .Values.edgeNode.service.loadBalancerIP }}
+    app: {{ template "seleniumGrid.edgeNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  {{- if and (eq $nodeConfig.service.type "LoadBalancer") ($nodeConfig.service.loadBalancerIP) }}
+  loadBalancerIP: {{ $nodeConfig.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: tcp-edge
       protocol: TCP
-      port: {{ .Values.edgeNode.port }}
-      targetPort: {{ .Values.edgeNode.port }}
-      {{- if and (eq $.Values.edgeNode.service.type "NodePort") .Values.edgeNode.nodePort }}
-      nodePort: {{ .Values.edgeNode.nodePort }}
+      port: {{ $nodeConfig.port }}
+      targetPort: {{ $nodeConfig.port }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") $nodeConfig.nodePort }}
+      nodePort: {{ $nodeConfig.nodePort }}
       {{- end }}
-  {{- with .Values.edgeNode.service.ports }}
+  {{- with $nodeConfig.service.ports }}
     {{- range . }}
     - name: {{ .name }}
       port: {{ .port }}
@@ -35,9 +37,11 @@ spec:
       {{- if .protocol }}
       protocol: {{ .protocol }}
       {{- end }}
-      {{- if and (eq $.Values.edgeNode.service.type "NodePort") .nodePort }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
     {{- end }}
   {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-deployment.yaml
+++ b/charts/selenium-grid/templates/firefox-node-deployment.yaml
@@ -1,36 +1,40 @@
-{{- if and .Values.firefoxNode.enabled ((eq (include "seleniumGrid.useKEDA" .) "true") | ternary (eq .Values.autoscaling.scalingType "deployment")  .Values.firefoxNode.deploymentEnabled) }}
+{{- range $i, $newNode := .Values.crossBrowsers.firefoxNode }}
+{{- $nodeConfig := merge $newNode $.Values.firefoxNode -}}
+{{- if and $nodeConfig.enabled ((eq (include "seleniumGrid.useKEDA" $) "true") | ternary (eq $.Values.autoscaling.scalingType "deployment")  $nodeConfig.deploymentEnabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    app: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- with .Values.firefoxNode.labels }}
+    app: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   strategy:
-    {{- template "seleniumGrid.updateStrategy" (list $.Values.firefoxNode $.Values.global.seleniumGrid) }}
+    {{- template "seleniumGrid.updateStrategy" (list $nodeConfig $.Values.global.seleniumGrid) }}
   {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
-  replicas: {{ .Values.firefoxNode.replicas }}
+  replicas: {{ $nodeConfig.replicas }}
   {{- else }}
-  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.firefoxNode.scaledOptions).minReplicaCount }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($nodeConfig.scaledOptions).minReplicaCount }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ $.Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-{{- $podScope := deepCopy . -}}
-{{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
-{{- $_ =  set $podScope "node" .Values.firefoxNode -}}
-{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.firefoxNode.videoRecorder) -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
+      app: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- $podScope := deepCopy $ -}}
+{{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $)) -}}
+{{- $_ =  set $podScope "node" $nodeConfig -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-hpa.yaml
+++ b/charts/selenium-grid/templates/firefox-node-hpa.yaml
@@ -1,26 +1,30 @@
-{{- if and .Values.firefoxNode.enabled (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "deployment") }}
+{{- range $i, $newNode := .Values.crossBrowsers.firefoxNode }}
+{{- $nodeConfig := merge $newNode $.Values.firefoxNode -}}
+{{- if and $nodeConfig.enabled (eq (include "seleniumGrid.useKEDA" $) "true") (eq $.Values.autoscaling.scalingType "deployment") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    deploymentName: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.firefoxNode.labels }}
+    deploymentName: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.firefoxNode -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
+++ b/charts/selenium-grid/templates/firefox-node-scaledjob.yaml
@@ -1,30 +1,34 @@
-{{- if and .Values.firefoxNode.enabled (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "job") }}
+{{- range $i, $newNode := .Values.crossBrowsers.firefoxNode }}
+{{- $nodeConfig := merge $newNode $.Values.firefoxNode -}}
+{{- if and $nodeConfig.enabled (eq (include "seleniumGrid.useKEDA" $) "true") (eq $.Values.autoscaling.scalingType "job") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
-  name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    app: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.firefoxNode.labels }}
+    app: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.firefoxNode -}}
-  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.firefoxNode.videoRecorder) -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder ($podScope.recorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-service.yaml
+++ b/charts/selenium-grid/templates/firefox-node-service.yaml
@@ -1,33 +1,35 @@
-{{- if and .Values.firefoxNode.enabled .Values.firefoxNode.service.enabled }}
+{{- range $i, $newNode := .Values.crossBrowsers.firefoxNode }}
+{{- $nodeConfig := merge $newNode $.Values.firefoxNode -}}
+{{- if and $nodeConfig.enabled $.Values.firefoxNode.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    name: {{ template "seleniumGrid.firefoxNode.fullname" . }}
+    name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
     {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-  {{- with .Values.firefoxNode.service.annotations }}
+  {{- with $nodeConfig.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.firefoxNode.service.type }}
+  type: {{ $nodeConfig.service.type }}
   selector:
-    app: {{ template "seleniumGrid.firefoxNode.fullname" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if and (eq .Values.firefoxNode.service.type "LoadBalancer") (.Values.firefoxNode.service.loadBalancerIP) }}
-  loadBalancerIP: {{ .Values.firefoxNode.service.loadBalancerIP }}
+    app: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  {{- if and (eq $nodeConfig.service.type "LoadBalancer") ($nodeConfig.service.loadBalancerIP) }}
+  loadBalancerIP: {{ $nodeConfig.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: tcp-firefox
       protocol: TCP
-      port: {{ .Values.firefoxNode.port }}
-      targetPort: {{ .Values.firefoxNode.port }}
-      {{- if and (eq $.Values.firefoxNode.service.type "NodePort") .Values.firefoxNode.nodePort }}
-      nodePort: {{ .Values.firefoxNode.nodePort }}
+      port: {{ $nodeConfig.port }}
+      targetPort: {{ $nodeConfig.port }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") $nodeConfig.nodePort }}
+      nodePort: {{ $nodeConfig.nodePort }}
       {{- end }}
-  {{- with .Values.firefoxNode.service.ports }}
+  {{- with $nodeConfig.service.ports }}
     {{- range . }}
     - name: {{ .name }}
       port: {{ .port }}
@@ -35,9 +37,11 @@ spec:
       {{- if .protocol }}
       protocol: {{ .protocol }}
       {{- end }}
-      {{- if and (eq $.Values.firefoxNode.service.type "NodePort") .nodePort }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
     {{- end }}
   {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/relay-node-deployment.yaml
+++ b/charts/selenium-grid/templates/relay-node-deployment.yaml
@@ -1,36 +1,40 @@
-{{- if and .Values.relayNode.enabled ((eq (include "seleniumGrid.useKEDA" .) "true") | ternary (eq .Values.autoscaling.scalingType "deployment") .Values.relayNode.deploymentEnabled) }}
+{{- range $i, $newNode := .Values.crossBrowsers.relayNode }}
+{{- $nodeConfig := merge $newNode $.Values.relayNode -}}
+{{- if and $nodeConfig.enabled ((eq (include "seleniumGrid.useKEDA" $) "true") | ternary (eq $.Values.autoscaling.scalingType "deployment") $nodeConfig.deploymentEnabled) }}
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: {{ template "seleniumGrid.relayNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    app: {{ template "seleniumGrid.relayNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.relayNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- with .Values.relayNode.labels }}
+    app: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
   strategy:
-    {{- template "seleniumGrid.updateStrategy" (list $.Values.relayNode $.Values.global.seleniumGrid) }}
+    {{- template "seleniumGrid.updateStrategy" (list $nodeConfig $.Values.global.seleniumGrid) }}
   {{- if not (eq (include "seleniumGrid.useKEDA" $) "true") }}
-  replicas: {{ .Values.relayNode.replicas }}
+  replicas: {{ $nodeConfig.replicas }}
   {{- else }}
-  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($.Values.relayNode.scaledOptions).minReplicaCount }}
+  replicas: {{ default $.Values.autoscaling.scaledOptions.minReplicaCount ($nodeConfig.scaledOptions).minReplicaCount }}
   {{- end }}
-  revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
+  revisionHistoryLimit: {{ $.Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:
-      app: {{ template "seleniumGrid.relayNode.fullname" . }}
-      app.kubernetes.io/instance: {{ .Release.Name }}
-{{- $podScope := deepCopy . -}}
-{{- $_ := set $podScope "name" (include "seleniumGrid.relayNode.fullname" .) -}}
-{{- $_ =  set $podScope "node" .Values.relayNode -}}
-{{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.relayNode.videoRecorder) -}}
-{{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+      app: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+      app.kubernetes.io/instance: {{ $.Release.Name }}
+{{- $podScope := deepCopy $ -}}
+{{- $_ := set $podScope "name" (include "seleniumGrid.relayNode.fullname" (list $nodeConfig $)) -}}
+{{- $_ =  set $podScope "node" $nodeConfig -}}
+{{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+{{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
 {{- include "seleniumGrid.podTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/relay-node-hpa.yaml
+++ b/charts/selenium-grid/templates/relay-node-hpa.yaml
@@ -1,26 +1,30 @@
-{{- if and .Values.relayNode.enabled (eq (include "seleniumGrid.useKEDA" .) "true") (eq .Values.autoscaling.scalingType "deployment") }}
+{{- range $i, $newNode := .Values.crossBrowsers.relayNode }}
+{{- $nodeConfig := merge $newNode $.Values.relayNode -}}
+{{- if and $nodeConfig.enabled (eq (include "seleniumGrid.useKEDA" $) "true") (eq $.Values.autoscaling.scalingType "deployment") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:
-  name: {{ template "seleniumGrid.relayNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    deploymentName: {{ template "seleniumGrid.relayNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.relayNode.labels }}
+    deploymentName: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.relayNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.relayNode -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.relayNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/relay-node-scaledjobs.yaml
+++ b/charts/selenium-grid/templates/relay-node-scaledjobs.yaml
@@ -1,30 +1,34 @@
-{{- if and .Values.relayNode.enabled (include "seleniumGrid.useKEDA" .) (eq .Values.autoscaling.scalingType "job") }}
+{{- range $i, $newNode := .Values.crossBrowsers.relayNode }}
+{{- $nodeConfig := merge $newNode $.Values.relayNode -}}
+{{- if and $nodeConfig.enabled (include "seleniumGrid.useKEDA" $) (eq $.Values.autoscaling.scalingType "job") }}
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
-  name: {{ template "seleniumGrid.relayNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   annotations:
-    {{- with .Values.autoscaling.annotations }}
+    {{- with $.Values.autoscaling.annotations }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
   labels:
-    app: {{ template "seleniumGrid.relayNode.fullname" . }}
-    app.kubernetes.io/name: {{ template "seleniumGrid.relayNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-    {{- include "seleniumGrid.autoscalingLabels" . | nindent 4 }}
-    {{- with .Values.relayNode.labels }}
+    app: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- include "seleniumGrid.autoscalingLabels" $ | nindent 4 }}
+    {{- with $nodeConfig.labels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
-    {{- with .Values.customLabels }}
+    {{- with $.Values.customLabels }}
       {{- toYaml . | nindent 4 }}
     {{- end }}
 spec:
-  {{- $podScope := deepCopy . -}}
-  {{- $_ := set $podScope "name" (include "seleniumGrid.relayNode.fullname" .) -}}
-  {{- $_ =  set $podScope "node" .Values.relayNode -}}
-  {{- $_ =  set $podScope "recorder" (mergeOverwrite .Values.videoRecorder .Values.relayNode.videoRecorder) -}}
-  {{- $_ =  set $podScope "uploader" (get .Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
+  {{- $podScope := deepCopy $ -}}
+  {{- $_ := set $podScope "name" (include "seleniumGrid.relayNode.fullname" (list $nodeConfig $)) -}}
+  {{- $_ =  set $podScope "node" $nodeConfig -}}
+  {{- $_ =  set $podScope "recorder" (mergeOverwrite $.Values.videoRecorder $nodeConfig.videoRecorder) -}}
+  {{- $_ =  set $podScope "uploader" (get $.Values.videoRecorder (.Values.videoRecorder.uploader.name | toString)) -}}
   {{- $_ =  set $podScope "podTemplate" (include "seleniumGrid.podTemplate" $podScope | fromYaml) }}
   {{- include "seleniumGrid.autoscalingTemplate" $podScope | nindent 2 }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/templates/relay-node-service.yaml
+++ b/charts/selenium-grid/templates/relay-node-service.yaml
@@ -1,33 +1,35 @@
-{{- if and .Values.relayNode.enabled .Values.relayNode.service.enabled }}
+{{- range $i, $newNode := .Values.crossBrowsers.relayNode }}
+{{- $nodeConfig := merge $newNode $.Values.relayNode -}}
+{{- if and $nodeConfig.enabled $nodeConfig.service.enabled }}
 apiVersion: v1
 kind: Service
 metadata:
-  name: {{ template "seleniumGrid.relayNode.fullname" . }}
-  namespace: {{ .Release.Namespace }}
+  name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+  namespace: {{ $.Release.Namespace }}
   labels:
-    name: {{ template "seleniumGrid.relayNode.fullname" . }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
-  {{- with .Values.relayNode.service.annotations }}
+    name: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+  {{- with $nodeConfig.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
   {{- end }}
 spec:
-  type: {{ .Values.relayNode.service.type }}
+  type: {{ $nodeConfig.service.type }}
   selector:
-    app: {{ template "seleniumGrid.relayNode.fullname" . }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
-  {{- if and (eq .Values.relayNode.service.type "LoadBalancer") (.Values.relayNode.service.loadBalancerIP) }}
-  loadBalancerIP: {{ .Values.relayNode.service.loadBalancerIP }}
+    app: {{ template "seleniumGrid.relayNode.fullname" (list $nodeConfig $) }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
+  {{- if and (eq $nodeConfig.service.type "LoadBalancer") ($nodeConfig.service.loadBalancerIP) }}
+  loadBalancerIP: {{ $nodeConfig.service.loadBalancerIP }}
   {{- end }}
   ports:
     - name: tcp-chrome
       protocol: TCP
-      port: {{ .Values.relayNode.port }}
-      targetPort: {{ .Values.relayNode.port }}
-      {{- if and (eq $.Values.relayNode.service.type "NodePort") .Values.relayNode.nodePort }}
-      nodePort: {{ .Values.relayNode.nodePort }}
+      port: {{ $nodeConfig.port }}
+      targetPort: {{ $nodeConfig.port }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") $nodeConfig.nodePort }}
+      nodePort: {{ $nodeConfig.nodePort }}
       {{- end }}
-  {{- with .Values.relayNode.service.ports }}
+  {{- with $nodeConfig.service.ports }}
     {{- range . }}
     - name: {{ .name }}
       port: {{ .port }}
@@ -35,9 +37,11 @@ spec:
       {{- if .protocol }}
       protocol: {{ .protocol }}
       {{- end }}
-      {{- if and (eq $.Values.relayNode.service.type "NodePort") .nodePort }}
+      {{- if and (eq $nodeConfig.service.type "NodePort") .nodePort }}
       nodePort: {{ .nodePort }}
       {{- end }}
     {{- end }}
   {{- end }}
+---
+{{- end }}
 {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -910,6 +910,21 @@ autoscaling:
   #    exec:
   #      command: [ "bash", "-c", "/opt/bin/nodePreStop.sh" ]
 
+# -- Configuration additional nodes with different versions, capabilities, etc.
+crossBrowsers:
+  # -- Additional chrome nodes, array of objects with the same structure as `chromeNode`
+  chromeNode:
+    - nameOverride:
+  # - Refer to file `cross-browsers-values.yaml` to configure additional nodes
+  # -- Additional firefox nodes, array of objects with the same structure as `firefoxNode`
+  firefoxNode:
+    - nameOverride:
+  # - Refer to file `cross-browsers-values.yaml` to configure additional node browsers
+  # -- Additional edge nodes, array of objects with the same structure as `edgeNode`
+  edgeNode:
+    - nameOverride:
+  # - Refer to file `cross-browsers-values.yaml` to configure additional node browsers
+
 # Configuration for chrome nodes
 chromeNode:
   # -- Enable chrome nodes

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -910,7 +910,7 @@ autoscaling:
   #    exec:
   #      command: [ "bash", "-c", "/opt/bin/nodePreStop.sh" ]
 
-# -- Configuration additional nodes with different versions, capabilities, etc.
+# Configuration additional nodes with different versions, capabilities, etc.
 crossBrowsers:
   # -- Additional chrome nodes, array of objects with the same structure as `chromeNode`
   chromeNode:
@@ -924,6 +924,9 @@ crossBrowsers:
   edgeNode:
     - nameOverride:
   # - Refer to file `cross-browsers-values.yaml` to configure additional node browsers
+  # -- Additional release nodes, array of objects with the same structure as `relayNode`
+  relayNode:
+    - nameOverride:
 
 # Configuration for chrome nodes
 chromeNode:

--- a/tests/charts/bootstrap.sh
+++ b/tests/charts/bootstrap.sh
@@ -18,6 +18,7 @@ helm package charts/selenium-grid --version 1.0.0-SNAPSHOT -d tests/tests
 RELEASE_NAME="selenium"
 
 helm template ${RELEASE_NAME} --values tests/charts/templates/render/dummy.yaml \
+  --values charts/selenium-grid/cross-browsers-values.yaml \
   --set-file 'nodeConfigMap.extraScripts.setFromCommand\.sh=tests/charts/templates/render/dummy_external.sh' \
   --set-file 'recorderConfigMap.extraScripts.setFromCommand\.sh=tests/charts/templates/render/dummy_external.sh' \
   --set-file 'uploaderConfigMap.extraScripts.setFromCommand\.sh=tests/charts/templates/render/dummy_external.sh' \
@@ -37,6 +38,7 @@ helm package tests/charts/umbrella-charts --version 1.0.0-SNAPSHOT -d tests/test
 RELEASE_NAME="test"
 
 helm template ${RELEASE_NAME} --values tests/charts/templates/render/dummy_solution.yaml \
+  --values charts/selenium-grid/cross-browsers-values.yaml \
   --set-file 'selenium-grid.nodeConfigMap.extraScripts.setFromCommand\.sh=tests/charts/templates/render/dummy_external.sh' \
   --set-file 'selenium-grid.recorderConfigMap.extraScripts.setFromCommand\.sh=tests/charts/templates/render/dummy_external.sh' \
   --set-file 'selenium-grid.uploaderConfigMap.extraScripts.setFromCommand\.sh=tests/charts/templates/render/dummy_external.sh' \

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -18,10 +18,10 @@ def load_template(yaml_file):
 
 class ChartTemplateTests(unittest.TestCase):
     def test_set_affinity(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',
                           f'{RELEASE_NAME}selenium-distributor',
-                          f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',
+                          f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',
                           f'{RELEASE_NAME}selenium-event-bus',
                           f'{RELEASE_NAME}selenium-router',
                           f'{RELEASE_NAME}selenium-session-map',
@@ -107,10 +107,10 @@ class ChartTemplateTests(unittest.TestCase):
         self.assertTrue(is_present, "ENV variable SE_DISABLE_UI is not populated")
 
     def test_log_level_set_to_logging_config_map(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',
                           f'{RELEASE_NAME}selenium-distributor',
-                          f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',
+                          f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',
                           f'{RELEASE_NAME}selenium-event-bus',
                           f'{RELEASE_NAME}selenium-router',
                           f'{RELEASE_NAME}selenium-session-map',
@@ -193,9 +193,9 @@ class ChartTemplateTests(unittest.TestCase):
         self.assertEqual(count, len(resources_name), "No recorder config resources found")
 
     def test_upload_conf_mount_to_video_container(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',
-                          f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',]
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',
+                          f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',]
         is_present = False
         for doc in LIST_OF_DOCUMENTS:
             if doc['metadata']['name'] in resources_name and doc['kind'] == 'Deployment':
@@ -208,7 +208,7 @@ class ChartTemplateTests(unittest.TestCase):
                     if container['name'] == 's3':
                         uploader_container = container
                 # Test for case override upload config in Edge node
-                if doc['metadata']['name'] == f'{RELEASE_NAME}selenium-edge-node':
+                if doc['metadata']['name'] == f'{RELEASE_NAME}selenium-node-edge':
                     self.assertTrue(uploader_container is None, "Video uploader should be disabled in Edge node config")
                     continue
                 list_volume_mounts = None
@@ -222,7 +222,7 @@ class ChartTemplateTests(unittest.TestCase):
         self.assertTrue(is_present, "Volume mount for upload config is not present in the container")
 
     def test_terminationGracePeriodSeconds_in_deployment_autoscaling(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',]
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',]
         count = 0
         for doc in LIST_OF_DOCUMENTS:
             if doc['metadata']['name'] in resources_name and doc['kind'] == 'Deployment':
@@ -231,8 +231,8 @@ class ChartTemplateTests(unittest.TestCase):
                 count += 1
         self.assertEqual(count, len(resources_name), "node.terminationGracePeriodSeconds doesn't override a higher value than autoscaling.terminationGracePeriodSeconds")
 
-        resources_name = [f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',]
+        resources_name = [f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',]
         count = 0
         for doc in LIST_OF_DOCUMENTS:
             if doc['metadata']['name'] in resources_name and doc['kind'] == 'Deployment':
@@ -270,9 +270,9 @@ class ChartTemplateTests(unittest.TestCase):
                     f'{RELEASE_NAME}selenium-router',
                     f'{RELEASE_NAME}selenium-session-map',
                     f'{RELEASE_NAME}selenium-session-queue',]
-        rolling  = [f'{RELEASE_NAME}selenium-chrome-node',
-                    f'{RELEASE_NAME}selenium-edge-node',
-                    f'{RELEASE_NAME}selenium-firefox-node',]
+        rolling  = [f'{RELEASE_NAME}selenium-node-chrome',
+                    f'{RELEASE_NAME}selenium-node-edge',
+                    f'{RELEASE_NAME}selenium-node-firefox',]
         count_recreate = 0
         count_rolling = 0
         for doc in LIST_OF_DOCUMENTS:
@@ -288,9 +288,9 @@ class ChartTemplateTests(unittest.TestCase):
         self.assertEqual(count_recreate, len(recreate), "No deployment resources found with strategy Recreate")
 
     def test_topologySpreadConstraints_in_all_components(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',
-                          f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',
+                          f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',
                           f'{RELEASE_NAME}selenium-distributor',
                           f'{RELEASE_NAME}selenium-event-bus',
                           f'{RELEASE_NAME}selenium-router',
@@ -314,9 +314,9 @@ class ChartTemplateTests(unittest.TestCase):
         self.assertEqual(count, 0, "Basic auth secret resource is created when nameOverride is set")
 
     def test_router_envFrom_secretRef_name_use_external_secret_when_basicAuth_nameOverride_is_set(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',
-                          f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',
+                          f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',
                           f'{RELEASE_NAME}selenium-distributor',
                           f'{RELEASE_NAME}selenium-event-bus',
                           f'{RELEASE_NAME}selenium-router',
@@ -334,9 +334,9 @@ class ChartTemplateTests(unittest.TestCase):
         self.assertTrue(is_present, "ENV variable from secretRef name is not set to external secret")
 
     def test_scaler_triggers_authenticationRef_name_is_added(self):
-        resources_name = [f'{RELEASE_NAME}selenium-chrome-node',
-                          f'{RELEASE_NAME}selenium-edge-node',
-                          f'{RELEASE_NAME}selenium-firefox-node',]
+        resources_name = [f'{RELEASE_NAME}selenium-node-chrome',
+                          f'{RELEASE_NAME}selenium-node-edge',
+                          f'{RELEASE_NAME}selenium-node-firefox',]
         is_present = False
         for doc in LIST_OF_DOCUMENTS:
             if doc['metadata']['name'] in resources_name and doc['kind'] == 'ScaledObject':
@@ -345,9 +345,9 @@ class ChartTemplateTests(unittest.TestCase):
                 self.assertTrue(name, f'{RELEASE_NAME}selenium-scaler-trigger-auth')
 
     def test_scaler_triggers_parameter_nodeMaxSessions_global_and_individual_value(self):
-        resources_name = {f'{RELEASE_NAME}selenium-chrome-node': 2,
-                          f'{RELEASE_NAME}selenium-edge-node': 3,
-                          f'{RELEASE_NAME}selenium-firefox-node': 1,}
+        resources_name = {f'{RELEASE_NAME}selenium-node-chrome': 2,
+                          f'{RELEASE_NAME}selenium-node-edge': 3,
+                          f'{RELEASE_NAME}selenium-node-firefox': 1,}
         count = 0
         for resource_name in resources_name.keys():
             for doc in LIST_OF_DOCUMENTS:


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
This pull request includes several changes to the Selenium Grid Helm chart to enhance its configuration and scalability. The key changes involve renaming deployment names for consistency, adding support for cross-browser nodes, and updating templates to accommodate these new configurations.

### Example Usage
```yaml
crossBrowsers:
  chromeNode:
    # Keep the first iteration with latest version of Chrome
    - nameOverride:
    - nameOverride: '{{ $.Release.Name }}-node-chrome-130'
      imageTag: '130.0'
      hpa:
        browserVersion: '130.0'
    - nameOverride: '{{ $.Release.Name }}-node-chrome-129'
      imageTag: '129.0'
      hpa:
        browserVersion: '129.0'
    - nameOverride: '{{ $.Release.Name }}-node-chrome-128'
      imageTag: '128.0'
      hpa:
        browserVersion: '128.0'
  firefoxNode:
    # Keep the first iteration with latest version of Firefox
    - nameOverride:
    - nameOverride: '{{ $.Release.Name }}-node-firefox-130'
      imageTag: '130.0'
      hpa:
        browserVersion: '130.0'
    - nameOverride: '{{ $.Release.Name }}-node-firefox-129'
      imageTag: '129.0'
      hpa:
        browserVersion: '129.0'
    - nameOverride: '{{ $.Release.Name }}-node-firefox-128'
      imageTag: '128.0'
      hpa:
        browserVersion: '128.0'
  edgeNode:
    # Keep the first iteration with latest version of Edge
    - nameOverride:
    - nameOverride: '{{ $.Release.Name }}-node-edge-130'
      imageTag: '130.0'
      hpa:
        browserVersion: '130.0'
    - nameOverride: '{{ $.Release.Name }}-node-edge-129'
      imageTag: '129.0'
      hpa:
        browserVersion: '129.0'
    - nameOverride: '{{ $.Release.Name }}-node-edge-128'
      imageTag: '128.0'
      hpa:
        browserVersion: '128.0'
```

### Cross-Browser Support:
* Added support for additional Chrome, Firefox, and Edge nodes in the Helm chart configuration. (`charts/selenium-grid/CONFIGURATION.md`: [[1]](diffhunk://#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786R351-R354) `charts/selenium-grid/cross-browsers-values.yaml`: [[2]](diffhunk://#diff-29b4fda31b69cd7b63bd7aa5afeb9197c682d06990a803be7b020aaec1da3eaaR1-R46)

### Template Updates:
* Updated templates to handle the new cross-browser node configurations, including deployment, HPA, ScaledJob, and service templates. (`charts/selenium-grid/templates/chrome-node-deployment.yaml`: [[1]](diffhunk://#diff-34c2065883f6f9ebf3df5c03b4478e44842d87f953577465088c705a17b2fa46L1-R39) `charts/selenium-grid/templates/chrome-node-hpa.yaml`: [[2]](diffhunk://#diff-1f8fe33ad569caa97711c4424a0acd1b0b2c863302393c964deb6a18a1b1c9f8L1-R29) `charts/selenium-grid/templates/chrome-node-scaledjobs.yaml`: [[3]](diffhunk://#diff-d7dac3df6778fd7822c244f0dbe3baba0fd192f4723750e65a1f889504a2d763L1-R33) `charts/selenium-grid/templates/chrome-node-service.yaml`: [[4]](diffhunk://#diff-3a658573ccead4c2cf2ef5a22de7f376ca76c7b26380739f38cae3167e756b62L1-R46) `charts/selenium-grid/templates/edge-node-deployment.yaml`: [[5]](diffhunk://#diff-507359f2b12a0dd188309d744bad913359324cfd194bb6358a6f231929e38b28L1-R39)

### Name Helper Template:
* Modified the name helper template to generate consistent names for cross-browser nodes. (`charts/selenium-grid/templates/_nameHelpers.tpl`: [charts/selenium-grid/templates/_nameHelpers.tplL126-R155](diffhunk://#diff-81a82f068405c6e0c78f9c712e58508ee92d328bcd4329cfdb7f7c3b25c11282L126-R155))

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, tests


___

### **Description**
- Enhanced Selenium Grid Helm chart to support multiple nodes for Chrome, Firefox, Edge, and Relay.
- Updated test scripts to reflect new naming conventions for browser nodes.
- Added cross-browser configurations in `values.yaml` and `cross-browsers-values.yaml`.
- Updated deployment, HPA, ScaledJob, and service templates to support cross-browser configurations.
- Documented new configurations in `CONFIGURATION.md`.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>bootstrap.sh</strong><dd><code>Add cross-browser values to Helm template commands</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/bootstrap.sh

<li>Added cross-browser values to Helm template commands.<br> <li> Enhanced testing configurations for Selenium Grid.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-d21c39459120b3a738e8e353cf8fb88b04fbffbb9cdc78dd38ae07856f2d226f">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>test.py</strong><dd><code>Update resource names in test cases</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/test.py

<li>Updated resource names for Chrome, Edge, and Firefox nodes.<br> <li> Adjusted test cases to reflect new naming conventions.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-313e81a96e34d08dcd821e7a1223f59ffce689433658ae3999a26fc7f6dcb343">+28/-28</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Enhancement</strong></td><td><details><summary>9 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>_nameHelpers.tpl</strong><dd><code>Rename node templates and add relay node support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/_nameHelpers.tpl

<li>Renamed node templates for consistency.<br> <li> Added support for relay nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-81a82f068405c6e0c78f9c712e58508ee92d328bcd4329cfdb7f7c3b25c11282">+12/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-deployment.yaml</strong><dd><code>Support multiple Chrome node configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-deployment.yaml

<li>Added support for multiple Chrome node configurations.<br> <li> Implemented templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-34c2065883f6f9ebf3df5c03b4478e44842d87f953577465088c705a17b2fa46">+23/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-hpa.yaml</strong><dd><code>Add HPA configuration for multiple Chrome nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-hpa.yaml

<li>Added HPA configuration for multiple Chrome nodes.<br> <li> Enhanced templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-1f8fe33ad569caa97711c4424a0acd1b0b2c863302393c964deb6a18a1b1c9f8">+16/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-scaledjobs.yaml</strong><dd><code>Add scaled job configuration for Chrome nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-scaledjobs.yaml

<li>Added scaled job configuration for multiple Chrome nodes.<br> <li> Enhanced templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-d7dac3df6778fd7822c244f0dbe3baba0fd192f4723750e65a1f889504a2d763">+19/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome-node-service.yaml</strong><dd><code>Add service configuration for Chrome nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-service.yaml

<li>Added service configuration for multiple Chrome nodes.<br> <li> Enhanced templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-3a658573ccead4c2cf2ef5a22de7f376ca76c7b26380739f38cae3167e756b62">+18/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge-node-deployment.yaml</strong><dd><code>Support multiple Edge node configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-deployment.yaml

<li>Added support for multiple Edge node configurations.<br> <li> Implemented templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-507359f2b12a0dd188309d744bad913359324cfd194bb6358a6f231929e38b28">+23/-19</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge-node-hpa.yaml</strong><dd><code>Add HPA configuration for multiple Edge nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-hpa.yaml

<li>Added HPA configuration for multiple Edge nodes.<br> <li> Enhanced templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-21f4c7dc3f78b08236de19af1fbd08f920cd0c17e44e7c529fe071ef653e0256">+16/-12</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge-node-scaledjob.yaml</strong><dd><code>Add scaled job configuration for Edge nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-scaledjob.yaml

<li>Added scaled job configuration for multiple Edge nodes.<br> <li> Enhanced templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-b9b151402d2339683d56e768fcdd8c045189ec768b6c056963e314e9b8ce830b">+19/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>edge-node-service.yaml</strong><dd><code>Add service configuration for Edge nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/edge-node-service.yaml

<li>Added service configuration for multiple Edge nodes.<br> <li> Enhanced templating for cross-browser support.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-0968f7e6c05dee505721bb68ffa501bab2d401445306c0ab7a1541b54040e9fb">+21/-17</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium-grid-scaler.md</strong><dd><code>Update deployment names in KEDA scaler configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.keda/scalers/selenium-grid-scaler.md

- Updated deployment names for Chrome, Firefox, and Edge nodes.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-227785b68e5d0238e9c4048856d300458ec0658fa13526af89e7357b697ddd6e">+14/-14</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>cross-browsers-values.yaml</strong><dd><code>Add configurations for additional browser nodes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/cross-browsers-values.yaml

<li>Added configurations for additional Chrome, Firefox, and Edge nodes.<br> <li> Specified image tags and HPA settings for each browser version.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-29b4fda31b69cd7b63bd7aa5afeb9197c682d06990a803be7b020aaec1da3eaa">+46/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add cross-browser configurations to values.yaml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Added cross-browser configurations for Chrome, Firefox, Edge, and <br>Relay nodes.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Document cross-browser node configurations</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

- Documented additional cross-browser node configurations.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2475/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+4/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information