### PR TITLE
Docker: set/unset stereotype via env var SE_NODE_BROWSER_VERSION and SE_BROWSER_BINARY_LOCATION

### DIFF
--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -47,6 +47,7 @@ ENV LANG_WHICH=${LANG_WHICH} \
     SE_OTEL_SERVICE_NAME="selenium-node" \
     # Setting Selenium Manager to work offline
     SE_OFFLINE=true \
+    SE_NODE_BROWSER_VERSION="stable" \
 #============================
 # Some configuration options
 #============================

--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -55,16 +55,16 @@ echo "max-sessions = ${SE_NODE_MAX_CONCURRENCY:-${SE_NODE_MAX_SESSIONS}}
 if [ -f /opt/selenium/browser_name ]; then
 	SE_NODE_BROWSER_NAME=$(cat /opt/selenium/browser_name)
 fi
-if [ -f /opt/selenium/browser_version ]; then
+if [ -f /opt/selenium/browser_version ] && [ "${SE_NODE_BROWSER_VERSION}" = "stable" ]; then
 	SE_NODE_BROWSER_VERSION=$(short_version $(cat /opt/selenium/browser_version))
 fi
-if [ -f /opt/selenium/browser_binary_location ]; then
-	SE__BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
+if [ -f /opt/selenium/browser_binary_location ] && [ -z "${SE_BROWSER_BINARY_LOCATION}" ]; then
+	SE_BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
 fi
 
 # 'browserName' is mandatory for default stereotype
 if [[ -z "${SE_NODE_STEREOTYPE}" ]] && [[ -n "${SE_NODE_BROWSER_NAME}" ]]; then
-	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE__BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
+	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
 else
 	SE_NODE_STEREOTYPE="${SE_NODE_STEREOTYPE}"
 fi

--- a/Standalone/generate_config
+++ b/Standalone/generate_config
@@ -32,12 +32,18 @@ echo "drain-after-session-count = ${DRAIN_AFTER_SESSION_COUNT:-$SE_DRAIN_AFTER_S
 echo "max-sessions = ${SE_NODE_MAX_SESSIONS}
 " >>"$FILENAME"
 
-SE_NODE_BROWSER_NAME=$(cat /opt/selenium/browser_name)
-SE_NODE_BROWSER_VERSION=$(short_version $(cat /opt/selenium/browser_version))
-SE__BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
+if [ -f /opt/selenium/browser_name ]; then
+	SE_NODE_BROWSER_NAME=$(cat /opt/selenium/browser_name)
+fi
+if [ -f /opt/selenium/browser_version ] && [ "${SE_NODE_BROWSER_VERSION}" = "stable" ]; then
+	SE_NODE_BROWSER_VERSION=$(short_version $(cat /opt/selenium/browser_version))
+fi
+if [ -f /opt/selenium/browser_binary_location ] && [ -z "${SE_BROWSER_BINARY_LOCATION}" ]; then
+	SE_BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
+fi
 
 if [[ -z "$SE_NODE_STEREOTYPE" ]]; then
-	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE__BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
+	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
 else
 	SE_NODE_STEREOTYPE="$SE_NODE_STEREOTYPE"
 fi

--- a/tests/docker-compose-v3-test-parallel.yml
+++ b/tests/docker-compose-v3-test-parallel.yml
@@ -18,6 +18,7 @@ services:
       - ./videos/certs:/opt/selenium/secrets
       - ./videos:/videos
     environment:
+      - SE_NODE_BROWSER_VERSION=
       - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
@@ -53,6 +54,7 @@ services:
       - ./videos/certs:/opt/selenium/secrets
       - ./videos:/videos
     environment:
+      - SE_NODE_BROWSER_VERSION=
       - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
@@ -84,6 +86,7 @@ services:
     volumes:
       - ./videos/certs:/opt/selenium/secrets
     environment:
+      - SE_NODE_BROWSER_VERSION=
       - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442

--- a/tests/docker-compose-v3-test-standalone.yml
+++ b/tests/docker-compose-v3-test-standalone.yml
@@ -12,6 +12,7 @@ services:
     depends_on:
       - browser_video
     environment:
+      - SE_NODE_BROWSER_VERSION=
       - SE_ENABLE_TRACING=false
       - SE_NODE_MAX_SESSIONS=1
       - SE_NODE_OVERRIDE_MAX_SESSIONS=true


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
By default, Node stereotype sets `browserVersion` in short format e.g `131.0`.
In a case, if want to unset `browserVersion` (leave it as empty). Setting env var `SE_NODE_BROWSER_VERSION=`

Similarly, for `SE_BROWSER_BINARY_LOCATION` to unset or set another location in the container for browser binary or based on official image, you rebuild your own, then can set via this env var.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added ability to control browser version through `SE_NODE_BROWSER_VERSION` environment variable
- Added support for custom browser binary location via `SE_BROWSER_BINARY_LOCATION` environment variable
- Enhanced configuration generation scripts to handle empty/unset browser version
- Updated test configurations to demonstrate browser version configuration
- Fixed variable name inconsistency for browser binary location
- Added proper file existence checks in configuration scripts



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add browser version environment variable configuration</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/Dockerfile

<li>Added new environment variable <code>SE_NODE_BROWSER_VERSION</code> with default <br>value "stable"<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2520/files#diff-16a06916a1ac13cfa86d64f9a62439648853b0e48f98b68ac36305f31de7f2c4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Update browser configuration generation logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/generate_config

<li>Modified browser version check to consider <code>SE_NODE_BROWSER_VERSION</code> <br>environment variable<br> <li> Updated browser binary location handling with <br><code>SE_BROWSER_BINARY_LOCATION</code> variable<br> <li> Fixed variable name typo from <code>SE__BROWSER_BINARY_LOCATION</code> to <br><code>SE_BROWSER_BINARY_LOCATION</code><br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2520/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+4/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Enhance standalone configuration generation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Standalone/generate_config

<li>Added file existence checks for browser configuration files<br> <li> Implemented conditional browser version and binary location settings<br> <li> Updated stereotype generation with new environment variables<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2520/files#diff-dbfea8e89862249087918cf19250edbbe7f6ec4666fdaee5958bcf58cdd89557">+10/-4</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-test-parallel.yml</strong><dd><code>Add browser version configuration to test services</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/docker-compose-v3-test-parallel.yml

<li>Added <code>SE_NODE_BROWSER_VERSION</code> environment variable to multiple <br>services<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2520/files#diff-85fc408adf8bd428755578c2c89e6b6dd45c57d3f556811786ddc19fccefb115">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-test-standalone.yml</strong><dd><code>Add browser version configuration to standalone test</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/docker-compose-v3-test-standalone.yml

<li>Added <code>SE_NODE_BROWSER_VERSION</code> environment variable to standalone <br>service<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2520/files#diff-4abafe5523b1f77c0f1d493d4625be4a0cdd36309218f4953a2697618e9e109b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information