### PR TITLE
feat: Deploy Node/Standalone Chrome browser version from v97 to v109 on top of Grid 4.28.1

### DIFF
--- a/.github/workflows/release-chrome-versions.yml
+++ b/.github/workflows/release-chrome-versions.yml
@@ -22,18 +22,23 @@ on:
         description: 'Build date in format YYYYMMDD. Must provide if reusing base image'
         required: false
         type: string
-        default: ''
+        default: '20250123'
       browser-name:
         description: 'Browser name to build. E.g: chrome'
         required: true
         type: string
         default: 'chrome'
-      browser-version:
-        description: 'Browser version to build. E.g: 120'
+      browser-versions:
+        description: 'List browser version to build. E.g: [130, 131]'
         required: true
-        type: string
+        default: '[97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132]'
       push-image:
         description: 'Push image after testing successfully'
+        required: true
+        type: boolean
+        default: false
+      pr-changelog:
+        description: 'Create a PR for CHANGELOG'
         required: true
         type: boolean
         default: true
@@ -41,18 +46,25 @@ on:
 env:
   GRID_VERSION: ${{ github.event.inputs.grid-version }}
   BROWSER_NAME: ${{ github.event.inputs.browser-name }}
-  BROWSER_VERSION: ${{ github.event.inputs.browser-version }}
   REUSE_BASE: ${{ github.event.inputs.reuse-base || true }}
   BUILD_DATE: ${{ github.event.inputs.build-date || '' }}
   NAMESPACE: ${{ vars.DOCKER_NAMESPACE || 'selenium' }}
   AUTHORS: ${{ vars.AUTHORS || 'SeleniumHQ' }}
   PUSH_IMAGE: ${{ github.event.inputs.push-image || false }}
+  PR_CHANGELOG: ${{ github.event.inputs.pr-changelog || true }}
+  RUN_ID: ${{ github.run_id }}
 
 jobs:
   deploy:
-    name: Deploy Node/Standalone Chrome with specific browser version
+    name: Deploy Node/Standalone Chrome
     runs-on: ubuntu-24.04
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        browser-version: ${{ fromJSON(github.event.inputs.browser-versions)}}
+    outputs:
+      GRID_VERSION: ${{ steps.display_grid_version.outputs.GRID_VERSION }}
     steps:
       - name: Checkout code
         uses: actions/checkout@main
@@ -81,21 +93,32 @@ jobs:
             echo "BUILD_DATE=${BUILD_DATE}" >> $GITHUB_ENV
           fi
           echo "NAME=${NAMESPACE}" >> $GITHUB_ENV
+          echo "BROWSER_VERSION=${BROWSER_VERSION}" >> $GITHUB_ENV
+        env:
+          BROWSER_VERSION: ${{ matrix.browser-version }}
       - name: Get Grid version
         if: env.GRID_VERSION == ''
         run: |
           echo ${BASE_VERSION}
           echo "GRID_VERSION=${BASE_VERSION}" >> $GITHUB_ENV
       - name: Display Grid version
-        run: echo ${GRID_VERSION}
+        id: display_grid_version
+        run: |
+          echo ${GRID_VERSION}
+          echo "GRID_VERSION=${GRID_VERSION}" >> "$GITHUB_OUTPUT"
       - name: Login Docker Hub
         run: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
         env:
           DOCKER_USERNAME: ${{secrets.DOCKER_USERNAME}}
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       - name: Build images with Grid core ${{ env.GRID_VERSION }} and ${{ env.BROWSER_NAME }} v${{ env.BROWSER_VERSION }}
-        run: |
-          ./tests/build-backward-compatible/bootstrap.sh ${GRID_VERSION} ${BROWSER_VERSION} ${BROWSER_NAME} ${REUSE_BASE}
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 20
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: |
+            ./tests/build-backward-compatible/bootstrap.sh ${GRID_VERSION} ${BROWSER_VERSION} ${BROWSER_NAME} ${REUSE_BASE}
       - name: Build Hub image for testing
         if: env.REUSE_BASE == 'false'
         run: make hub
