### PR TITLE
SE_NODE_STEREOTYPE_EXTRA to append custom capabilities to default Node stereotype

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -53,7 +53,7 @@
 | SE_HTTPS_PRIVATE_KEY | /opt/selenium/secrets/tls.key |  |  |
 | SE_ENABLE_TRACING | true |  |  |
 | SE_OTEL_EXPORTER_ENDPOINT |  |  |  |
-| SE_OTEL_SERVICE_NAME | selenium-standalone-docker |  |  |
+| SE_OTEL_SERVICE_NAME | selenium-router |  |  |
 | SE_OTEL_JVM_ARGS |  |  |  |
 | SE_OTEL_TRACES_EXPORTER | otlp |  |  |
 | SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED | true |  |  |
@@ -121,3 +121,24 @@
 | SE_SUPERVISORD_START_RETRIES | 5 |  |  |
 | SE_RECORD_AUDIO | false | Flag to enable recording the audio source (default is Pulse Audio input) |  |
 | SE_AUDIO_SOURCE | -f pulse -ac 2 -i default | FFmpeg arguments to record the audio source |  |
+| SE_BROWSER_BINARY_LOCATION |  |  |  |
+| SE_NODE_BROWSER_NAME |  |  |  |
+| SE_NODE_CONTAINER_NAME |  |  |  |
+| SE_NODE_HOST |  |  |  |
+| SE_NODE_MAX_CONCURRENCY |  | When node is handled both browser and relay, SE_NODE_MAX_CONCURRENCY is used to configure max concurrency based on sum of them |  |
+| SE_NODE_RELAY_BROWSER_NAME |  |  |  |
+| SE_NODE_RELAY_MAX_SESSIONS |  |  |  |
+| SE_NODE_RELAY_PLATFORM_NAME |  |  |  |
+| SE_NODE_RELAY_PLATFORM_VERSION |  |  |  |
+| SE_NODE_RELAY_PROTOCOL_VERSION |  |  |  |
+| SE_NODE_RELAY_STATUS_ENDPOINT |  |  |  |
+| SE_NODE_RELAY_URL |  |  |  |
+| SE_NODE_STEREOTYPE |  | Capabilities in JSON string to overwrite the default Node stereotype |  |
+| SE_NODE_STEREOTYPE_EXTRA |  | Extra capabilities in JSON string that wants to merge to the default Node stereotype |  |
+| SE_SESSIONS_MAP_EXTERNAL_HOSTNAME |  |  |  |
+| SE_SESSIONS_MAP_EXTERNAL_IMPLEMENTATION |  |  |  |
+| SE_SESSIONS_MAP_EXTERNAL_JDBC_PASSWORD |  |  |  |
+| SE_SESSIONS_MAP_EXTERNAL_JDBC_URL |  |  |  |
+| SE_SESSIONS_MAP_EXTERNAL_JDBC_USER |  |  |  |
+| SE_SESSIONS_MAP_EXTERNAL_PORT |  |  |  |
+| SE_SESSIONS_MAP_EXTERNAL_SCHEME |  |  |  |

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -152,7 +152,8 @@ COPY --chown="${SEL_UID}:${SEL_GID}" start-selenium-node.sh \
       start-xvfb.sh \
       start-vnc.sh \
       start-novnc.sh \
