### PR TITLE
[ci] Upload CHANGELOG for Node/Standalone edge version with Grid 4.28.1

### DIFF
--- a/CHANGELOG/4.28.1/edge_114.md
+++ b/CHANGELOG/4.28.1/edge_114.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 114.0.1823.82
 Short Edge version -> 114.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 114.0.1823.82
 Short EdgeDriver version -> 114.0
 Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.28.1-20250202
-Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250123
-Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250123
-Tagged selenium/node-edge:114.0.1823.82-20250123
-Tagged selenium/standalone-edge:114.0.1823.82-20250123
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250202
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250202
+Tagged selenium/node-edge:114.0.1823.82-20250202
+Tagged selenium/standalone-edge:114.0.1823.82-20250202
 Tagged selenium/node-edge:114.0-edgedriver-114.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:114.0-edgedriver-114.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:114.0-edgedriver-114.0-20250123
-Tagged selenium/standalone-edge:114.0-edgedriver-114.0-20250123
-Tagged selenium/node-edge:114.0-20250123
-Tagged selenium/standalone-edge:114.0-20250123
+Tagged selenium/node-edge:114.0-edgedriver-114.0-20250202
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-20250202
+Tagged selenium/node-edge:114.0-20250202
+Tagged selenium/standalone-edge:114.0-20250202

--- a/CHANGELOG/4.28.1/edge_115.md
+++ b/CHANGELOG/4.28.1/edge_115.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 115.0.1901.203
 Short Edge version -> 115.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 115.0.1901.203
 Short EdgeDriver version -> 115.0
 Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.28.1-20250202
-Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250123
-Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250123
-Tagged selenium/node-edge:115.0.1901.203-20250123
-Tagged selenium/standalone-edge:115.0.1901.203-20250123
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250202
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250202
+Tagged selenium/node-edge:115.0.1901.203-20250202
+Tagged selenium/standalone-edge:115.0.1901.203-20250202
 Tagged selenium/node-edge:115.0-edgedriver-115.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:115.0-edgedriver-115.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:115.0-edgedriver-115.0-20250123
-Tagged selenium/standalone-edge:115.0-edgedriver-115.0-20250123
-Tagged selenium/node-edge:115.0-20250123
-Tagged selenium/standalone-edge:115.0-20250123
+Tagged selenium/node-edge:115.0-edgedriver-115.0-20250202
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-20250202
+Tagged selenium/node-edge:115.0-20250202
+Tagged selenium/standalone-edge:115.0-20250202

--- a/CHANGELOG/4.28.1/edge_116.md
+++ b/CHANGELOG/4.28.1/edge_116.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 116.0.1938.81
 Short Edge version -> 116.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 116.0.1938.81
 Short EdgeDriver version -> 116.0
 Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.28.1-20250202
-Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250123
-Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250123
-Tagged selenium/node-edge:116.0.1938.81-20250123
-Tagged selenium/standalone-edge:116.0.1938.81-20250123
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250202
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250202
+Tagged selenium/node-edge:116.0.1938.81-20250202
+Tagged selenium/standalone-edge:116.0.1938.81-20250202
 Tagged selenium/node-edge:116.0-edgedriver-116.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:116.0-edgedriver-116.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:116.0-edgedriver-116.0-20250123
-Tagged selenium/standalone-edge:116.0-edgedriver-116.0-20250123
-Tagged selenium/node-edge:116.0-20250123
-Tagged selenium/standalone-edge:116.0-20250123
+Tagged selenium/node-edge:116.0-edgedriver-116.0-20250202
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-20250202
+Tagged selenium/node-edge:116.0-20250202
+Tagged selenium/standalone-edge:116.0-20250202

--- a/CHANGELOG/4.28.1/edge_117.md
+++ b/CHANGELOG/4.28.1/edge_117.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 117.0.2045.55
 Short Edge version -> 117.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 117.0.2045.55
 Short EdgeDriver version -> 117.0
 Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.28.1-20250202
-Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250123
-Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250123
-Tagged selenium/node-edge:117.0.2045.55-20250123
-Tagged selenium/standalone-edge:117.0.2045.55-20250123
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250202
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250202
+Tagged selenium/node-edge:117.0.2045.55-20250202
+Tagged selenium/standalone-edge:117.0.2045.55-20250202
 Tagged selenium/node-edge:117.0-edgedriver-117.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:117.0-edgedriver-117.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:117.0-edgedriver-117.0-20250123
-Tagged selenium/standalone-edge:117.0-edgedriver-117.0-20250123
-Tagged selenium/node-edge:117.0-20250123
-Tagged selenium/standalone-edge:117.0-20250123
+Tagged selenium/node-edge:117.0-edgedriver-117.0-20250202
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-20250202
+Tagged selenium/node-edge:117.0-20250202
+Tagged selenium/standalone-edge:117.0-20250202

--- a/CHANGELOG/4.28.1/edge_118.md
+++ b/CHANGELOG/4.28.1/edge_118.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 118.0.2088.76
 Short Edge version -> 118.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 118.0.2088.76
 Short EdgeDriver version -> 118.0
 Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.28.1-20250202
-Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250123
-Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250123
-Tagged selenium/node-edge:118.0.2088.76-20250123
-Tagged selenium/standalone-edge:118.0.2088.76-20250123
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250202
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250202
+Tagged selenium/node-edge:118.0.2088.76-20250202
+Tagged selenium/standalone-edge:118.0.2088.76-20250202
 Tagged selenium/node-edge:118.0-edgedriver-118.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:118.0-edgedriver-118.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:118.0-edgedriver-118.0-20250123
-Tagged selenium/standalone-edge:118.0-edgedriver-118.0-20250123
-Tagged selenium/node-edge:118.0-20250123
-Tagged selenium/standalone-edge:118.0-20250123
+Tagged selenium/node-edge:118.0-edgedriver-118.0-20250202
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-20250202
+Tagged selenium/node-edge:118.0-20250202
+Tagged selenium/standalone-edge:118.0-20250202

--- a/CHANGELOG/4.28.1/edge_119.md
+++ b/CHANGELOG/4.28.1/edge_119.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 119.0.2151.97
 Short Edge version -> 119.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 119.0.2151.97
 Short EdgeDriver version -> 119.0
 Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.28.1-20250202
-Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250123
-Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250123
-Tagged selenium/node-edge:119.0.2151.97-20250123
-Tagged selenium/standalone-edge:119.0.2151.97-20250123
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250202
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250202
+Tagged selenium/node-edge:119.0.2151.97-20250202
+Tagged selenium/standalone-edge:119.0.2151.97-20250202
 Tagged selenium/node-edge:119.0-edgedriver-119.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:119.0-edgedriver-119.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:119.0-edgedriver-119.0-20250123
-Tagged selenium/standalone-edge:119.0-edgedriver-119.0-20250123
-Tagged selenium/node-edge:119.0-20250123
-Tagged selenium/standalone-edge:119.0-20250123
+Tagged selenium/node-edge:119.0-edgedriver-119.0-20250202
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-20250202
+Tagged selenium/node-edge:119.0-20250202
+Tagged selenium/standalone-edge:119.0-20250202

--- a/CHANGELOG/4.28.1/edge_120.md
+++ b/CHANGELOG/4.28.1/edge_120.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 120.0.2210.91
 Short Edge version -> 120.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 120.0.2210.144
 Short EdgeDriver version -> 120.0
 Tagged selenium/node-edge:120.0.2210.91-edgedriver-120.0.2210.144-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:120.0.2210.91-edgedriver-120.0.2210.144-grid-4.28.1-20250202
-Tagged selenium/node-edge:120.0.2210.91-edgedriver-120.0.2210.144-20250123
-Tagged selenium/standalone-edge:120.0.2210.91-edgedriver-120.0.2210.144-20250123
-Tagged selenium/node-edge:120.0.2210.91-20250123
-Tagged selenium/standalone-edge:120.0.2210.91-20250123
+Tagged selenium/node-edge:120.0.2210.91-edgedriver-120.0.2210.144-20250202
+Tagged selenium/standalone-edge:120.0.2210.91-edgedriver-120.0.2210.144-20250202
+Tagged selenium/node-edge:120.0.2210.91-20250202
+Tagged selenium/standalone-edge:120.0.2210.91-20250202
 Tagged selenium/node-edge:120.0-edgedriver-120.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:120.0-edgedriver-120.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:120.0-edgedriver-120.0-20250123
