### PR TITLE
[ci] Upload CHANGELOG for Node/Standalone chrome version with Grid 4.28.1

### DIFF
--- a/CHANGELOG/4.28.1/chrome_100.md
+++ b/CHANGELOG/4.28.1/chrome_100.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 100.0.4896.127
+Short Chrome version -> 100.0
+ChromeDriver version -> 100.0.4896.60
+Short ChromeDriver version -> 100.0
+Tagged selenium/node-chrome:100.0.4896.127-chromedriver-100.0.4896.60-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:100.0.4896.127-chromedriver-100.0.4896.60-grid-4.28.1-20250123
+Tagged selenium/node-chrome:100.0.4896.127-chromedriver-100.0.4896.60-20250123
+Tagged selenium/standalone-chrome:100.0.4896.127-chromedriver-100.0.4896.60-20250123
+Tagged selenium/node-chrome:100.0.4896.127-20250123
+Tagged selenium/standalone-chrome:100.0.4896.127-20250123
+Tagged selenium/node-chrome:100.0-chromedriver-100.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:100.0-chromedriver-100.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:100.0-chromedriver-100.0-20250123
+Tagged selenium/standalone-chrome:100.0-chromedriver-100.0-20250123
+Tagged selenium/node-chrome:100.0-20250123
+Tagged selenium/standalone-chrome:100.0-20250123

--- a/CHANGELOG/4.28.1/chrome_101.md
+++ b/CHANGELOG/4.28.1/chrome_101.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 101.0.4951.64
+Short Chrome version -> 101.0
+ChromeDriver version -> 101.0.4951.41
+Short ChromeDriver version -> 101.0
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.28.1-20250123
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250123
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250123
+Tagged selenium/node-chrome:101.0.4951.64-20250123
+Tagged selenium/standalone-chrome:101.0.4951.64-20250123
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-20250123
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-20250123
+Tagged selenium/node-chrome:101.0-20250123
+Tagged selenium/standalone-chrome:101.0-20250123

--- a/CHANGELOG/4.28.1/chrome_102.md
+++ b/CHANGELOG/4.28.1/chrome_102.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 102.0.5005.115
+Short Chrome version -> 102.0
+ChromeDriver version -> 102.0.5005.61
+Short ChromeDriver version -> 102.0
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.28.1-20250123
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250123
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250123
+Tagged selenium/node-chrome:102.0.5005.115-20250123
+Tagged selenium/standalone-chrome:102.0.5005.115-20250123
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-20250123
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-20250123
+Tagged selenium/node-chrome:102.0-20250123
+Tagged selenium/standalone-chrome:102.0-20250123

--- a/CHANGELOG/4.28.1/chrome_103.md
+++ b/CHANGELOG/4.28.1/chrome_103.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 103.0.5060.134
+Short Chrome version -> 103.0
+ChromeDriver version -> 103.0.5060.134
+Short ChromeDriver version -> 103.0
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.28.1-20250123
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250123
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250123
+Tagged selenium/node-chrome:103.0.5060.134-20250123
+Tagged selenium/standalone-chrome:103.0.5060.134-20250123
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-20250123
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-20250123
+Tagged selenium/node-chrome:103.0-20250123
+Tagged selenium/standalone-chrome:103.0-20250123

--- a/CHANGELOG/4.28.1/chrome_104.md
+++ b/CHANGELOG/4.28.1/chrome_104.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 104.0.5112.101
+Short Chrome version -> 104.0
+ChromeDriver version -> 104.0.5112.79
+Short ChromeDriver version -> 104.0
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.28.1-20250123
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250123
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250123
+Tagged selenium/node-chrome:104.0.5112.101-20250123
+Tagged selenium/standalone-chrome:104.0.5112.101-20250123
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-20250123
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-20250123
+Tagged selenium/node-chrome:104.0-20250123
+Tagged selenium/standalone-chrome:104.0-20250123

--- a/CHANGELOG/4.28.1/chrome_105.md
+++ b/CHANGELOG/4.28.1/chrome_105.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 105.0.5195.125
+Short Chrome version -> 105.0
+ChromeDriver version -> 105.0.5195.52
+Short ChromeDriver version -> 105.0
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.28.1-20250123
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250123
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250123
+Tagged selenium/node-chrome:105.0.5195.125-20250123
+Tagged selenium/standalone-chrome:105.0.5195.125-20250123
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-20250123
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-20250123
+Tagged selenium/node-chrome:105.0-20250123
+Tagged selenium/standalone-chrome:105.0-20250123

