### PR TITLE
Enable passing securityContext to initContainers in the Helm chart

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -319,12 +319,18 @@ template:
       {{- with .node.resources }}
         resources: {{- toYaml . | nindent 10 }}
       {{- end }}
+      {{- with .node.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
+      {{- end }}
     {{- if .recorder.enabled }}
       - name: "pre-puller-{{ .recorder.name }}"
         image: {{ printf "%s/%s:%s" $videoImageRegistry .recorder.imageName $videoImageTag }}
         command: ["bash", "-c", "'true'"]
       {{- with .recorder.resources }}
         resources: {{- toYaml . | nindent 10 }}
+      {{- end }}
+      {{- with .recorder.securityContext }}
+        securityContext: {{- toYaml . | nindent 10 }}
       {{- end }}
     {{- end }}
     {{- with .node.initContainers }}


### PR DESCRIPTION
### **User description**
### Description
A simple change adding the missing `securityContext` fields to the `initContainers` so that they can be set for those along with the regular containers.

### Motivation and Context
When security policies are enforced in a cluster that the default configuration does not comply with the `pre-puller-*` pods will not be allowed to start, even though `securityContext` is set.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Added `securityContext` support for `initContainers` in Helm chart.

- Ensured compatibility with enforced cluster security policies.

- Updated `pre-puller-*` pods to include `securityContext`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Add `securityContext` to `initContainers` and containers</code>&nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Added <code>securityContext</code> field for <code>node</code> containers.<br> <li> Added <code>securityContext</code> field for <code>recorder</code> containers.<br> <li> Ensured <code>securityContext</code> is configurable for <code>initContainers</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2607/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any question about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>