-Tagged selenium/standalone-edge:120.0-edgedriver-120.0-20250123
-Tagged selenium/node-edge:120.0-20250123
-Tagged selenium/standalone-edge:120.0-20250123
+Tagged selenium/node-edge:120.0-edgedriver-120.0-20250202
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-20250202
+Tagged selenium/node-edge:120.0-20250202
+Tagged selenium/standalone-edge:120.0-20250202

--- a/CHANGELOG/4.28.1/edge_121.md
+++ b/CHANGELOG/4.28.1/edge_121.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 121.0.2277.98
 Short Edge version -> 121.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 121.0.2277.128
 Short EdgeDriver version -> 121.0
 Tagged selenium/node-edge:121.0.2277.98-edgedriver-121.0.2277.128-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:121.0.2277.98-edgedriver-121.0.2277.128-grid-4.28.1-20250202
-Tagged selenium/node-edge:121.0.2277.98-edgedriver-121.0.2277.128-20250123
-Tagged selenium/standalone-edge:121.0.2277.98-edgedriver-121.0.2277.128-20250123
-Tagged selenium/node-edge:121.0.2277.98-20250123
-Tagged selenium/standalone-edge:121.0.2277.98-20250123
+Tagged selenium/node-edge:121.0.2277.98-edgedriver-121.0.2277.128-20250202
+Tagged selenium/standalone-edge:121.0.2277.98-edgedriver-121.0.2277.128-20250202
+Tagged selenium/node-edge:121.0.2277.98-20250202
+Tagged selenium/standalone-edge:121.0.2277.98-20250202
 Tagged selenium/node-edge:121.0-edgedriver-121.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:121.0-edgedriver-121.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:121.0-edgedriver-121.0-20250123
-Tagged selenium/standalone-edge:121.0-edgedriver-121.0-20250123
-Tagged selenium/node-edge:121.0-20250123
-Tagged selenium/standalone-edge:121.0-20250123
+Tagged selenium/node-edge:121.0-edgedriver-121.0-20250202
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-20250202
+Tagged selenium/node-edge:121.0-20250202
+Tagged selenium/standalone-edge:121.0-20250202

--- a/CHANGELOG/4.28.1/edge_122.md
+++ b/CHANGELOG/4.28.1/edge_122.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 122.0.2365.92
 Short Edge version -> 122.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 122.0.2365.92
 Short EdgeDriver version -> 122.0
 Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.28.1-20250202
-Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250123
-Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250123
-Tagged selenium/node-edge:122.0.2365.92-20250123
-Tagged selenium/standalone-edge:122.0.2365.92-20250123
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250202
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250202
+Tagged selenium/node-edge:122.0.2365.92-20250202
+Tagged selenium/standalone-edge:122.0.2365.92-20250202
 Tagged selenium/node-edge:122.0-edgedriver-122.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:122.0-edgedriver-122.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:122.0-edgedriver-122.0-20250123
-Tagged selenium/standalone-edge:122.0-edgedriver-122.0-20250123
-Tagged selenium/node-edge:122.0-20250123
-Tagged selenium/standalone-edge:122.0-20250123
+Tagged selenium/node-edge:122.0-edgedriver-122.0-20250202
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-20250202
+Tagged selenium/node-edge:122.0-20250202
+Tagged selenium/standalone-edge:122.0-20250202

--- a/CHANGELOG/4.28.1/edge_123.md
+++ b/CHANGELOG/4.28.1/edge_123.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 123.0.2420.97
 Short Edge version -> 123.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 123.0.2420.97
 Short EdgeDriver version -> 123.0
 Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.28.1-20250202
-Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250123
-Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250123
-Tagged selenium/node-edge:123.0.2420.97-20250123
-Tagged selenium/standalone-edge:123.0.2420.97-20250123
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250202
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250202
+Tagged selenium/node-edge:123.0.2420.97-20250202
+Tagged selenium/standalone-edge:123.0.2420.97-20250202
 Tagged selenium/node-edge:123.0-edgedriver-123.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:123.0-edgedriver-123.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:123.0-edgedriver-123.0-20250123
