### PR TITLE
Docker: Video uploader process is spawned by env var flag SE_VIDEO_UPLOAD_ENABLED

### DIFF
--- a/README.md
+++ b/README.md
@@ -692,9 +692,9 @@ services:
 `SE_VIDEO_FILE_NAME=auto` will use the session id as the video file name. This ensures that the video file name is unique to upload.
 Video file name construction automatically works based on Node endpoint `/status` (and optional GraphQL endpoint) to get session ID, capabilities.
 
-`SE_VIDEO_UPLOAD_ENABLED=true` will enable the video upload feature. In the background, it will create a pipefile with file and destination for uploader to consume and proceed.
+`SE_VIDEO_UPLOAD_ENABLED=true` (`false` by default) will enable the video upload feature. In the background, it will create a pipefile with file and destination for uploader to consume and proceed.
 
-`SE_VIDEO_INTERNAL_UPLOAD=true` will use RCLONE installed in the container for upload. If you want to use another sidecar container for upload, set it to `false`.
+`SE_VIDEO_INTERNAL_UPLOAD=true` (by default) will use RCLONE installed in the container for upload. If you want to use another sidecar container for upload, set it to `false`.
 
 | ENV variables per mode                   | Hub/Nodes         | Standalone roles | Dynamic Grid   |
 |------------------------------------------|-------------------|------------------|----------------|

--- a/Video/uploader.conf
+++ b/Video/uploader.conf
@@ -2,9 +2,9 @@
 priority=5
 command=/opt/bin/upload.sh
 killasgroup=true
-autostart=%(ENV_SE_VIDEO_INTERNAL_UPLOAD)s
+autostart=%(ENV_SE_VIDEO_UPLOAD_ENABLED)s
 startsecs=0
-autorestart=%(ENV_SE_VIDEO_INTERNAL_UPLOAD)s
+autorestart=%(ENV_SE_VIDEO_UPLOAD_ENABLED)s
 stopsignal=TERM
 stopwaitsecs=30
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
In Node container could see logs as below
```bash
Trapped SIGTERM/SIGINT/x so shutting down supervisord...
2025-01-06 19:57:50,220 WARN received SIGTERM indicating exit request
2025-01-06 19:57:50,221 INFO waiting for xvfb, video-upload, vnc, novnc, selenium-standalone to die
2025-01-06 19:57:51,655 WARN stopped: selenium-standalone (terminated by SIGTERM)
2025-01-06 19:57:53,662 WARN stopped: novnc (terminated by SIGTERM)
2025-01-06 19:57:53,663 INFO waiting for xvfb, video-upload, vnc to die
2025-01-06 19:57:54,667 WARN stopped: vnc (terminated by SIGTERM)
2025-01-06 19:57:54,828 [video.uploader] - Trapped SIGTERM/SIGINT/x so shutting down uploader
2025-01-06 19:57:54,833 [video.uploader] - Start consuming pipe file to upload
2025-01-06 19:57:54,834 [video.uploader] - Stopped consuming pipe file. Upload process is done
2025-01-06 19:57:54,835 [video.uploader] - Uploader consumed all files in the pipe
2025-01-06 19:57:54,836 [video.uploader] - Uploader is ready to shutdown
2025-01-06 19:57:54,837 [video.uploader] - Trapped SIGTERM/SIGINT/x so shutting down uploader
2025-01-06 19:57:54,839 [video.uploader] - Start consuming pipe file to upload
2025-01-06 19:57:54,840 [video.uploader] - Received exit signal. Aborting upload process
2025-01-06 19:57:54,841 [video.uploader] - Uploader consumed all files in the pipe
2025-01-06 19:57:54,843 [video.uploader] - Uploader is ready to shutdown
2025-01-06 19:57:54,843 INFO stopped: video-upload (exit status 0)
2025-01-06 19:57:55,846 WARN stopped: xvfb (terminated by SIGTERM)
Shutdown complete
```

It is due to process is spawned by env var flag `SE_VIDEO_INTERNAL_UPLOAD`, which is always `true`

However, video uploader should be listen on flag `SE_VIDEO_UPLOAD_ENABLED` (which is false by default). So, expect that the process of uploader should not be present in container logs.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Updated `SE_VIDEO_UPLOAD_ENABLED` to default to `false` in documentation.

- Clarified default behavior of `SE_VIDEO_INTERNAL_UPLOAD` in documentation.

- Changed `video-upload` process configuration to depend on `SE_VIDEO_UPLOAD_ENABLED`.

- Adjusted `video-upload` process restart behavior based on `SE_VIDEO_UPLOAD_ENABLED`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update documentation for video upload configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<li>Updated <code>SE_VIDEO_UPLOAD_ENABLED</code> to default to <code>false</code>.<br> <li> Clarified default value of <code>SE_VIDEO_INTERNAL_UPLOAD</code>.<br> <li> Improved documentation for video upload feature.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2565/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>uploader.conf</strong><dd><code>Update video-upload process configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Video/uploader.conf

<li>Changed <code>autostart</code> to depend on <code>SE_VIDEO_UPLOAD_ENABLED</code>.<br> <li> Changed <code>autorestart</code> to depend on <code>SE_VIDEO_UPLOAD_ENABLED</code>.<br> <li> Adjusted process behavior for video upload feature.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2565/files#diff-7b5c631d7136c001255585aec394b97d9f5a99a5aa26993cb1f5702414cde29a">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> 💡 **PR-Agent usage**: Comment `/help "your question"` on any pull request to receive relevant information