@@ -114,3 +137,48 @@ jobs:
           name: image_tags_${{ env.GRID_VERSION }}_${{ env.BROWSER_NAME }}_${{ env.BROWSER_VERSION }}
           path: ./CHANGELOG/${{ env.GRID_VERSION }}/${{ env.BROWSER_NAME }}_${{ env.BROWSER_VERSION }}.md
           if-no-files-found: ignore
+
+  pr-results:
+    name: Create a PR with changelog
+    if: (!failure() && !cancelled() && (github.event.inputs.pr-changelog == 'true'))
+    runs-on: ubuntu-24.04
+    needs: deploy
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+          fetch-depth: 0
+      - name: Get Grid version
+        run: |
+          echo "GRID_VERSION=${GRID_VERSION}" >> $GITHUB_ENV
+        env:
+          GRID_VERSION: ${{ needs.deploy.outputs.GRID_VERSION }}
+      - name: Download results
+        uses: actions/download-artifact@v4
+        with:
+          path: ./CHANGELOG/${{ env.GRID_VERSION }}
+          pattern: 'image_tags_*'
+          merge-multiple: 'true'
+          run-id: ${{ env.RUN_ID }}
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+      - name: Commit configs
+        run: |
+          git config --local user.email "selenium-ci@users.noreply.github.com"
+          git config --local user.name "Selenium CI Bot"
+      - name: Create Pull Request
+        id: cpr
+        uses: peter-evans/create-pull-request@main
+        with:
+          token: ${{ secrets.SELENIUM_CI_TOKEN }}
+          commit-message: "[ci] Upload CHANGELOG for Node/Standalone ${{ env.BROWSER_NAME }} version with Grid ${{ env.GRID_VERSION }}"
+          title: "[ci] Upload CHANGELOG for Node/Standalone ${{ env.BROWSER_NAME }} version with Grid ${{ env.GRID_VERSION }}"
+          body: "This PR contains the CHANGELOG for Node/Standalone Chrome with specific browser versions: ${{ github.event.inputs.browser-versions }}"
+          committer: 'Selenium CI Bot <selenium-ci@users.noreply.github.com>'
+          author: 'Selenium CI Bot <selenium-ci@users.noreply.github.com>'
+          branch: browser-node-changelog
+      - name: Check outputs
+        if: ${{ steps.cpr.outputs.pull-request-number }}
+        run: |
+          echo "Pull Request Number - ${{ steps.cpr.outputs.pull-request-number }}"
+          echo "Pull Request URL - ${{ steps.cpr.outputs.pull-request-url }}"

--- a/.github/workflows/release-chrome-versions.yml
+++ b/.github/workflows/release-chrome-versions.yml
@@ -56,7 +56,7 @@ env:
 
 jobs:
   deploy:
-    name: Deploy Node/Standalone Chrome
+    name: Node/Standalone Chrome
     runs-on: ubuntu-24.04
     permissions: write-all
     strategy:

--- a/CHANGELOG/4.28.1/chrome_100.md
+++ b/CHANGELOG/4.28.1/chrome_100.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 100.0.4896.127
+Short Chrome version -> 100.0
+ChromeDriver version -> 100.0.4896.60
+Short ChromeDriver version -> 100.0
+Tagged selenium/node-chrome:100.0.4896.127-chromedriver-100.0.4896.60-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:100.0.4896.127-chromedriver-100.0.4896.60-grid-4.28.1-20250123
+Tagged selenium/node-chrome:100.0.4896.127-chromedriver-100.0.4896.60-20250123
+Tagged selenium/standalone-chrome:100.0.4896.127-chromedriver-100.0.4896.60-20250123
+Tagged selenium/node-chrome:100.0.4896.127-20250123
+Tagged selenium/standalone-chrome:100.0.4896.127-20250123
+Tagged selenium/node-chrome:100.0-chromedriver-100.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:100.0-chromedriver-100.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:100.0-chromedriver-100.0-20250123
+Tagged selenium/standalone-chrome:100.0-chromedriver-100.0-20250123
+Tagged selenium/node-chrome:100.0-20250123
+Tagged selenium/standalone-chrome:100.0-20250123

