### PR TITLE
Docker: set/unset stereotype via env var SE_NODE_PLATFORM_NAME

### DIFF
--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -48,6 +48,7 @@ ENV LANG_WHICH=${LANG_WHICH} \
     # Setting Selenium Manager to work offline
     SE_OFFLINE=true \
     SE_NODE_BROWSER_VERSION="stable" \
+    SE_NODE_PLATFORM_NAME="Linux" \
 #============================
 # Some configuration options
 #============================

--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -55,7 +55,7 @@ echo "max-sessions = ${SE_NODE_MAX_CONCURRENCY:-${SE_NODE_MAX_SESSIONS}}
 if [ -f /opt/selenium/browser_name ]; then
 	SE_NODE_BROWSER_NAME=$(cat /opt/selenium/browser_name)
 fi
-if [ -f /opt/selenium/browser_version ] && [ "${SE_NODE_BROWSER_VERSION}" = "stable" ]; then
+if [ -f /opt/selenium/browser_version ] && [ "${SE_NODE_BROWSER_VERSION,,}" = "stable" ]; then
 	SE_NODE_BROWSER_VERSION=$(short_version $(cat /opt/selenium/browser_version))
 fi
 if [ -f /opt/selenium/browser_binary_location ] && [ -z "${SE_BROWSER_BINARY_LOCATION}" ]; then
@@ -64,7 +64,7 @@ fi
 
 # 'browserName' is mandatory for default stereotype
 if [[ -z "${SE_NODE_STEREOTYPE}" ]] && [[ -n "${SE_NODE_BROWSER_NAME}" ]]; then
-	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"Linux\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
+	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"${SE_NODE_PLATFORM_NAME}\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
 else
 	SE_NODE_STEREOTYPE="${SE_NODE_STEREOTYPE}"
 fi


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Env var `SE_NODE_PLATFORM_NAME ` can be used to unset default value `Linux` in Node stereotype. This supports to work with autoscaling with KEDA, aligned config with scaler trigger params `platformName`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Added new environment variable `SE_NODE_PLATFORM_NAME` to allow configurable platform name in node stereotype
- Default value set to "Linux" to maintain backward compatibility
- Made browser version comparison case-insensitive for better flexibility
- Supports integration with KEDA autoscaling by aligning configuration with scaler trigger params



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add platform name environment variable configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/Dockerfile

<li>Added new environment variable <code>SE_NODE_PLATFORM_NAME</code> with default <br>value "Linux"<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2525/files#diff-16a06916a1ac13cfa86d64f9a62439648853b0e48f98b68ac36305f31de7f2c4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Make platform name configurable in node stereotype</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/generate_config

<li>Modified browser version comparison to be case-insensitive using <br><code>${SE_NODE_BROWSER_VERSION,,}</code><br> <li> Updated node stereotype generation to use configurable <br><code>SE_NODE_PLATFORM_NAME</code> instead of hardcoded "Linux"<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2525/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information