### PR TITLE
Docker: Process of xvfb_vnc_novnc start by env variable

### DIFF
--- a/NodeBase/selenium.conf
+++ b/NodeBase/selenium.conf
@@ -5,8 +5,8 @@
 [program:xvfb]
 priority=0
 command=/opt/bin/start-xvfb.sh
-autostart=true
-autorestart=true
+autostart=%(ENV_SE_START_XVFB)s
+autorestart=%(ENV_SE_START_XVFB)s
 killasgroup=true
 
 ;Logs
@@ -23,8 +23,8 @@ stderr_capture_maxbytes=50MB
 [program:vnc]
 priority=5
 command=/opt/bin/start-vnc.sh
-autostart=true
-autorestart=true
+autostart=%(ENV_SE_START_VNC)s
+autorestart=%(ENV_SE_START_VNC)s
 killasgroup=true
 
 ;Logs
@@ -41,8 +41,8 @@ stderr_capture_maxbytes=50MB
 [program:novnc]
 priority=10
 command=/opt/bin/start-novnc.sh
-autostart=true
-autorestart=true
+autostart=%(ENV_SE_START_NO_VNC)s
+autorestart=%(ENV_SE_START_NO_VNC)s
 killasgroup=true
 
 ;Logs

--- a/tests/AutoscalingTests/common.py
+++ b/tests/AutoscalingTests/common.py
@@ -79,7 +79,8 @@ def randomly_quit_sessions(sessions, sublist_size):
             session.quit()
             sessions.remove(session)
         print(f"QUIT: {len(sessions_to_quit)} sessions have been randomly quit.")
-    return len(sessions_to_quit)
+        return len(sessions_to_quit)
+    return 0
 
 def get_result_file_name():
     return f"tests/autoscaling_results"


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/2500
To prevent confusion messages from PID spawn again, even already set it as false to disable
```
2024-12-10 19:14:29,438 INFO spawned: 'vnc' with pid 1412
2024-12-10 19:14:29,439 INFO spawned: 'novnc' with pid 1413
2024-12-10 19:14:29,441 WARN exited: vnc (exit status 0; not expected)
2024-12-10 19:14:29,442 WARN exited: novnc (exit status 0; not expected)
2024-12-10 19:14:32,446 INFO spawned: 'vnc' with pid 1425
2024-12-10 19:14:32,447 INFO spawned: 'novnc' with pid 1426
2024-12-10 19:14:32,449 WARN exited: vnc (exit status 0; not expected)
2024-12-10 19:14:32,449 INFO gave up: vnc entered FATAL state, too many start retries too quickly
2024-12-10 19:14:32,450 WARN exited: novnc (exit status 0; not expected)
2024-12-10 19:14:33,451 INFO gave up: novnc entered FATAL state, too many start retries too quickly
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Fixed issue where VNC and noVNC processes would attempt to start even when disabled via environment variables
- Modified supervisor configuration to properly respect SE_START_VNC, SE_START_NO_VNC, and SE_START_XVFB environment variables
- Prevents unnecessary process spawning and error messages when services are intentionally disabled
- Improves resource usage by properly disabling unused display and remote access services



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium.conf</strong><dd><code>Enable environment variable control for VNC and display services</code></dd></summary>
<hr>

NodeBase/selenium.conf

<li>Modified supervisor configuration to respect environment variables for <br>process control<br> <li> Changed autostart and autorestart settings for xvfb, vnc, and novnc <br>services to use environment variables<br> <li> Added dynamic control through SE_START_XVFB, SE_START_VNC, and <br>SE_START_NO_VNC variables<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2534/files#diff-ed39d098d56e265c885f29c77d233837899c9c843b173f47dff57b5b4861b8c5">+6/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information