### PR TITLE
K8s: regression issue on template for nodes service.enabled

### DIFF
--- a/charts/selenium-grid/templates/chrome-node-service.yaml
+++ b/charts/selenium-grid/templates/chrome-node-service.yaml
@@ -5,10 +5,10 @@ apiVersion: v1
 kind: Service
 metadata:
   name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
-  namespace: {{ .Release.Namespace }}
+  namespace: {{ $.Release.Namespace }}
   labels:
     name: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
   {{- with $nodeConfig.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}
@@ -17,7 +17,7 @@ spec:
   type: {{ $nodeConfig.service.type }}
   selector:
     app: {{ template "seleniumGrid.chromeNode.fullname" (list $nodeConfig $) }}
-    app.kubernetes.io/instance: {{ .Release.Name }}
+    app.kubernetes.io/instance: {{ $.Release.Name }}
   {{- if and (eq $nodeConfig.service.type "LoadBalancer") ($nodeConfig.service.loadBalancerIP) }}
   loadBalancerIP: {{ $nodeConfig.service.loadBalancerIP }}
   {{- end }}

--- a/charts/selenium-grid/templates/firefox-node-service.yaml
+++ b/charts/selenium-grid/templates/firefox-node-service.yaml
@@ -8,7 +8,7 @@ metadata:
   namespace: {{ $.Release.Namespace }}
   labels:
     name: {{ template "seleniumGrid.firefoxNode.fullname" (list $nodeConfig $) }}
-    {{- include "seleniumGrid.commonLabels" . | nindent 4 }}
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
   {{- with $nodeConfig.service.annotations }}
   annotations:
     {{- toYaml . | nindent 4 }}

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -121,16 +121,22 @@ chromeNode:
   annotations:
     "restartOnUpdate": "true"
   terminationGracePeriodSeconds: 7200
+  service:
+    enabled: true
 
 firefoxNode:
   nodeMaxSessions: 1
   annotations:
     "restartOnUpdate": "true"
   terminationGracePeriodSeconds: 720
+  service:
+    enabled: true
 
 edgeNode:
   annotations:
     "restartOnUpdate": "true"
+  service:
+    enabled: true
   videoRecorder:
     uploader:
       enabled: false

--- a/tests/charts/templates/render/dummy_solution.yaml
+++ b/tests/charts/templates/render/dummy_solution.yaml
@@ -111,14 +111,20 @@ selenium-grid:
     nodeMaxSessions: 2
     affinity: *affinity
     terminationGracePeriodSeconds: 7200
+    service:
+      enabled: true
 
   firefoxNode:
     nodeMaxSessions: 1
     affinity: *affinity
     terminationGracePeriodSeconds: 720
+    service:
+      enabled: true
 
   edgeNode:
     affinity: *affinity
+    service:
+      enabled: true
     videoRecorder:
       uploader:
         enabled: false


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed a regression issue in the Kubernetes templates for Chrome and Firefox node services by correcting the context used for namespace and label references.
- Added `service.enabled` field to the test configurations for Chrome, Firefox, and Edge nodes to ensure services are enabled as expected.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome-node-service.yaml</strong><dd><code>Fix namespace and label context in Chrome node service template</code></dd></summary>
<hr>

charts/selenium-grid/templates/chrome-node-service.yaml

<li>Fixed namespace reference to use root context.<br> <li> Corrected label inclusion to use root context.<br> <li> Updated selector to use root context for release name.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2484/files#diff-3a658573ccead4c2cf2ef5a22de7f376ca76c7b26380739f38cae3167e756b62">+3/-3</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox-node-service.yaml</strong><dd><code>Fix label context in Firefox node service template</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/firefox-node-service.yaml

- Corrected label inclusion to use root context.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2484/files#diff-0842dc185b69e2b0a3bd3c656b0a8557dcc77a525c4f7be227180282d49db739">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>dummy.yaml</strong><dd><code>Add service enabled field in dummy test configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/templates/render/dummy.yaml

- Added `service.enabled` field for Chrome, Firefox, and Edge nodes.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2484/files#diff-5aaf14c24dad808759277c90e4431d7f17c31b2a6bd7c8def5ba8361b73de5a9">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>dummy_solution.yaml</strong><dd><code>Add service enabled field in dummy solution configuration</code></dd></summary>
<hr>

tests/charts/templates/render/dummy_solution.yaml

- Added `service.enabled` field for Chrome, Firefox, and Edge nodes.



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2484/files#diff-076f5cdbdf212cb19276dd9a4a63001d747537595d7966188a5155dc2aeaaca2">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information