### PR TITLE
Docker: Node env vars to disable/enable VNC view only, password

### DIFF
--- a/NodeBase/start-vnc.sh
+++ b/NodeBase/start-vnc.sh
@@ -14,7 +14,7 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ]; then
       fi
     done
     VNC_NO_PASSWORD=${VNC_NO_PASSWORD:-$SE_VNC_NO_PASSWORD}
-    if [ ! -z $VNC_NO_PASSWORD ]; then
+    if [ "${VNC_NO_PASSWORD}" = "true" ] || [ "${VNC_NO_PASSWORD}" = "1" ]; then
       echo "Starting VNC server without password authentication"
       X11VNC_OPTS=
     else
@@ -22,7 +22,7 @@ if [ "${START_XVFB:-$SE_START_XVFB}" = true ]; then
     fi
 
     VNC_VIEW_ONLY=${VNC_VIEW_ONLY:-$SE_VNC_VIEW_ONLY}
-    if [ ! -z $VNC_VIEW_ONLY ]; then
+    if [ "${VNC_VIEW_ONLY}" = "true" ] || [ "${VNC_VIEW_ONLY}" = "1" ]; then
       echo "Starting VNC server with viewonly option"
       X11VNC_OPTS="${X11VNC_OPTS} -viewonly"
     fi

--- a/README.md
+++ b/README.md
@@ -1661,9 +1661,9 @@ Then, you would use in your VNC client:
 If you get a prompt asking for a password, it is: `secret`. If you wish to change this, 
 you can set the environment variable `SE_VNC_PASSWORD`.
 
-If you want to run VNC without password authentication you can set the environment variable `SE_VNC_NO_PASSWORD=1`.
+If you want to run VNC without password authentication you can set the environment variable `SE_VNC_NO_PASSWORD=true`.
 
-If you want to run VNC in view-only mode you can set the environment variable `SE_VNC_VIEW_ONLY=1`.
+If you want to run VNC in view-only mode you can set the environment variable `SE_VNC_VIEW_ONLY=true`.
 
 If you want to modify the open file descriptor limit for the VNC server process you can set the environment variable `SE_VNC_ULIMIT=4096`.
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #2485

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Documentation


___

### **Description**
- Fixed the logic for enabling/disabling VNC view-only mode and password authentication in `start-vnc.sh` by checking if the environment variables are set to "true" or "1".
- Updated the documentation in `README.md` to reflect the correct usage of environment variables `SE_VNC_NO_PASSWORD` and `SE_VNC_VIEW_ONLY`, recommending the use of "true" instead of "1".



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start-vnc.sh</strong><dd><code>Fix VNC environment variable conditions for correct behavior</code></dd></summary>
<hr>

NodeBase/start-vnc.sh

<li>Updated condition to check for <code>VNC_NO_PASSWORD</code> and <code>VNC_VIEW_ONLY</code>.<br> <li> Changed condition to check for "true" or "1" values.<br> <li> Ensures correct behavior for enabling/disabling VNC options.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2489/files#diff-0dc21857d7f8bf7c04f278a449432133894507b870bbe534f0d1dc675e59840e">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for VNC environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated documentation for <code>SE_VNC_NO_PASSWORD</code> and <code>SE_VNC_VIEW_ONLY</code>.<br> <li> Changed recommended value to "true" for enabling options.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2489/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information