### PR TITLE
Fix add-cert-helper.sh only adding a single certificate in Chrome

### DIFF
--- a/charts/selenium-grid/certs/add-cert-helper.sh
+++ b/charts/selenium-grid/certs/add-cert-helper.sh
@@ -58,7 +58,7 @@ TARGET_CERT_DIR=${TARGET_CERT_DIR:-"/usr/local/share/ca-certificates"} # Target 
 BUNDLE_CA_CERTS=${BUNDLE_CA_CERTS:-"/etc/ssl/certs/ca-certificates.crt"} # Bundle CA certificates
 NSSDB_HOME=${NSSDB_HOME:-"${HOME}/.pki/nssdb"} # Default location of the NSSDB
 APPEND_CRT_KEY="/tmp/tls.crt"
-ALIAS=${ALIAS:-"SeleniumHQ"}
+ALIAS_PREFIX=${ALIAS_PREFIX:-"SeleniumHQ"}
 
 sudo mkdir -p ${TARGET_CERT_DIR}
 
@@ -75,6 +75,7 @@ for cert_file in "${cert_files[@]}"; do
   else
     echo "Processing $cert_file"
   fi
+  ALIAS="${ALIAS_PREFIX}_$(basename $cert_file)"
   cert_file=$(append_private_key_if_exists $cert_file)
   for cert_db_file in "${cert_db_files[@]}"; do
     echo "Adding to db: $cert_db_file"

--- a/tests/customCACert/bootstrap.sh
+++ b/tests/customCACert/bootstrap.sh
@@ -22,7 +22,7 @@ docker build ${COMMON_BUILD_ARGS} --build-arg BASE=node-edge -t ${NAMESPACE}/nod
 
 list_cert_files=($(find ./charts/selenium-grid/certs/ -name "*.crt"))
 for cert_file_path in "${list_cert_files[@]}"; do
-  cert_nick_name="SeleniumHQ"
+  cert_nick_name="SeleniumHQ_$(basename $cert_file_path)"
   docker run --entrypoint="" --rm  ${NAMESPACE}/node-chrome:${VERSION} bash -c "certutil -L -d sql:/home/seluser/.pki/nssdb -n ${cert_nick_name}"
   docker run --entrypoint="" --rm  ${NAMESPACE}/node-firefox:${VERSION} bash -c "certutil -L -d sql:/home/seluser/.pki/nssdb -n ${cert_nick_name}"
   docker run --entrypoint="" --rm  ${NAMESPACE}/node-edge:${VERSION} bash -c "certutil -L -d sql:/home/seluser/.pki/nssdb -n ${cert_nick_name}"


### PR DESCRIPTION
### **User description**
### Description
When running `/opt/bin/add-cert-helper.sh`, if multiple certificates are present in the directory passed in the `-d` argument, only the last certificate alphabetically will be added to the Chrome store, as the same certificate alias is used for each certificate.

#### Steps to reproduce

Prepare a certificates folder on an instance of the container, e.g. `/tmp/certs`, containing more than one root certificate.

Run

    /opt/bin/add-cert-helper.sh -d /tmp/certs

Using NoVNC, open the Chrome browser and verify that only the last certificate has been added: three dots > Settings > Privacy and Security > Security > Manage certificates > Authorities.

If you View the certificate, the added certificate will have the alias **SeleniumHQ** displayed immediately under Certificate Hierarchy.

Any other certificates that were imported before the last alphabetical certificate will not be present.

This pull request alters the `add-cert-helper.sh` script to use a different `ALIAS` for each imported certificate from the source directory.

To verify this addresses the issue, repeat the process to add a directory of certificates as above. Using NoVNC, open the Chrome browser and verify the available certificates: three dots > Settings > Privacy and Security > Security > Manage certificates > Authorities.

Note that multiple certificates, if present in the source directory, are now imported.

### Motivation and Context

This change is necessary in order to use `add-cert-helper.sh` to load a directory containing more than one root certificate into Chrome's root certificate store.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

I have not run automated tests, but this change only affects the utility script `/opt/bin/add-cert-helper.sh`.


___

### **PR Type**
Bug fix


___

### **Description**
- Fixes issue where only one certificate was added to Chrome.

- Introduces unique aliases for each certificate during import.

- Ensures multiple certificates from a directory are imported correctly.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>add-cert-helper.sh</strong><dd><code>Use unique aliases for importing multiple certificates</code>&nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/certs/add-cert-helper.sh

<li>Replaced static <code>ALIAS</code> with dynamic <code>ALIAS_PREFIX</code>.<br> <li> Generated unique aliases for each certificate using file basename.<br> <li> Ensured compatibility with multiple certificates in a directory.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2660/files#diff-3be5e52de7434fa9d4b2981a0b301c95d62c0cc21e632376ba17b3ecc8f39f77">+2/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>