--- a/CHANGELOG/4.28.1/chrome_101.md
+++ b/CHANGELOG/4.28.1/chrome_101.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 101.0.4951.64
+Short Chrome version -> 101.0
+ChromeDriver version -> 101.0.4951.41
+Short ChromeDriver version -> 101.0
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.28.1-20250123
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250123
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250123
+Tagged selenium/node-chrome:101.0.4951.64-20250123
+Tagged selenium/standalone-chrome:101.0.4951.64-20250123
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-20250123
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-20250123
+Tagged selenium/node-chrome:101.0-20250123
+Tagged selenium/standalone-chrome:101.0-20250123

--- a/CHANGELOG/4.28.1/chrome_102.md
+++ b/CHANGELOG/4.28.1/chrome_102.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 102.0.5005.115
+Short Chrome version -> 102.0
+ChromeDriver version -> 102.0.5005.61
+Short ChromeDriver version -> 102.0
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.28.1-20250123
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250123
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250123
+Tagged selenium/node-chrome:102.0.5005.115-20250123
+Tagged selenium/standalone-chrome:102.0.5005.115-20250123
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-20250123
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-20250123
+Tagged selenium/node-chrome:102.0-20250123
+Tagged selenium/standalone-chrome:102.0-20250123

--- a/CHANGELOG/4.28.1/chrome_103.md
+++ b/CHANGELOG/4.28.1/chrome_103.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 103.0.5060.134
+Short Chrome version -> 103.0
+ChromeDriver version -> 103.0.5060.134
+Short ChromeDriver version -> 103.0
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.28.1-20250123
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250123
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250123
+Tagged selenium/node-chrome:103.0.5060.134-20250123
+Tagged selenium/standalone-chrome:103.0.5060.134-20250123
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-20250123
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-20250123
+Tagged selenium/node-chrome:103.0-20250123
+Tagged selenium/standalone-chrome:103.0-20250123

--- a/CHANGELOG/4.28.1/chrome_104.md
+++ b/CHANGELOG/4.28.1/chrome_104.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 104.0.5112.101
+Short Chrome version -> 104.0
+ChromeDriver version -> 104.0.5112.79
+Short ChromeDriver version -> 104.0
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.28.1-20250123
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250123
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250123
+Tagged selenium/node-chrome:104.0.5112.101-20250123
+Tagged selenium/standalone-chrome:104.0.5112.101-20250123
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-20250123
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-20250123
+Tagged selenium/node-chrome:104.0-20250123
+Tagged selenium/standalone-chrome:104.0-20250123

--- a/CHANGELOG/4.28.1/chrome_105.md
+++ b/CHANGELOG/4.28.1/chrome_105.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 105.0.5195.125
+Short Chrome version -> 105.0
+ChromeDriver version -> 105.0.5195.52
+Short ChromeDriver version -> 105.0
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.28.1-20250123
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250123
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250123
+Tagged selenium/node-chrome:105.0.5195.125-20250123
+Tagged selenium/standalone-chrome:105.0.5195.125-20250123
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-20250123
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-20250123
+Tagged selenium/node-chrome:105.0-20250123
+Tagged selenium/standalone-chrome:105.0-20250123

--- a/CHANGELOG/4.28.1/chrome_106.md
+++ b/CHANGELOG/4.28.1/chrome_106.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 106.0.5249.119
+Short Chrome version -> 106.0
+ChromeDriver version -> 106.0.5249.61
+Short ChromeDriver version -> 106.0
+Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.28.1-20250123
+Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250123
+Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250123
+Tagged selenium/node-chrome:106.0.5249.119-20250123
+Tagged selenium/standalone-chrome:106.0.5249.119-20250123
+Tagged selenium/node-chrome:106.0-chromedriver-106.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:106.0-chromedriver-106.0-20250123
+Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-20250123
+Tagged selenium/node-chrome:106.0-20250123
+Tagged selenium/standalone-chrome:106.0-20250123

