### PR TITLE
Docker: Update condition to enable tracing to avoid annoying warning messages

### DIFF
--- a/Distributor/start-selenium-grid-distributor.sh
+++ b/Distributor/start-selenium-grid-distributor.sh
@@ -151,7 +151,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/EventBus/start-selenium-grid-eventbus.sh
+++ b/EventBus/start-selenium-grid-eventbus.sh
@@ -81,7 +81,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/Hub/start-selenium-grid-hub.sh
+++ b/Hub/start-selenium-grid-hub.sh
@@ -131,7 +131,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/NodeBase/start-selenium-node.sh
+++ b/NodeBase/start-selenium-node.sh
@@ -127,7 +127,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/NodeDocker/start-selenium-grid-docker.sh
+++ b/NodeDocker/start-selenium-grid-docker.sh
@@ -91,7 +91,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/Router/start-selenium-grid-router.sh
+++ b/Router/start-selenium-grid-router.sh
@@ -132,7 +132,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/SessionQueue/start-selenium-grid-session-queue.sh
+++ b/SessionQueue/start-selenium-grid-session-queue.sh
@@ -85,7 +85,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/Sessions/start-selenium-grid-sessions.sh
+++ b/Sessions/start-selenium-grid-sessions.sh
@@ -107,7 +107,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="${EXTRA_LIBS}${EXTERNAL_JARS}"

--- a/Standalone/start-selenium-standalone.sh
+++ b/Standalone/start-selenium-standalone.sh
@@ -130,7 +130,7 @@ echo "Starting Selenium Grid Standalone..."
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/StandaloneDocker/start-selenium-grid-docker.sh
+++ b/StandaloneDocker/start-selenium-grid-docker.sh
@@ -96,7 +96,7 @@ fi
 
 EXTRA_LIBS=""
 
-if [ "$SE_ENABLE_TRACING" = "true" ]; then
+if [ "${SE_ENABLE_TRACING}" = "true" ] && [ -n "${SE_OTEL_EXPORTER_ENDPOINT}" ]; then
   EXTERNAL_JARS=$(</external_jars/.classpath.txt)
   [ -n "$EXTRA_LIBS" ] && [ -n "${EXTERNAL_JARS}" ] && EXTRA_LIBS=${EXTRA_LIBS}:
   EXTRA_LIBS="--ext "${EXTRA_LIBS}${EXTERNAL_JARS}

--- a/docker-compose-v2.yml
+++ b/docker-compose-v2.yml
@@ -12,7 +12,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     ports:
       - "6900:5900"
 
@@ -25,7 +24,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     ports:
       - "6901:5900"
 
@@ -38,14 +36,11 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     ports:
       - "6902:5900"
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-basicauth.yml
+++ b/docker-compose-v3-basicauth.yml
@@ -12,7 +12,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -23,7 +22,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -34,7 +32,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
@@ -43,7 +40,5 @@ services:
       - "4442:4442"
       - "4443:4443"
       - "4444:4444"
-    environment:
-      - SE_ENABLE_TRACING=false
     volumes:
       - ./Hub/example-config.toml:/opt/selenium/config.toml

--- a/docker-compose-v3-beta-channel.yml
+++ b/docker-compose-v3-beta-channel.yml
@@ -12,7 +12,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:beta
@@ -23,7 +22,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:beta
@@ -34,13 +32,10 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:latest
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-dev-channel.yml
+++ b/docker-compose-v3-dev-channel.yml
@@ -12,7 +12,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:dev
@@ -23,7 +22,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:dev
@@ -34,13 +32,10 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:latest
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-dev.yml
+++ b/docker-compose-v3-dev.yml
@@ -14,7 +14,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -27,7 +26,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -40,15 +38,12 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
     volumes:
       - ./selenium_server_deploy.jar:/opt/selenium/selenium-server.jar
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-dynamic-grid.yml
+++ b/docker-compose-v3-dynamic-grid.yml
@@ -15,13 +15,10 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-full-grid-dev.yml
+++ b/docker-compose-v3-full-grid-dev.yml
@@ -8,8 +8,6 @@ services:
     volumes:
       - ./selenium_server_deploy.jar:/opt/selenium/selenium-server.jar
     container_name: selenium-event-bus
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"
@@ -28,15 +26,12 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-session-queue:
     image: selenium/session-queue:4.27.0-20241225
     volumes:
       - ./selenium_server_deploy.jar:/opt/selenium/selenium-server.jar
     container_name: selenium-session-queue
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "5559:5559"
 
