### PR TITLE
Correct kubectl cli params in keda patch job

### DIFF
--- a/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
@@ -35,8 +35,8 @@ spec:
             - |
               echo "Cleaning up ScaledObjects, ScaledJobs and HPAs for {{ .Release.Name }} when upgrading or disabling autoscaling."
               kubectl get ScaledObjects,ScaledJobs,TriggerAuthentication -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} -o=json | jq '.metadata.finalizers = null' | kubectl apply -f - || true ;
-              kubectl delete ScaledObjects,ScaledJobs,TriggerAuthentication -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait false || true ;
-              kubectl delete hpa -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait false || true ;
+              kubectl delete ScaledObjects,ScaledJobs,TriggerAuthentication -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait=false || true ;
+              kubectl delete hpa -n {{ .Release.Namespace }} -l component.autoscaling={{ .Release.Name }} --wait=false || true ;
         {{- with $.Values.autoscaling.patchObjectFinalizers.resources }}
           resources: {{ toYaml . | nindent 12 }}
         {{- end }}


### PR DESCRIPTION
### **User description**
### Description
--wait is a flag by itself, need to add `--wait=false` else `false` gets interpreted as an object name and leads to the error:

> error: name cannot be provided when a selector is specified

### Motivation and Context
Without this, the `selenium-patch-scaledobjects-finalizers` job will consistently fail

### Types of changes

- [X] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [X] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed the `kubectl` command parameters in the KEDA patch job by adding `--wait=false` to ensure `false` is not interpreted as an object name.
- This change prevents the `selenium-patch-scaledobjects-finalizers` job from failing due to incorrect parameter interpretation.



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>patch-keda-objects-job.yaml</strong><dd><code>Fix `kubectl` command parameters in KEDA patch job</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml

<li>Corrected the <code>kubectl</code> command by adding <code>--wait=false</code>.<br> <li> Prevented <code>false</code> from being interpreted as an object name.<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2501/files#diff-45939f6d4fb5ad9a484c9afd9221bf408cf9e2c0afa2a5198cdfdb4a2d937a24">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information