-Tagged selenium/standalone-edge:123.0-edgedriver-123.0-20250123
-Tagged selenium/node-edge:123.0-20250123
-Tagged selenium/standalone-edge:123.0-20250123
+Tagged selenium/node-edge:123.0-edgedriver-123.0-20250202
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-20250202
+Tagged selenium/node-edge:123.0-20250202
+Tagged selenium/standalone-edge:123.0-20250202

--- a/CHANGELOG/4.28.1/edge_124.md
+++ b/CHANGELOG/4.28.1/edge_124.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 124.0.2478.51
 Short Edge version -> 124.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 124.0.2478.109
 Short EdgeDriver version -> 124.0
 Tagged selenium/node-edge:124.0.2478.51-edgedriver-124.0.2478.109-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:124.0.2478.51-edgedriver-124.0.2478.109-grid-4.28.1-20250202
-Tagged selenium/node-edge:124.0.2478.51-edgedriver-124.0.2478.109-20250123
-Tagged selenium/standalone-edge:124.0.2478.51-edgedriver-124.0.2478.109-20250123
-Tagged selenium/node-edge:124.0.2478.51-20250123
-Tagged selenium/standalone-edge:124.0.2478.51-20250123
+Tagged selenium/node-edge:124.0.2478.51-edgedriver-124.0.2478.109-20250202
+Tagged selenium/standalone-edge:124.0.2478.51-edgedriver-124.0.2478.109-20250202
+Tagged selenium/node-edge:124.0.2478.51-20250202
+Tagged selenium/standalone-edge:124.0.2478.51-20250202
 Tagged selenium/node-edge:124.0-edgedriver-124.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:124.0-edgedriver-124.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:124.0-edgedriver-124.0-20250123
-Tagged selenium/standalone-edge:124.0-edgedriver-124.0-20250123
-Tagged selenium/node-edge:124.0-20250123
-Tagged selenium/standalone-edge:124.0-20250123
+Tagged selenium/node-edge:124.0-edgedriver-124.0-20250202
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-20250202
+Tagged selenium/node-edge:124.0-20250202
+Tagged selenium/standalone-edge:124.0-20250202

--- a/CHANGELOG/4.28.1/edge_125.md
+++ b/CHANGELOG/4.28.1/edge_125.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 125.0.2535.92
 Short Edge version -> 125.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 125.0.2535.92
 Short EdgeDriver version -> 125.0
 Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.28.1-20250202
-Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250123
-Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250123
-Tagged selenium/node-edge:125.0.2535.92-20250123
-Tagged selenium/standalone-edge:125.0.2535.92-20250123
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250202
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250202
+Tagged selenium/node-edge:125.0.2535.92-20250202
+Tagged selenium/standalone-edge:125.0.2535.92-20250202
 Tagged selenium/node-edge:125.0-edgedriver-125.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:125.0-edgedriver-125.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:125.0-edgedriver-125.0-20250123
-Tagged selenium/standalone-edge:125.0-edgedriver-125.0-20250123
-Tagged selenium/node-edge:125.0-20250123
-Tagged selenium/standalone-edge:125.0-20250123
+Tagged selenium/node-edge:125.0-edgedriver-125.0-20250202
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-20250202
+Tagged selenium/node-edge:125.0-20250202
+Tagged selenium/standalone-edge:125.0-20250202

--- a/CHANGELOG/4.28.1/edge_126.md
+++ b/CHANGELOG/4.28.1/edge_126.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 126.0.2592.113
 Short Edge version -> 126.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 126.0.2592.123
 Short EdgeDriver version -> 126.0
 Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.28.1-20250202
-Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250123
-Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250123
-Tagged selenium/node-edge:126.0.2592.113-20250123
-Tagged selenium/standalone-edge:126.0.2592.113-20250123
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250202
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250202
+Tagged selenium/node-edge:126.0.2592.113-20250202
+Tagged selenium/standalone-edge:126.0.2592.113-20250202
 Tagged selenium/node-edge:126.0-edgedriver-126.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:126.0-edgedriver-126.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:126.0-edgedriver-126.0-20250123