@@ -59,7 +54,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   selenium-router:
     image: selenium/router:4.27.0-20241225
@@ -79,7 +73,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   chrome:
     image: selenium/node-chrome:4.27.0-20241225
@@ -92,7 +85,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -105,7 +97,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -118,4 +109,3 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false

--- a/docker-compose-v3-full-grid-external-datastore.yml
+++ b/docker-compose-v3-full-grid-external-datastore.yml
@@ -6,8 +6,6 @@ services:
   selenium-event-bus:
     image: selenium/event-bus:4.27.0-20241225
     container_name: selenium-event-bus
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"
@@ -24,7 +22,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
       - SE_SESSIONS_MAP_EXTERNAL_DATASTORE=true
       - SE_SESSIONS_MAP_EXTERNAL_IMPLEMENTATION=org.openqa.selenium.grid.sessionmap.jdbc.JdbcBackedSessionMap
       - SE_SESSIONS_MAP_EXTERNAL_JDBC_URL=jdbc:postgresql://postgresql:5432/selenium_sessions
@@ -57,8 +54,6 @@ services:
   selenium-session-queue:
     image: selenium/session-queue:4.27.0-20241225
     container_name: selenium-session-queue
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "5559:5559"
 
@@ -79,7 +74,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   selenium-router:
     image: selenium/router:4.27.0-20241225
@@ -97,7 +91,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   chrome:
     image: selenium/node-chrome:4.27.0-20241225
@@ -108,7 +101,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -119,7 +111,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -130,4 +121,3 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false

--- a/docker-compose-v3-full-grid-nightly.yml
+++ b/docker-compose-v3-full-grid-nightly.yml
@@ -6,8 +6,6 @@ services:
   selenium-event-bus:
     image: selenium/event-bus:nightly
     container_name: selenium-event-bus
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"
@@ -24,15 +22,12 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-session-queue:
     image: selenium/session-queue:nightly
     container_name: selenium-session-queue
     ports:
       - "5559:5559"
-    environment:
-      - SE_ENABLE_TRACING=false
 
   selenium-distributor:
     image: selenium/distributor:nightly
@@ -51,7 +46,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   selenium-router:
     image: selenium/router:nightly
@@ -69,7 +63,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   chrome:
     image: selenium/node-chrome:nightly
@@ -80,7 +73,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:nightly
@@ -91,7 +83,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:nightly
@@ -102,7 +93,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   chrome_video:
     image: selenium/video:nightly
@@ -114,7 +104,6 @@ services:
       - DISPLAY_CONTAINER_NAME=chrome
       - SE_NODE_GRID_URL=http://selenium-router:4444
       - SE_VIDEO_FILE_NAME=auto
-      - SE_ENABLE_TRACING=false
 
   edge_video:
     image: selenium/video:nightly
@@ -126,7 +115,6 @@ services:
       - DISPLAY_CONTAINER_NAME=edge
       - SE_NODE_GRID_URL=http://selenium-router:4444
       - SE_VIDEO_FILE_NAME=auto
-      - SE_ENABLE_TRACING=false
 
   firefox_video:
     image: selenium/video:nightly
@@ -138,4 +126,3 @@ services:
       - DISPLAY_CONTAINER_NAME=firefox
       - SE_NODE_GRID_URL=http://selenium-router:4444
       - SE_VIDEO_FILE_NAME=auto
-      - SE_ENABLE_TRACING=false

--- a/docker-compose-v3-full-grid-secure.yml
+++ b/docker-compose-v3-full-grid-secure.yml
@@ -14,7 +14,6 @@ services:
       - ./charts/selenium-grid/certs:/opt/selenium/secrets
     environment:
       - SE_ENABLE_TLS=true
-      - SE_ENABLE_TRACING=false
 
   selenium-sessions:
     image: selenium/sessions:4.27.0-20241225
@@ -30,7 +29,6 @@ services:
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
       - SE_ENABLE_TLS=true
-      - SE_ENABLE_TRACING=false
 
   selenium-session-queue:
     image: selenium/session-queue:4.27.0-20241225
@@ -41,7 +39,6 @@ services:
       - "5559:5559"
     environment:
       - SE_ENABLE_TLS=true