--- a/CHANGELOG/4.28.1/chrome_107.md
+++ b/CHANGELOG/4.28.1/chrome_107.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 107.0.5304.121
+Short Chrome version -> 107.0
+ChromeDriver version -> 107.0.5304.62
+Short ChromeDriver version -> 107.0
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.28.1-20250123
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250123
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250123
+Tagged selenium/node-chrome:107.0.5304.121-20250123
+Tagged selenium/standalone-chrome:107.0.5304.121-20250123
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-20250123
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-20250123
+Tagged selenium/node-chrome:107.0-20250123
+Tagged selenium/standalone-chrome:107.0-20250123

--- a/CHANGELOG/4.28.1/chrome_108.md
+++ b/CHANGELOG/4.28.1/chrome_108.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 108.0.5359.124
+Short Chrome version -> 108.0
+ChromeDriver version -> 108.0.5359.71
+Short ChromeDriver version -> 108.0
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.28.1-20250123
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250123
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250123
+Tagged selenium/node-chrome:108.0.5359.124-20250123
+Tagged selenium/standalone-chrome:108.0.5359.124-20250123
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-20250123
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-20250123
+Tagged selenium/node-chrome:108.0-20250123
+Tagged selenium/standalone-chrome:108.0-20250123

--- a/CHANGELOG/4.28.1/chrome_109.md
+++ b/CHANGELOG/4.28.1/chrome_109.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 109.0.5414.119
+Short Chrome version -> 109.0
+ChromeDriver version -> 109.0.5414.74
+Short ChromeDriver version -> 109.0
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.28.1-20250123
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250123
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250123
+Tagged selenium/node-chrome:109.0.5414.119-20250123
+Tagged selenium/standalone-chrome:109.0.5414.119-20250123
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-20250123
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-20250123
+Tagged selenium/node-chrome:109.0-20250123
+Tagged selenium/standalone-chrome:109.0-20250123

--- a/CHANGELOG/4.28.1/chrome_97.md
+++ b/CHANGELOG/4.28.1/chrome_97.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 97.0.4692.99
+Short Chrome version -> 97.0
+ChromeDriver version -> 97.0.4692.71
+Short ChromeDriver version -> 97.0
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.28.1-20250123
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250123
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250123
+Tagged selenium/node-chrome:97.0.4692.99-20250123
+Tagged selenium/standalone-chrome:97.0.4692.99-20250123
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-20250123
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-20250123
+Tagged selenium/node-chrome:97.0-20250123
+Tagged selenium/standalone-chrome:97.0-20250123

--- a/CHANGELOG/4.28.1/chrome_98.md
+++ b/CHANGELOG/4.28.1/chrome_98.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 98.0.4758.102
+Short Chrome version -> 98.0
+ChromeDriver version -> 98.0.4758.102
+Short ChromeDriver version -> 98.0
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.28.1-20250123
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250123
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250123
+Tagged selenium/node-chrome:98.0.4758.102-20250123
+Tagged selenium/standalone-chrome:98.0.4758.102-20250123
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-20250123
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-20250123
+Tagged selenium/node-chrome:98.0-20250123
+Tagged selenium/standalone-chrome:98.0-20250123

--- a/CHANGELOG/4.28.1/chrome_99.md
+++ b/CHANGELOG/4.28.1/chrome_99.md
@@ -1,0 +1,19 @@
+./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false chrome true
+Tagging images for browser chrome, version 4.28.1, build date 20250123, namespace selenium
+Selenium Grid version -> 4.28.1-20250123
+Chrome version -> 99.0.4844.84
+Short Chrome version -> 99.0
+ChromeDriver version -> 99.0.4844.51
+Short ChromeDriver version -> 99.0
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.28.1-20250123
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250123
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250123
+Tagged selenium/node-chrome:99.0.4844.84-20250123
+Tagged selenium/standalone-chrome:99.0.4844.84-20250123
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-grid-4.28.1-20250123
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-grid-4.28.1-20250123
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-20250123
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-20250123
+Tagged selenium/node-chrome:99.0-20250123
+Tagged selenium/standalone-chrome:99.0-20250123