-Tagged selenium/standalone-edge:126.0-edgedriver-126.0-20250123
-Tagged selenium/node-edge:126.0-20250123
-Tagged selenium/standalone-edge:126.0-20250123
+Tagged selenium/node-edge:126.0-edgedriver-126.0-20250202
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-20250202
+Tagged selenium/node-edge:126.0-20250202
+Tagged selenium/standalone-edge:126.0-20250202

--- a/CHANGELOG/4.28.1/edge_127.md
+++ b/CHANGELOG/4.28.1/edge_127.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 127.0.2651.105
 Short Edge version -> 127.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 127.0.2651.107
 Short EdgeDriver version -> 127.0
 Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.28.1-20250202
-Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250123
-Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250123
-Tagged selenium/node-edge:127.0.2651.105-20250123
-Tagged selenium/standalone-edge:127.0.2651.105-20250123
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250202
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250202
+Tagged selenium/node-edge:127.0.2651.105-20250202
+Tagged selenium/standalone-edge:127.0.2651.105-20250202
 Tagged selenium/node-edge:127.0-edgedriver-127.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:127.0-edgedriver-127.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:127.0-edgedriver-127.0-20250123
-Tagged selenium/standalone-edge:127.0-edgedriver-127.0-20250123
-Tagged selenium/node-edge:127.0-20250123
-Tagged selenium/standalone-edge:127.0-20250123
+Tagged selenium/node-edge:127.0-edgedriver-127.0-20250202
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-20250202
+Tagged selenium/node-edge:127.0-20250202
+Tagged selenium/standalone-edge:127.0-20250202

--- a/CHANGELOG/4.28.1/edge_128.md
+++ b/CHANGELOG/4.28.1/edge_128.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 128.0.2739.79
 Short Edge version -> 128.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 128.0.2739.81
 Short EdgeDriver version -> 128.0
 Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.28.1-20250202
-Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250123
-Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250123
-Tagged selenium/node-edge:128.0.2739.79-20250123
-Tagged selenium/standalone-edge:128.0.2739.79-20250123
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250202
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250202
+Tagged selenium/node-edge:128.0.2739.79-20250202
+Tagged selenium/standalone-edge:128.0.2739.79-20250202
 Tagged selenium/node-edge:128.0-edgedriver-128.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:128.0-edgedriver-128.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:128.0-edgedriver-128.0-20250123
-Tagged selenium/standalone-edge:128.0-edgedriver-128.0-20250123
-Tagged selenium/node-edge:128.0-20250123
-Tagged selenium/standalone-edge:128.0-20250123
+Tagged selenium/node-edge:128.0-edgedriver-128.0-20250202
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-20250202
+Tagged selenium/node-edge:128.0-20250202
+Tagged selenium/standalone-edge:128.0-20250202

--- a/CHANGELOG/4.28.1/edge_129.md
+++ b/CHANGELOG/4.28.1/edge_129.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 129.0.2792.89
 Short Edge version -> 129.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 129.0.2792.98
 Short EdgeDriver version -> 129.0
 Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.28.1-20250202
-Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250123
-Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250123
-Tagged selenium/node-edge:129.0.2792.89-20250123
-Tagged selenium/standalone-edge:129.0.2792.89-20250123
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250202
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250202
+Tagged selenium/node-edge:129.0.2792.89-20250202
+Tagged selenium/standalone-edge:129.0.2792.89-20250202
 Tagged selenium/node-edge:129.0-edgedriver-129.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:129.0-edgedriver-129.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:129.0-edgedriver-129.0-20250123
-Tagged selenium/standalone-edge:129.0-edgedriver-129.0-20250123
-Tagged selenium/node-edge:129.0-20250123
-Tagged selenium/standalone-edge:129.0-20250123
+Tagged selenium/node-edge:129.0-edgedriver-129.0-20250202
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-20250202
+Tagged selenium/node-edge:129.0-20250202
+Tagged selenium/standalone-edge:129.0-20250202

--- a/CHANGELOG/4.28.1/edge_130.md
+++ b/CHANGELOG/4.28.1/edge_130.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 130.0.2849.80
 Short Edge version -> 130.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 130.0.2849.78
 Short EdgeDriver version -> 130.0
 Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.28.1-20250202
-Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250123
-Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250123
-Tagged selenium/node-edge:130.0.2849.80-20250123
-Tagged selenium/standalone-edge:130.0.2849.80-20250123
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250202
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250202
+Tagged selenium/node-edge:130.0.2849.80-20250202
+Tagged selenium/standalone-edge:130.0.2849.80-20250202
 Tagged selenium/node-edge:130.0-edgedriver-130.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:130.0-edgedriver-130.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:130.0-edgedriver-130.0-20250123
-Tagged selenium/standalone-edge:130.0-edgedriver-130.0-20250123
-Tagged selenium/node-edge:130.0-20250123
-Tagged selenium/standalone-edge:130.0-20250123
+Tagged selenium/node-edge:130.0-edgedriver-130.0-20250202
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-20250202
+Tagged selenium/node-edge:130.0-20250202
+Tagged selenium/standalone-edge:130.0-20250202

--- a/CHANGELOG/4.28.1/edge_131.md
+++ b/CHANGELOG/4.28.1/edge_131.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 131.0.2903.147
 Short Edge version -> 131.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 131.0.2903.147
 Short EdgeDriver version -> 131.0
 Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.28.1-20250202
-Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250123
-Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250123
-Tagged selenium/node-edge:131.0.2903.147-20250123
-Tagged selenium/standalone-edge:131.0.2903.147-20250123
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250202
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250202
+Tagged selenium/node-edge:131.0.2903.147-20250202
+Tagged selenium/standalone-edge:131.0.2903.147-20250202
 Tagged selenium/node-edge:131.0-edgedriver-131.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:131.0-edgedriver-131.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:131.0-edgedriver-131.0-20250123
-Tagged selenium/standalone-edge:131.0-edgedriver-131.0-20250123
-Tagged selenium/node-edge:131.0-20250123
-Tagged selenium/standalone-edge:131.0-20250123
+Tagged selenium/node-edge:131.0-edgedriver-131.0-20250202
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-20250202
+Tagged selenium/node-edge:131.0-20250202
+Tagged selenium/standalone-edge:131.0-20250202

--- a/CHANGELOG/4.28.1/edge_132.md
+++ b/CHANGELOG/4.28.1/edge_132.md
@@ -1,5 +1,5 @@
-./tag_and_push_browser_images.sh 4.28.1 20250123 selenium false edge true
-Tagging images for browser edge, version 4.28.1, build date 20250123, namespace selenium
+./tag_and_push_browser_images.sh 4.28.1 20250202 selenium false edge true
+Tagging images for browser edge, version 4.28.1, build date 20250202, namespace selenium
 Selenium Grid version -> 4.28.1-20250202
 Edge version -> 132.0.2957.140
 Short Edge version -> 132.0
@@ -7,13 +7,13 @@ EdgeDriver version -> 132.0.2957.140
 Short EdgeDriver version -> 132.0
 Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.28.1-20250202
-Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250123
-Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250123
-Tagged selenium/node-edge:132.0.2957.140-20250123
-Tagged selenium/standalone-edge:132.0.2957.140-20250123
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250202
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250202
+Tagged selenium/node-edge:132.0.2957.140-20250202
+Tagged selenium/standalone-edge:132.0.2957.140-20250202
 Tagged selenium/node-edge:132.0-edgedriver-132.0-grid-4.28.1-20250202
 Tagged selenium/standalone-edge:132.0-edgedriver-132.0-grid-4.28.1-20250202
-Tagged selenium/node-edge:132.0-edgedriver-132.0-20250123
-Tagged selenium/standalone-edge:132.0-edgedriver-132.0-20250123
-Tagged selenium/node-edge:132.0-20250123
-Tagged selenium/standalone-edge:132.0-20250123
+Tagged selenium/node-edge:132.0-edgedriver-132.0-20250202
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-20250202
+Tagged selenium/node-edge:132.0-20250202
+Tagged selenium/standalone-edge:132.0-20250202


### PR DESCRIPTION
This PR contains the CHANGELOG for Node/Standalone Edge with specific browser versions: [114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132]