-      - SE_ENABLE_TRACING=false
 
   selenium-distributor:
     image: selenium/distributor:4.27.0-20241225
@@ -63,7 +60,6 @@ services:
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
       - SE_ENABLE_TLS=true
-      - SE_ENABLE_TRACING=false
 
   selenium-router:
     image: selenium/router:4.27.0-20241225
@@ -84,7 +80,6 @@ services:
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
       - SE_ENABLE_TLS=true
-      - SE_ENABLE_TRACING=false
 
   chrome:
     image: selenium/node-chrome:4.27.0-20241225
@@ -100,7 +95,6 @@ services:
       - SE_ENABLE_TLS=true
       - SE_NODE_GRID_URL=https://localhost:4444
       - SE_SERVER_PROTOCOL=https
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -116,7 +110,6 @@ services:
       - SE_ENABLE_TLS=true
       - SE_NODE_GRID_URL=https://localhost:4444
       - SE_SERVER_PROTOCOL=https
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -132,4 +125,3 @@ services:
       - SE_ENABLE_TLS=true
       - SE_NODE_GRID_URL=https://localhost:4444
       - SE_SERVER_PROTOCOL=https
-      - SE_ENABLE_TRACING=false

--- a/docker-compose-v3-full-grid-swarm.yml
+++ b/docker-compose-v3-full-grid-swarm.yml
@@ -13,7 +13,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     deploy:
       replicas: 1
     entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
@@ -25,7 +24,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     deploy:
       replicas: 1
     entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
@@ -37,15 +35,12 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     deploy:
       replicas: 1
     entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-full-grid.yml
+++ b/docker-compose-v3-full-grid.yml
@@ -6,8 +6,6 @@ services:
   selenium-event-bus:
     image: selenium/event-bus:4.27.0-20241225
     container_name: selenium-event-bus
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"
@@ -24,13 +22,10 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-session-queue:
     image: selenium/session-queue:4.27.0-20241225
     container_name: selenium-session-queue
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "5559:5559"
 
@@ -51,7 +46,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   selenium-router:
     image: selenium/router:4.27.0-20241225
@@ -69,7 +63,6 @@ services:
       - SE_SESSIONS_MAP_PORT=5556
       - SE_SESSION_QUEUE_HOST=selenium-session-queue
       - SE_SESSION_QUEUE_PORT=5559
-      - SE_ENABLE_TRACING=false
 
   chrome:
     image: selenium/node-chrome:4.27.0-20241225
@@ -80,7 +73,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -91,7 +83,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -102,4 +93,3 @@ services:
       - SE_EVENT_BUS_HOST=selenium-event-bus
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false

--- a/docker-compose-v3-swarm.yml
+++ b/docker-compose-v3-swarm.yml
@@ -13,7 +13,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     deploy:
       replicas: 1
     entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
@@ -25,7 +24,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     deploy:
       replicas: 1
     entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
@@ -37,15 +35,12 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
     deploy:
       replicas: 1
     entrypoint: bash -c 'SE_OPTS="--host $$HOSTNAME" /opt/bin/entry_point.sh'
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-video-in-node.yml
+++ b/docker-compose-v3-video-in-node.yml
@@ -15,7 +15,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
       - SE_RECORD_VIDEO=true
       - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
@@ -32,7 +31,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
       - SE_RECORD_VIDEO=true
       - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
@@ -49,7 +47,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
       - SE_RECORD_VIDEO=true
       - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
@@ -57,8 +54,6 @@ services:
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-video-upload-dynamic-grid.yml
+++ b/docker-compose-v3-video-upload-dynamic-grid.yml
@@ -40,13 +40,10 @@ services:
       # Password encrypted using command: rclone obscure <your_password>
       - SE_RCLONE_CONFIG_MYFTP_PASS=KkK8RsUIba-MMTBUSnuYIdAKvcnFyLl2pdhQig
       - SE_RCLONE_CONFIG_MYFTP_FTP_CONCURRENCY=10
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-video-upload-standalone.yml
+++ b/docker-compose-v3-video-upload-standalone.yml
@@ -25,7 +25,6 @@ services:
       - SE_ROUTER_USERNAME=admin
       - SE_ROUTER_PASSWORD=admin
       - SE_SUB_PATH=/selenium
-      - SE_ENABLE_TRACING=false
 
   standalone_edge:
     image: selenium/standalone-edge:4.27.0-20241225