--- a/CHANGELOG/4.28.1/chrome_106.md
+++ b/CHANGELOG/4.28.1/chrome_106.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 106.0.5249.119
+Short Chrome version -> 106.0
+ChromeDriver version -> 106.0.5249.61
+Short ChromeDriver version -> 106.0
+Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.28.1-20250123
+Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250123
+Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250123
+Tagged selenium/node-chrome:106.0.5249.119-20250123
+Tagged selenium/standalone-chrome:106.0.5249.119-20250123
+Tagged selenium/node-chrome:106.0-chromedriver-106.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:106.0-chromedriver-106.0-20250123
+Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-20250123
+Tagged selenium/node-chrome:106.0-20250123
+Tagged selenium/standalone-chrome:106.0-20250123

--- a/CHANGELOG/4.28.1/chrome_107.md
+++ b/CHANGELOG/4.28.1/chrome_107.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 107.0.5304.121
+Short Chrome version -> 107.0
+ChromeDriver version -> 107.0.5304.62
+Short ChromeDriver version -> 107.0
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.28.1-20250123
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250123
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250123
+Tagged selenium/node-chrome:107.0.5304.121-20250123
+Tagged selenium/standalone-chrome:107.0.5304.121-20250123
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-20250123
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-20250123
+Tagged selenium/node-chrome:107.0-20250123
+Tagged selenium/standalone-chrome:107.0-20250123

--- a/CHANGELOG/4.28.1/chrome_108.md
+++ b/CHANGELOG/4.28.1/chrome_108.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 108.0.5359.124
+Short Chrome version -> 108.0
+ChromeDriver version -> 108.0.5359.71
+Short ChromeDriver version -> 108.0
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.28.1-20250123
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250123
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250123
+Tagged selenium/node-chrome:108.0.5359.124-20250123
+Tagged selenium/standalone-chrome:108.0.5359.124-20250123
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-20250123
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-20250123
+Tagged selenium/node-chrome:108.0-20250123
+Tagged selenium/standalone-chrome:108.0-20250123

--- a/CHANGELOG/4.28.1/chrome_109.md
+++ b/CHANGELOG/4.28.1/chrome_109.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 109.0.5414.119
+Short Chrome version -> 109.0
+ChromeDriver version -> 109.0.5414.74
+Short ChromeDriver version -> 109.0
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.28.1-20250123
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250123
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250123
+Tagged selenium/node-chrome:109.0.5414.119-20250123
+Tagged selenium/standalone-chrome:109.0.5414.119-20250123
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-20250123
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-20250123
+Tagged selenium/node-chrome:109.0-20250123
+Tagged selenium/standalone-chrome:109.0-20250123

--- a/CHANGELOG/4.28.1/chrome_97.md
+++ b/CHANGELOG/4.28.1/chrome_97.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 97.0.4692.99
+Short Chrome version -> 97.0
+ChromeDriver version -> 97.0.4692.71
+Short ChromeDriver version -> 97.0
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.28.1-20250123
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250123
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250123
+Tagged selenium/node-chrome:97.0.4692.99-20250123
+Tagged selenium/standalone-chrome:97.0.4692.99-20250123
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-20250123
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-20250123
+Tagged selenium/node-chrome:97.0-20250123
+Tagged selenium/standalone-chrome:97.0-20250123

--- a/CHANGELOG/4.28.1/chrome_98.md
+++ b/CHANGELOG/4.28.1/chrome_98.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 98.0.4758.102
+Short Chrome version -> 98.0
+ChromeDriver version -> 98.0.4758.102
+Short ChromeDriver version -> 98.0
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.28.1-20250123
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250123
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250123
+Tagged selenium/node-chrome:98.0.4758.102-20250123
+Tagged selenium/standalone-chrome:98.0.4758.102-20250123
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-20250123
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-20250123
+Tagged selenium/node-chrome:98.0-20250123
+Tagged selenium/standalone-chrome:98.0-20250123

--- a/CHANGELOG/4.28.1/chrome_99.md
+++ b/CHANGELOG/4.28.1/chrome_99.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 99.0.4844.84
+Short Chrome version -> 99.0
+ChromeDriver version -> 99.0.4844.51
+Short ChromeDriver version -> 99.0
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.28.1-20250123
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250123
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250123
+Tagged selenium/node-chrome:99.0.4844.84-20250123
+Tagged selenium/standalone-chrome:99.0.4844.84-20250123
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-20250123
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-20250123
+Tagged selenium/node-chrome:99.0-20250123
+Tagged selenium/standalone-chrome:99.0-20250123


### PR DESCRIPTION
This PR contains the CHANGELOG for Node/Standalone Chrome with specific browser versions: [97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109]