### PR TITLE
Docker: Disable HeapDumpOnOutOfMemoryError by default

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -195,7 +195,7 @@ ENV SE_BIND_HOST="false" \
     SE_STRUCTURED_LOGS="false" \
     SE_ENABLE_TRACING="true" \
     SE_ENABLE_TLS="false" \
-    SE_JAVA_OPTS_DEFAULT="-XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs" \
+    SE_JAVA_OPTS_DEFAULT="" \
     SE_JAVA_HEAP_DUMP="false" \
     SE_JAVA_HTTPCLIENT_VERSION="HTTP_1_1" \
     SE_JAVA_SSL_TRUST_STORE="/opt/selenium/secrets/server.jks" \

--- a/Distributor/start-selenium-grid-distributor.sh
+++ b/Distributor/start-selenium-grid-distributor.sh
@@ -186,18 +186,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} \
   distributor \

--- a/EventBus/start-selenium-grid-eventbus.sh
+++ b/EventBus/start-selenium-grid-eventbus.sh
@@ -116,18 +116,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} event-bus \
   --bind-host ${SE_BIND_HOST} \

--- a/Hub/start-selenium-grid-hub.sh
+++ b/Hub/start-selenium-grid-hub.sh
@@ -166,18 +166,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} \
   hub \

--- a/NodeBase/start-selenium-node.sh
+++ b/NodeBase/start-selenium-node.sh
@@ -181,18 +181,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   ${CHROME_DRIVER_PATH_PROPERTY} \
   ${EDGE_DRIVER_PATH_PROPERTY} \
   ${GECKO_DRIVER_PATH_PROPERTY} \

--- a/NodeDocker/start-selenium-grid-docker.sh
+++ b/NodeDocker/start-selenium-grid-docker.sh
@@ -133,18 +133,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} node \
   --publish-events tcp://"${SE_EVENT_BUS_HOST}":${SE_EVENT_BUS_PUBLISH_PORT} \

--- a/Router/start-selenium-grid-router.sh
+++ b/Router/start-selenium-grid-router.sh
@@ -167,18 +167,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} router \
   --sessions-host "${SE_SESSIONS_MAP_HOST}" --sessions-port "${SE_SESSIONS_MAP_PORT}" \

--- a/SessionQueue/start-selenium-grid-session-queue.sh
+++ b/SessionQueue/start-selenium-grid-session-queue.sh
@@ -120,18 +120,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} sessionqueue \
   --session-request-timeout ${SE_SESSION_REQUEST_TIMEOUT} \

--- a/Sessions/start-selenium-grid-sessions.sh
+++ b/Sessions/start-selenium-grid-sessions.sh
@@ -155,18 +155,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} sessions \
   --publish-events tcp://"${SE_EVENT_BUS_HOST}":${SE_EVENT_BUS_PUBLISH_PORT} \

--- a/Standalone/start-selenium-standalone.sh
+++ b/Standalone/start-selenium-standalone.sh
@@ -169,18 +169,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   ${CHROME_DRIVER_PATH_PROPERTY} \
   ${EDGE_DRIVER_PATH_PROPERTY} \
   ${GECKO_DRIVER_PATH_PROPERTY} \

--- a/StandaloneDocker/start-selenium-grid-docker.sh
+++ b/StandaloneDocker/start-selenium-grid-docker.sh
@@ -134,18 +134,21 @@ if [ -n "${SE_JAVA_OPTS_DEFAULT}" ]; then
   SE_JAVA_OPTS="${SE_JAVA_OPTS_DEFAULT} $SE_JAVA_OPTS"
 fi
 
-if [ -n "${JAVA_OPTS:-$SE_JAVA_OPTS}" ]; then
-  echo "Using JAVA_OPTS: ${JAVA_OPTS:-$SE_JAVA_OPTS}"
-fi
-
 function handle_heap_dump() {
   /opt/bin/handle_heap_dump.sh /opt/selenium/logs
 }
 if [ "${SE_JAVA_HEAP_DUMP}" = "true" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS -XX:+HeapDumpOnOutOfMemoryError -XX:HeapDumpPath=/opt/selenium/logs"
   trap handle_heap_dump ERR SIGTERM SIGINT
 fi
 
-java ${JAVA_OPTS:-$SE_JAVA_OPTS} \
+if [ -n "${JAVA_OPTS}" ]; then
+  SE_JAVA_OPTS="$SE_JAVA_OPTS ${JAVA_OPTS}"
+fi
+
+echo "Using JAVA_OPTS: ${SE_JAVA_OPTS}"
+
+java ${SE_JAVA_OPTS} \
   -jar /opt/selenium/selenium-server.jar \
   ${EXTRA_LIBS} standalone \
   --session-request-timeout ${SE_SESSION_REQUEST_TIMEOUT} \


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #2706 
It will be enabled when `SE_JAVA_HEAP_DUMP` is `true`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, configuration changes


___

### **Description**
- Removed default enabling of `HeapDumpOnOutOfMemoryError`.

- Added conditional handling of `JAVA_OPTS` in startup scripts.

- Improved logging of `JAVA_OPTS` for better debugging.

- Updated `Dockerfile` to reflect new default `SE_JAVA_OPTS_DEFAULT`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>10 files</summary><table>
<tr>
  <td><strong>start-selenium-grid-distributor.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-126c639972a47090b630e07da51b3eac94f6b12660e499c438ef0add24da2179">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-eventbus.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-efb04e0cc98998222e260278f17dfebd94e8c7b940282084935a86fef653744e">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-hub.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-9aa93031edb177db1d5e76fd9aa6b72cb4e540c5e2d9803aceb82bdb62c17446">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-node.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-58e47711a545fff697c0705c6e9cb305d11283c3ccba924f7beb3b336a9adb25">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-docker.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-9a789801c772a424a1ac7f17048e667ba5e054754f775f950144cc45edf03fa7">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-router.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-49e49d9819b9ccb5e9f1237c00742183dd23bcfa9ecdeb3164d018d4a9db8823">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-session-queue.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-c8a8d4c0223a75eaf52d5ba78803f75c73ff9bf72866869cffbf4dd86fc08cf6">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-sessions.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-191bf301a597ccaeb6ec67abcd988dda13fb44d8e7a7e76d3fc9d384921bdc57">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-standalone.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-bf348b8b097c88fc4de17029973206ddd04d9c29115cd8a9a1941eb4cd4cc8d9">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>start-selenium-grid-docker.sh</strong><dd><code>Enhanced handling of `JAVA_OPTS` and heap dump configuration</code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-eae2604fe4b687f3f296397a3351592fac817c98329e60c1d01ec746178bedca">+8/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>Dockerfile</strong><dd><code>Removed default <code>HeapDumpOnOutOfMemoryError</code> from <code>SE_JAVA_OPTS_DEFAULT</code></code></dd></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2708/files#diff-c7235ebbda8248c044e6b13da481ae97f4a21846ed2341a056b6b873abaa482b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>