@@ -36,7 +35,6 @@ services:
       - SE_ROUTER_USERNAME=admin
       - SE_ROUTER_PASSWORD=admin
       - SE_SUB_PATH=/selenium
-      - SE_ENABLE_TRACING=false
 
   standalone_firefox:
     image: selenium/standalone-firefox:4.27.0-20241225
@@ -47,7 +45,6 @@ services:
       - SE_ROUTER_USERNAME=admin
       - SE_ROUTER_PASSWORD=admin
       - SE_SUB_PATH=/selenium
-      - SE_ENABLE_TRACING=false
 
   chrome_video:
     image: selenium/video:ffmpeg-7.1-20241225

--- a/docker-compose-v3-video-upload.yml
+++ b/docker-compose-v3-video-upload.yml
@@ -25,7 +25,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -36,7 +35,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -47,7 +45,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   chrome_video:
     image: selenium/video:ffmpeg-7.1-20241225
@@ -112,8 +109,6 @@ services:
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3-video.yml
+++ b/docker-compose-v3-video.yml
@@ -12,7 +12,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -23,7 +22,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -34,7 +32,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   chrome_video:
     image: selenium/video:ffmpeg-7.1-20241225
@@ -75,8 +72,6 @@ services:
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/docker-compose-v3.yml
+++ b/docker-compose-v3.yml
@@ -12,7 +12,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   edge:
     image: selenium/node-edge:4.27.0-20241225
@@ -23,7 +22,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   firefox:
     image: selenium/node-firefox:4.27.0-20241225
@@ -34,13 +32,10 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
-      - SE_ENABLE_TRACING=false
 
   selenium-hub:
     image: selenium/hub:4.27.0-20241225
     container_name: selenium-hub
-    environment:
-      - SE_ENABLE_TRACING=false
     ports:
       - "4442:4442"
       - "4443:4443"

--- a/tests/docker-compose-v3-test-node-docker.yaml
+++ b/tests/docker-compose-v3-test-node-docker.yaml
@@ -17,7 +17,6 @@ services:
       - selenium-hub
       - ftp_server
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_NODE_DOCKER_CONFIG_FILENAME=docker.toml
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
@@ -43,7 +42,6 @@ services:
     user: ${UID}
     container_name: selenium-hub
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_LOG_LEVEL=${LOG_LEVEL}
       - SE_SESSION_REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
     ports:

--- a/tests/docker-compose-v3-test-node-relay.yml
+++ b/tests/docker-compose-v3-test-node-relay.yml
@@ -8,7 +8,6 @@ services:
     volumes:
       - ./videos/relay_config.toml:/opt/selenium/config.toml
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
@@ -19,14 +18,12 @@ services:
     image: ${NAMESPACE}/standalone-${BROWSER}:${TAG}
     shm_size: 2gb
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_OPTS=--enable-cdp true
       - SE_NODE_ENABLE_CDP=true
 
   selenium-hub:
     image: ${NAMESPACE}/hub:${TAG}
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_LOG_LEVEL=${LOG_LEVEL}
       - SE_SESSION_REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
     ports:
@@ -60,7 +57,6 @@ services:
       - selenium-hub
       - emulator
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443

--- a/tests/docker-compose-v3-test-parallel.yml
+++ b/tests/docker-compose-v3-test-parallel.yml
@@ -19,7 +19,6 @@ services:
       - ./videos:/videos
     environment:
       - SE_NODE_BROWSER_VERSION=
-      - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
@@ -55,7 +54,6 @@ services:
       - ./videos:/videos
     environment:
       - SE_NODE_BROWSER_VERSION=
-      - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
@@ -87,7 +85,6 @@ services:
       - ./videos/certs:/opt/selenium/secrets
     environment:
       - SE_NODE_BROWSER_VERSION=
-      - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
@@ -115,7 +112,6 @@ services:
     volumes:
       - ./videos/certs:/opt/selenium/secrets
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_LOG_LEVEL=${LOG_LEVEL}
       - SE_SESSION_REQUEST_TIMEOUT=${REQUEST_TIMEOUT}
       - SE_SUPERVISORD_LOG_LEVEL=error

--- a/tests/docker-compose-v3-test-standalone-docker.yaml
+++ b/tests/docker-compose-v3-test-standalone-docker.yaml
@@ -9,7 +9,6 @@ services:
       - ./videos/config.toml:/opt/selenium/config.toml
       - /var/run/docker.sock:/var/run/docker.sock
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_VNC_NO_PASSWORD=true
       - SE_START_VNC=true
       - SE_LOG_LEVEL=${LOG_LEVEL}