--- a/charts/selenium-grid/multiple-nodes-platform-version.yaml
+++ b/charts/selenium-grid/multiple-nodes-platform-version.yaml
@@ -128,6 +128,71 @@ crossBrowsers:
       hpa:
         platformName: 'Linux'
         browserVersion: '110.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-109'
+      imageTag: '109.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '109.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-108'
+      imageTag: '108.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '108.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-107'
+      imageTag: '107.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '107.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-106'
+      imageTag: '106.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '106.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-105'
+      imageTag: '105.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '105.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-104'
+      imageTag: '104.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '104.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-103'
+      imageTag: '103.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '103.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-102'
+      imageTag: '102.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '102.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-101'
+      imageTag: '101.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '101.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-100'
+      imageTag: '100.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '100.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-99'
+      imageTag: '99.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '99.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-98'
+      imageTag: '98.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '98.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-97'
+      imageTag: '97.0-20250123'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '97.0'
   firefoxNode:
     # Keep the first iteration with latest version of Firefox
     - nameOverride: '{{ $.Release.Name }}-node-firefox-latest'

--- a/tests/build-backward-compatible/bootstrap.sh
+++ b/tests/build-backward-compatible/bootstrap.sh
@@ -25,7 +25,7 @@ IFS=',' read -ra VERSION_LIST <<< "$CDP_VERSIONS"
 mkdir -p CHANGELOG/${SELENIUM_VERSION}
 
 for CDP_VERSION in "${VERSION_LIST[@]}"; do
-  python3 tests/build-backward-compatible/builder.py ${SELENIUM_VERSION} ${CDP_VERSION}
+  python3 tests/build-backward-compatible/builder.py ${SELENIUM_VERSION} ${CDP_VERSION} ${BROWSER}
   export $(cat .env | xargs)
   if [ "${BROWSER}" = "all" ] || [ "${BROWSER}" = "firefox" ] && [ "${SKIP_BUILD}" = "false" ]; then
     if [ -n "${FIREFOX_VERSION}" ]; then

--- a/tests/build-backward-compatible/builder.py
+++ b/tests/build-backward-compatible/builder.py
@@ -30,19 +30,23 @@ if __name__ == '__main__':
     # Get versions from arguments
     selenium_version = sys.argv[1]
     cdp_version = int(sys.argv[2])
+    browser_name = sys.argv[3]
     # Create .env with component versions
-    BASE_RELEASE = matrix["selenium"][selenium_version]["BASE_RELEASE"]
-    BASE_VERSION = matrix["selenium"][selenium_version]["BASE_VERSION"]
-    VERSION = matrix["selenium"][selenium_version]["VERSION"]
-    BINDING_VERSION = matrix["selenium"][selenium_version]["BINDING_VERSION"]
-    FIREFOX_VERSION = matrix["CDP"][cdp_version]["FIREFOX_VERSION"]
-    EDGE_VERSION = matrix["CDP"][cdp_version]["EDGE_VERSION"]
-    CHROME_VERSION = matrix["CDP"][cdp_version]["CHROME_VERSION"]
     with open('.env', 'w') as f:
-        f.write(f"BASE_RELEASE={BASE_RELEASE}\n")
-        f.write(f"BASE_VERSION={BASE_VERSION}\n")
-        f.write(f"VERSION={VERSION}\n")
-        f.write(f"BINDING_VERSION={BINDING_VERSION}\n")
+      BASE_RELEASE = matrix["selenium"][selenium_version]["BASE_RELEASE"]
+      BASE_VERSION = matrix["selenium"][selenium_version]["BASE_VERSION"]
+      VERSION = matrix["selenium"][selenium_version]["VERSION"]
+      BINDING_VERSION = matrix["selenium"][selenium_version]["BINDING_VERSION"]
+      f.write(f"BASE_RELEASE={BASE_RELEASE}\n")
+      f.write(f"BASE_VERSION={BASE_VERSION}\n")
+      f.write(f"VERSION={VERSION}\n")
+      f.write(f"BINDING_VERSION={BINDING_VERSION}\n")
+      if browser_name == "firefox" or browser_name == "all":
+        FIREFOX_VERSION = matrix["CDP"][cdp_version]["FIREFOX_VERSION"]
         f.write(f"FIREFOX_VERSION={FIREFOX_VERSION}\n")
+      if browser_name == "edge" or browser_name == "all":
+        EDGE_VERSION = matrix["CDP"][cdp_version]["EDGE_VERSION"]
         f.write(f"EDGE_VERSION={EDGE_VERSION}\n")
+      if browser_name == "chrome" or browser_name == "all":
+        CHROME_VERSION = matrix["CDP"][cdp_version]["CHROME_VERSION"]
         f.write(f"CHROME_VERSION={CHROME_VERSION}")

--- a/tests/build-backward-compatible/cdp-matrix.yml
+++ b/tests/build-backward-compatible/cdp-matrix.yml
@@ -8,6 +8,7 @@ matrix:
       EDGE_VERSION:
       CHROME_VERSION:
       FIREFOX_VERSION: '133.0.3'
+    #2025
     132:
       EDGE_VERSION: 'microsoft-edge-stable=132.0.2957.127-1'
       CHROME_VERSION: 'google-chrome-stable=132.0.6834.159-1'
@@ -56,6 +57,7 @@ matrix:
       EDGE_VERSION: 'microsoft-edge-stable=121.0.2277.98-1'
       CHROME_VERSION: 'google-chrome-stable=121.0.6167.184-1'
       FIREFOX_VERSION: '121.0.1'
+    #2024
     120:
       EDGE_VERSION: 'microsoft-edge-stable=120.0.2210.91-1'
       CHROME_VERSION: 'google-chrome-stable=120.0.6099.224-1'
@@ -100,3 +102,31 @@ matrix:
       EDGE_VERSION: 'microsoft-edge-stable=110.0.1587.69-1'
       CHROME_VERSION: 'google-chrome-stable=110.0.5481.177-1'
       FIREFOX_VERSION: '110.0.1'
+    #2023
+    109:
+      CHROME_VERSION: 'google-chrome-stable=109.0.5414.119-1'
+    108:
+      CHROME_VERSION: 'google-chrome-stable=108.0.5359.124-1'
+    107:
+      CHROME_VERSION: 'google-chrome-stable=107.0.5304.121-1'
+    106:
+      CHROME_VERSION: 'google-chrome-stable=106.0.5249.119-1'
+    105:
+      CHROME_VERSION: 'google-chrome-stable=105.0.5195.125-1'
+    104:
+      CHROME_VERSION: 'google-chrome-stable=104.0.5112.101-1'
+    103:
+      CHROME_VERSION: 'google-chrome-stable=103.0.5060.134-1'
+    102:
+      CHROME_VERSION: 'google-chrome-stable=102.0.5005.115-1'
+    101:
+      CHROME_VERSION: 'google-chrome-stable=101.0.4951.64-1'
+    100:
+      CHROME_VERSION: 'google-chrome-stable=100.0.4896.127-1'
+    99:
+      CHROME_VERSION: 'google-chrome-stable=99.0.4844.84-1'
+    98:
+      CHROME_VERSION: 'google-chrome-stable=98.0.4758.102-1'
+    97:
+      CHROME_VERSION: 'google-chrome-stable=97.0.4692.99-1'
+    #2022


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Continue of #2620

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Tests, Documentation


___

### **Description**
- Added support for building and deploying Node/Standalone Chrome images for versions 97 to 131 on Grid 4.28.1.