-      generate_config generate_relay_config /opt/bin/
+      generate_config generate_relay_config json_merge.py /opt/bin/
+RUN chmod +x /opt/bin/*.sh /opt/bin/*.py /opt/bin/generate_*
 
 # Selenium Grid logo as wallpaper for Fluxbox
 COPY selenium_grid_logo.png /usr/share/images/fluxbox/ubuntu-light.png

--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -61,12 +61,22 @@ fi
 if [ -f /opt/selenium/browser_binary_location ] && [ -z "${SE_BROWSER_BINARY_LOCATION}" ]; then
 	SE_BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
 fi
+SE_NODE_CONTAINER_NAME="${SE_NODE_CONTAINER_NAME:-$(hostname)}"
 
 # 'browserName' is mandatory for default stereotype
 if [[ -z "${SE_NODE_STEREOTYPE}" ]] && [[ -n "${SE_NODE_BROWSER_NAME}" ]]; then
-	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"${SE_NODE_PLATFORM_NAME}\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
+	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"${SE_NODE_PLATFORM_NAME}\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\", \"container:hostname\": \"$(hostname)\"}"
 else
 	SE_NODE_STEREOTYPE="${SE_NODE_STEREOTYPE}"
+fi
+if [[ -n "${SE_NODE_STEREOTYPE_EXTRA}" ]]; then
+	echo "Merging SE_NODE_STEREOTYPE_EXTRA=${SE_NODE_STEREOTYPE_EXTRA} to main stereotype"
+	SE_NODE_STEREOTYPE="$(python3 /opt/bin/json_merge.py "${SE_NODE_STEREOTYPE}" "${SE_NODE_STEREOTYPE_EXTRA}")"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to merge SE_NODE_STEREOTYPE_EXTRA. Please check the format of the JSON string. Keep using main stereotype."
+	else
+		echo "Merged stereotype: ${SE_NODE_STEREOTYPE}"
+	fi
 fi
 
 # 'stereotype' setting is mandatory

--- a/NodeBase/json_merge.py
+++ b/NodeBase/json_merge.py
@@ -1,0 +1,20 @@
+import json
+import sys
+
+json_str1 = sys.argv[1]
+json_str2 = sys.argv[2]
+
+try:
+  # Parse JSON strings into dictionaries
+  dict1 = json.loads(json_str1)
+  dict2 = json.loads(json_str2)
+  # Merge dictionaries
+  merged_dict = {**dict1, **dict2}
+  # Convert merged dictionary back to JSON string
+  merged_json_str = json.dumps(merged_dict, separators=(',', ':'), ensure_ascii=True)
+  # Print the merged JSON string
+  print(merged_json_str)
+except:
+  # Print the first JSON string if an error occurs
+  print(json_str1)
+  sys.exit(1)

--- a/Standalone/generate_config
+++ b/Standalone/generate_config
@@ -41,11 +41,21 @@ fi
 if [ -f /opt/selenium/browser_binary_location ] && [ -z "${SE_BROWSER_BINARY_LOCATION}" ]; then
 	SE_BROWSER_BINARY_LOCATION=$(cat /opt/selenium/browser_binary_location)
 fi
+SE_NODE_CONTAINER_NAME="${SE_NODE_CONTAINER_NAME:-$(hostname)}"
 
 if [[ -z "$SE_NODE_STEREOTYPE" ]]; then
-	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"${SE_NODE_PLATFORM_NAME}\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\"}"
+	SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"${SE_NODE_PLATFORM_NAME}\", ${SE_BROWSER_BINARY_LOCATION}, \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\", \"container:hostname\": \"$(hostname)\"}"
 else
 	SE_NODE_STEREOTYPE="$SE_NODE_STEREOTYPE"
+fi
+if [[ -n "${SE_NODE_STEREOTYPE_EXTRA}" ]]; then
+	echo "Merging SE_NODE_STEREOTYPE_EXTRA=${SE_NODE_STEREOTYPE_EXTRA} to main stereotype"
+	SE_NODE_STEREOTYPE="$(python3 /opt/bin/json_merge.py "${SE_NODE_STEREOTYPE}" "${SE_NODE_STEREOTYPE_EXTRA}")"
+	if [[ $? -ne 0 ]]; then
+		echo "Failed to merge SE_NODE_STEREOTYPE_EXTRA. Please check the format of the JSON string. Keep using main stereotype."
+	else
+		echo "Merged stereotype: ${SE_NODE_STEREOTYPE}"
+	fi
 fi
 
 echo "[[node.driver-configuration]]" >>"$FILENAME"

--- a/scripts/generate_list_env_vars/description.yaml
+++ b/scripts/generate_list_env_vars/description.yaml
@@ -366,3 +366,68 @@
 - name: SE_AUDIO_SOURCE
   description: FFmpeg arguments to record the audio source
   cli: ''
+- name: SE_BROWSER_BINARY_LOCATION
+  description: ''
+  cli: ''
+- name: SE_NODE_BROWSER_NAME
+  description: ''
+  cli: ''
+- name: SE_NODE_CONTAINER_NAME
+  description: ''
+  cli: ''
+- name: SE_NODE_HOST
+  description: ''
+  cli: ''
+- name: SE_NODE_MAX_CONCURRENCY
+  description: When node is handled both browser and relay, SE_NODE_MAX_CONCURRENCY
+    is used to configure max concurrency based on sum of them
+  cli: ''
+- name: SE_NODE_RELAY_BROWSER_NAME
+  description: ''
+  cli: ''
+- name: SE_NODE_RELAY_MAX_SESSIONS
+  description: ''
+  cli: ''
+- name: SE_NODE_RELAY_PLATFORM_NAME
+  description: ''
+  cli: ''
+- name: SE_NODE_RELAY_PLATFORM_VERSION
+  description: ''
+  cli: ''
+- name: SE_NODE_RELAY_PROTOCOL_VERSION
+  description: ''
+  cli: ''
+- name: SE_NODE_RELAY_STATUS_ENDPOINT
+  description: ''
+  cli: ''
+- name: SE_NODE_RELAY_URL
+  description: ''
+  cli: ''
+- name: SE_NODE_STEREOTYPE
+  description: Capabilities in JSON string to overwrite the default Node stereotype
+  cli: ''
+- name: SE_NODE_STEREOTYPE_EXTRA
+  description: Extra capabilities in JSON string that wants to merge to the default
+    Node stereotype
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_HOSTNAME
+  description: ''
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_IMPLEMENTATION
+  description: ''
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_JDBC_PASSWORD
+  description: ''
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_JDBC_URL
+  description: ''
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_JDBC_USER
+  description: ''
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_PORT
+  description: ''
+  cli: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_SCHEME
+  description: ''
+  cli: ''

--- a/scripts/generate_list_env_vars/extract_env.py
+++ b/scripts/generate_list_env_vars/extract_env.py
@@ -8,7 +8,7 @@ def extract_variables_from_shell_scripts(directory_path):
     for root, _, files in os.walk(directory_path):
         files.sort()
         for file in files:
-            if file.endswith(".sh"):
+            if file.endswith(".sh") or file.startswith("generate_"):
                 file_path = os.path.join(root, file)
                 try:
                     with open(file_path, 'r') as f:

--- a/scripts/generate_list_env_vars/value.yaml
+++ b/scripts/generate_list_env_vars/value.yaml
@@ -2,6 +2,8 @@
   default: -f pulse -ac 2 -i default
 - name: SE_BIND_HOST
   default: 'false'
+- name: SE_BROWSER_BINARY_LOCATION
+  default: ''
 - name: SE_BROWSER_LEFTOVERS_INTERVAL_SECS
   default: '3600'
 - name: SE_BROWSER_LEFTOVERS_PROCESSES_SECS
@@ -72,8 +74,12 @@
   default: '%Y-%m-%d %H:%M:%S,%3N'
 - name: SE_NEW_SESSION_THREAD_POOL_SIZE
   default: ''
+- name: SE_NODE_BROWSER_NAME
+  default: ''
 - name: SE_NODE_BROWSER_VERSION
   default: stable
+- name: SE_NODE_CONTAINER_NAME
+  default: ''
 - name: SE_NODE_DOCKER_CONFIG_FILENAME
   default: ''
 - name: SE_NODE_ENABLE_CDP
@@ -88,6 +94,10 @@
   default: ''
 - name: SE_NODE_HEARTBEAT_PERIOD
   default: '30'
+- name: SE_NODE_HOST
+  default: ''
+- name: SE_NODE_MAX_CONCURRENCY
+  default: ''
 - name: SE_NODE_MAX_SESSIONS
   default: '1'
 - name: SE_NODE_OVERRIDE_MAX_SESSIONS
@@ -102,8 +112,26 @@
   default: ''
 - name: SE_NODE_REGISTER_PERIOD
   default: ''
+- name: SE_NODE_RELAY_BROWSER_NAME
+  default: ''
+- name: SE_NODE_RELAY_MAX_SESSIONS
+  default: ''
+- name: SE_NODE_RELAY_PLATFORM_NAME
+  default: ''
+- name: SE_NODE_RELAY_PLATFORM_VERSION
+  default: ''
+- name: SE_NODE_RELAY_PROTOCOL_VERSION
+  default: ''
+- name: SE_NODE_RELAY_STATUS_ENDPOINT
+  default: ''
+- name: SE_NODE_RELAY_URL
+  default: ''
 - name: SE_NODE_SESSION_TIMEOUT
   default: '300'
+- name: SE_NODE_STEREOTYPE
+  default: ''
+- name: SE_NODE_STEREOTYPE_EXTRA
+  default: ''
 - name: SE_NO_VNC_PORT
   default: '7900'
 - name: SE_OFFLINE
@@ -117,7 +145,7 @@
 - name: SE_OTEL_JVM_ARGS
   default: ''
 - name: SE_OTEL_SERVICE_NAME
-  default: selenium-standalone-docker
+  default: selenium-router
 - name: SE_OTEL_TRACES_EXPORTER
   default: otlp
 - name: SE_PRESET
@@ -158,6 +186,20 @@
   default: ''
 - name: SE_SESSIONS_MAP_EXTERNAL_DATASTORE
   default: 'false'
+- name: SE_SESSIONS_MAP_EXTERNAL_HOSTNAME
+  default: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_IMPLEMENTATION
+  default: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_JDBC_PASSWORD
+  default: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_JDBC_URL
+  default: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_JDBC_USER
+  default: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_PORT
+  default: ''
+- name: SE_SESSIONS_MAP_EXTERNAL_SCHEME
+  default: ''
 - name: SE_SESSIONS_MAP_HOST
   default: ''
 - name: SE_SESSIONS_MAP_PORT

--- a/tests/docker-compose-v3-test-parallel.yml
+++ b/tests/docker-compose-v3-test-parallel.yml
@@ -38,6 +38,7 @@ services:
       - SE_VIDEO_FILE_NAME=auto
       - SE_SERVER_PROTOCOL=https
       - SE_NODE_GRID_URL=https://selenium-hub:4444
+      - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}
     restart: always
 
   firefox:
@@ -73,6 +74,7 @@ services:
       - SE_VIDEO_FILE_NAME=auto
       - SE_SERVER_PROTOCOL=https
       - SE_NODE_GRID_URL=https://selenium-hub:4444
+      - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}
     restart: always
 
   edge:
@@ -106,6 +108,7 @@ services:
       - SE_VIDEO_FILE_NAME=auto
       - SE_SERVER_PROTOCOL=https
       - SE_NODE_GRID_URL=https://selenium-hub:4444
+      - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}
     restart: always
 
   selenium-hub:

--- a/tests/docker-compose-v3-test-standalone.yml
+++ b/tests/docker-compose-v3-test-standalone.yml
@@ -20,6 +20,7 @@ services:
       - SE_ROUTER_USERNAME=${BASIC_AUTH_USERNAME}
       - SE_ROUTER_PASSWORD=${BASIC_AUTH_PASSWORD}
       - SE_SUB_PATH=${SUB_PATH}
+      - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}
     ports:
       - "4444:4444"
     healthcheck:


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/2506

In another case, if you want to retain the default Node stereotype and append additional capabilities, you can use the `SE_NODE_STEREOTYPE_EXTRA` environment variable to set your capabilities. Those will be merged to the default stereotype. For example:
```bash
$ docker run -d \
  -e SE_EVENT_BUS_HOST=<event_bus_ip|event_bus_name> \
  -e SE_EVENT_BUS_PUBLISH_PORT=4442 \
  -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
  -e SE_NODE_STEREOTYPE_EXTRA="{\"myApp:version\":\"beta\", \"myApp:publish:\":\"public\"}" \
  --shm-size="2g" selenium/node-chrome:4.28.1-20250123
```
This help setting custom capabilities for matching specific Nodes. For example, you added your custom capabilities when starting the Node, and you want assign a test to run on that Node which matches your capabilities. For example in test code:
```python
options = ChromeOptions()
options.set_capability('myApp:version', 'beta')
options.set_capability('myApp:publish', 'public')
driver = webdriver.Remote(options=options, command_executor=SELENIUM_GRID_URL)
```
Noted: Your custom capabilities with key values should be in W3C capabilities convention, extension capabilities key must contain a ":" (colon) character, denoting an implementation specific namespace.
Noted: Ensure that Node config `detect-drivers = false` in `config.toml` (or `--detect-drivers false` in CLI option) to make feature setting custom capabilities for matching specific Nodes get working.
In addition, default Node stereotype includes capability `se:containerName` which can visible in node capabilities, or session capabilities to identify the container name where the node/session is running. **The prefixed `se:containerName` is not included in slot matcher**. By default, value is getting from `hostname` command in container, this value is equivalent to the `container_id` that you saw via `docker ps` command. If you want to override this value, you can set the environment variable `SE_NODE_CONTAINER_NAME` to your desired value. For example, when deploy to Kubernetes cluster, you can assign Pod name to env var `SE_NODE_CONTAINER_NAME` to track a node is running in which Pod.
```yaml
  env:
    - name: SE_NODE_CONTAINER_NAME
      valueFrom:
        fieldRef:
          fieldPath: metadata.name
```
In an advanced case, where you control to spawn up a Node container, let it register to Hub, and then trigger a test to be assigned exactly to run on that Node. By default, the value of command `$(hostname)` is added to capability name `container:hostname` in Node stereotype. Combine with above feature setting custom capabilities for matching specific Nodes. You can use the `hostname` of the Node container just spawned up and set it as a custom capability. For example, in Python binding:
```bash
$ docker run -d --name my-node-1 -e SE_EVENT_BUS_HOST=localhost -e SE_EVENT_BUS_PUBLISH_PORT=4442 -e SE_EVENT_BUS_SUBSCRIBE_PORT=4443 \
  --shm-size="2g" selenium/node-chrome:4.28.1-20250123
$ docker exec -i my-node-1 hostname
a6971f95bbab
```
```python
options = ChromeOptions()
options.set_capability('container:hostname', 'a6971f95bbab')
driver = webdriver.Remote(options=options, command_executor=SELENIUM_GRID_URL)
```
_Noted: Those above changes require new image tag where the changeset is included & released._

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced `SE_NODE_STEREOTYPE_EXTRA` to append custom capabilities to default Node stereotype.

- Added a Python script (`json_merge.py`) for merging JSON strings.

- Updated Dockerfile and configuration scripts to integrate `SE_NODE_STEREOTYPE_EXTRA`.

- Enhanced documentation with examples and explanations for new environment variables.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>5 files</summary><table>
<tr>
  <td><strong>json_merge.py</strong><dd><code>Added Python script for merging JSON strings</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-ab725ce9616642c2f3c10d6b99f90465543d25e1eb839ebe7b2260f14520258c">+20/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>extract_env.py</strong><dd><code>Updated script to include additional file types</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-f98cae44c14fa33cd6292f4d3cbba1c173c6b02488e29fddfe39ed33385c21fc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>Dockerfile</strong><dd><code>Integrated `json_merge.py` into Docker image</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-16a06916a1ac13cfa86d64f9a62439648853b0e48f98b68ac36305f31de7f2c4">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate_config</strong><dd><code>Added logic to merge `SE_NODE_STEREOTYPE_EXTRA` into Node stereotype</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+11/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>generate_config</strong><dd><code>Integrated <code>SE_NODE_STEREOTYPE_EXTRA</code> into standalone Node configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-dbfea8e89862249087918cf19250edbbe7f6ec4666fdaee5958bcf58cdd89557">+11/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>ENV_VARIABLES.md</strong><dd><code>Documented new environment variables for Node configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-575787a64e27e14d8c3ef34ad655dde25f38457d2c82335a3cb9f2dd44024035">+22/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>README.md</strong><dd><code>Added usage examples for <code>SE_NODE_STEREOTYPE_EXTRA</code> and related features</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+50/-1</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>description.yaml</strong><dd><code>Added descriptions for new environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-b3cb49ac37600014419abf1369cf4b5a461d55671b0c6b815b18d7d5030c2352">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>value.yaml</strong><dd><code>Added default values for new environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2624/files#diff-40c21ad1afd76f2f3afbc05f7c916aebf35417a74feabeaec3d84600944e9e9e">+43/-1</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>