--- a/tests/docker-compose-v3-test-standalone.yml
+++ b/tests/docker-compose-v3-test-standalone.yml
@@ -13,7 +13,6 @@ services:
       - browser_video
     environment:
       - SE_NODE_BROWSER_VERSION=
-      - SE_ENABLE_TRACING=false
       - SE_NODE_MAX_SESSIONS=1
       - SE_NODE_OVERRIDE_MAX_SESSIONS=true
       - SE_NODE_ENABLE_MANAGED_DOWNLOADS=${SELENIUM_ENABLE_MANAGED_DOWNLOADS}

--- a/tests/docker-compose-v3-test-video.yml
+++ b/tests/docker-compose-v3-test-video.yml
@@ -11,7 +11,6 @@ services:
       - selenium-hub
       - browser_video
     environment:
-      - SE_ENABLE_TRACING=false
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_EVENT_BUS_PUBLISH_PORT=4442
       - SE_EVENT_BUS_SUBSCRIBE_PORT=4443
@@ -60,8 +59,6 @@ services:
       - "4442:4442"
       - "4443:4443"
       - "4444:4444"
-    environment:
-      - SE_ENABLE_TRACING=false
     healthcheck:
       test: "/opt/bin/check-grid.sh --host 0.0.0.0 --port 4444"
       interval: 15s


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #2355
Fixes #2415 
Fixes #2423
Fixes #2432
Fixes #2481

By default, `SE_ENABLE_TRACING` is `true` to align with CLI option config https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging
It is recommended that the user enable observability for tracing issues if having any. However, by default, it auto config the endpoint to a local OTLP `localhost/[0:0:0:0:0:0:0:1]:4317` and raises the warning if endpoint is unreachable.

```
ERROR (ThrottlingLogger.dolog) Failed to export spans.
  The request could not be executed. Error message: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4117
  java.net.ConnectException: Failed to connect to localhost/[0:0:0:0:0:0:0:1]:4317 
at okhttp3.internal.connection.RealConnection.connectSocket(RealConnection.kt:297)
at okhttp3.internal.connection. ExchangeFinder.findConnection (Exchangefinder.kt: 226)
at okhttp3.internal.connection.okhttps.internal.connection.RealConnection.connect(RealConnection.kt:207)
```
This warning might annoy users or cause messed up logs to identify another real issue.

Instead of repetitively asking the user to add env var `SE_ENABLE_TRACING=false`, updating the condition to enable this feature should be `SE_ENABLE_TRACING=true`, and users have to input a correct endpoint to env var `SE_OTEL_EXPORTER_ENDPOINT`. Otherwise, it is disabled.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Enhanced tracing configuration across all Selenium Grid components to prevent unnecessary warning messages
- Modified tracing condition to require both `SE_ENABLE_TRACING=true` and `SE_OTEL_EXPORTER_ENDPOINT` to be set
- Removed default `SE_ENABLE_TRACING=false` from all docker-compose files to simplify configuration
- Updated all component scripts (Hub, Node, Router, etc.) to use consistent tracing condition



___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>start-selenium-grid-distributor.sh</strong><dd><code>Update tracing condition in distributor script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Distributor/start-selenium-grid-distributor.sh

<li>Updated tracing condition to require both SE_ENABLE_TRACING=true and <br>SE_OTEL_EXPORTER_ENDPOINT to be set<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2541/files#diff-126c639972a47090b630e07da51b3eac94f6b12660e499c438ef0add24da2179">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>start-selenium-grid-hub.sh</strong><dd><code>Update tracing condition in hub script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Hub/start-selenium-grid-hub.sh

<li>Modified tracing condition to check for both SE_ENABLE_TRACING and <br>SE_OTEL_EXPORTER_ENDPOINT<br>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2541/files#diff-9aa93031edb177db1d5e76fd9aa6b72cb4e540c5e2d9803aceb82bdb62c17446">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3.yml</strong><dd><code>Remove tracing configuration from compose file</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

docker-compose-v3.yml

- Removed SE_ENABLE_TRACING environment variable from all services



</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2541/files#diff-65fac5522ca60b0205285214c198d5d6adf01d14900a3f81557fa658beef4758">+0/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information