- Enhanced CI workflows to handle multiple browser versions and automate changelog creation.

- Updated Helm chart to support autoscaling with multiple Chrome browser versions.

- Documented tagging conventions and added changelogs for Chrome versions 97 to 109.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>3 files</summary><table>
<tr>
  <td><strong>bootstrap.sh</strong><dd><code>Added browser-specific argument to builder script invocation</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-b5338bc065b0c36f5843dea30ecf7fe21dc2579d106fa60b6170f76d19cd945a">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>builder.py</strong><dd><code>Enhanced environment variable generation for specific browsers</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-4f2e01a4be44f255c734542e00cbaf15d48deac276d46b330110870b578d73c6">+15/-11</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>release-chrome-versions.yml</strong><dd><code>Updated workflow to support multiple browser versions and changelog PR </code><br><code>creation</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-18aecde011483f0ab1d5ce50514815c7eec7122d5f2d2a13a72f06302043f645">+77/-9</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>13 files</summary><table>
<tr>
  <td><strong>chrome_100.md</strong><dd><code>Added changelog for Chrome version 100</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-1cad21581965e093399e488a8e76cee7989df0a2a82d936e9bb50831e739772f">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_101.md</strong><dd><code>Added changelog for Chrome version 101</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-5c3ec1cce5ed4b61f8b7cc4720674758747a3cf27ae30d6bb6a3694ef64fea46">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_102.md</strong><dd><code>Added changelog for Chrome version 102</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-4b6c0ba51cb54e716c64f7a3281cba0150b677142ed8d612ccb821b27729e96f">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_103.md</strong><dd><code>Added changelog for Chrome version 103</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-5f48876aff24c64908d3ca8337286b80ec2fe9843883b9432e3ebe8767aa95fc">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_104.md</strong><dd><code>Added changelog for Chrome version 104</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-60e0b61cda666f9eba6f406c9ad86f219552533612777a3b4aaf5bf9bb6674e9">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_105.md</strong><dd><code>Added changelog for Chrome version 105</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-e97789b9040ee9fbac73631c086e7bf43f1a2ef0f89a5ee46d2ff32efc2c995e">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_106.md</strong><dd><code>Added changelog for Chrome version 106</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-d482cf48f8fc66d451078d000ab3b53d4f3d07bb6efb2f88b32e7b99d922093e">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_107.md</strong><dd><code>Added changelog for Chrome version 107</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-9451c268048a6bdf0db7ef647954bab8347d9f6e7789eb9928e9c2d393590d73">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_108.md</strong><dd><code>Added changelog for Chrome version 108</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-9173d7ad9815d37b75d472d197bdb8bd75a0e31e8ebcab3c23fddc9d22f45219">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_109.md</strong><dd><code>Added changelog for Chrome version 109</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-d334eadb031d13dc899c3036da6616351e13282d9c149067c3bbe24919b289a7">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_97.md</strong><dd><code>Added changelog for Chrome version 97</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-35b784075b83d7cef7fb2db56a37d479b09425c7178a60d06374bb32768341bc">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_98.md</strong><dd><code>Added changelog for Chrome version 98</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-bdc9180e3d247df289c68af060f18a62da1a95c4741c9bea5902efc0e1c8d4fb">+19/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>chrome_99.md</strong><dd><code>Added changelog for Chrome version 99</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-a1e6ab714525e5a766c34c4a7d73ba9b7c57acfa6ffb61a0417c3a433d3d0b51">+19/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>multiple-nodes-platform-version.yaml</strong><dd><code>Updated Helm chart for multiple Chrome browser versions</code>&nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-821b96ab47352e4eca519c639436806a9cc78c3b2226cda0fb9ca6a04f6ce4d4">+65/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>cdp-matrix.yml</strong><dd><code>Added Chrome versions 97 to 109 to CDP matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2626/files#diff-c8a911e32f51b55b534dc8b8a29e78f5f084daad3b4b05b8b8fb4b53a5c04bec">+30/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>