### PR TITLE
K8s: Update strategy as Recreate by default

### DIFF
--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -263,7 +263,7 @@ jobs:
       - name: Test chart upgrade
         if: (matrix.test-upgrade == true)
         run: |
-          NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} SET_MAX_REPLICAS=10 TEST_NAME_OVERRIDE=true TEST_UPGRADE_CHART=${TEST_UPGRADE_CHART} make chart_test_autoscaling_${{ matrix.test-strategy }}
+          NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} SET_MAX_REPLICAS=10 TEST_NAME_OVERRIDE=true TEST_UPGRADE_CHART=${TEST_UPGRADE_CHART} SET_UPDATE_STRATEGY=Recreate make chart_test_autoscaling_${{ matrix.test-strategy }}
       - name: Cleanup Kubernetes cluster
         if: always()
         run: CLUSTER=${CLUSTER} make chart_cluster_cleanup

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -44,7 +44,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | global.seleniumGrid.revisionHistoryLimit | int | `10` | Specify how many old ReplicaSets for this Deployment you want to retain. The rest will be garbage-collected in the background. |
 | global.seleniumGrid.structuredLogs | bool | `false` | Whether to enable structured logging |
 | global.seleniumGrid.httpLogs | bool | `false` | Enable http logging. Tracing should be enabled to log http logs. |
-| global.seleniumGrid.updateStrategy.type | string | `"RollingUpdate"` | Specify update strategy for all components, can be overridden individually |
+| global.seleniumGrid.updateStrategy.type | string | `"Recreate"` | Specify update strategy for all components, can be overridden individually |
 | global.seleniumGrid.updateStrategy.rollingUpdate | object | `{"maxSurge":1,"maxUnavailable":0}` | Specify for strategy RollingUpdate |
 | global.seleniumGrid.affinity | object | `{}` | Specify affinity for all components, can be overridden individually |
 | global.seleniumGrid.topologySpreadConstraints | list | `[]` | Specify topologySpreadConstraints for all components, can be overridden individually |
@@ -420,7 +420,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | crossBrowsers.relayNode | list | `[{"nameOverride":null}]` | Additional release nodes, array of objects with the same structure as `relayNode` |
 | chromeNode.enabled | bool | `true` | Enable chrome nodes |
 | chromeNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long-living pods false - for provisioning your own custom type such as Jobs |
-| chromeNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |
+| chromeNode.updateStrategy | object | `{"type":null}` | Global update strategy will be overwritten by individual component |
 | chromeNode.replicas | int | `1` | Number of chrome nodes |
 | chromeNode.imageRegistry | string | `nil` | Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter) |
 | chromeNode.imageName | string | `"node-chrome"` | Image of chrome nodes |
@@ -478,7 +478,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | chromeNode.videoRecorder | object | `{}` | Override specific video recording settings for chrome node |
 | firefoxNode.enabled | bool | `true` | Enable firefox nodes |
 | firefoxNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long living pods false - for provisioning your own custom type such as Jobs |
-| firefoxNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |
+| firefoxNode.updateStrategy | object | `{"type":null}` | Global update strategy will be overwritten by individual component |
 | firefoxNode.replicas | int | `1` | Number of firefox nodes |
 | firefoxNode.imageRegistry | string | `nil` | Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter) |
 | firefoxNode.imageName | string | `"node-firefox"` | Image of firefox nodes |
@@ -536,7 +536,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | firefoxNode.videoRecorder | object | `{}` | Override specific video recording settings for firefox node |
 | edgeNode.enabled | bool | `true` | Enable edge nodes |
 | edgeNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long living pods false - for provisioning your own custom type such as Jobs |
-| edgeNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |
+| edgeNode.updateStrategy | object | `{"type":null}` | Global update strategy will be overwritten by individual component |
 | edgeNode.replicas | int | `1` | Number of edge nodes |
 | edgeNode.imageRegistry | string | `nil` | Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter) |
 | edgeNode.imageName | string | `"node-edge"` | Image of edge nodes |
@@ -595,7 +595,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | relayNode.enabled | bool | `false` | Enable relay nodes |
 | relayNode.relayUrl | string | `""` | Specify another Grid, another network, or a cloud vendor that you wish to connect to (e.g. https://ondemand.us-west-1.saucelabs.com/wd/hub) |
 | relayNode.deploymentEnabled | bool | `true` | NOTE: Only used when autoscaling.enabled is false Enable creation of Deployment true (default) - if you want long-living pods false - for provisioning your own custom type such as Jobs |
-| relayNode.updateStrategy | object | `{"type":"RollingUpdate"}` | Global update strategy will be overwritten by individual component |
+| relayNode.updateStrategy | object | `{"type":null}` | Global update strategy will be overwritten by individual component |
 | relayNode.replicas | int | `1` | Number of relay nodes |
 | relayNode.imageRegistry | string | `nil` | Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter) |
 | relayNode.imageName | string | `"node-base"` | Image of relay nodes |

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -34,7 +34,7 @@ global:
     httpLogs: false
     updateStrategy:
       # -- Specify update strategy for all components, can be overridden individually
-      type: RollingUpdate
+      type: Recreate
       # type: RollingUpdate
       # -- Specify for strategy RollingUpdate
       rollingUpdate:
@@ -1124,7 +1124,7 @@ chromeNode:
   deploymentEnabled: true
   # -- Global update strategy will be overwritten by individual component
   updateStrategy:
-    type: RollingUpdate
+    type:
   # -- Number of chrome nodes
   replicas: 1
   # -- Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter)
@@ -1320,7 +1320,7 @@ firefoxNode:
   deploymentEnabled: true
   # -- Global update strategy will be overwritten by individual component
   updateStrategy:
-    type: RollingUpdate
+    type:
   # -- Number of firefox nodes
   replicas: 1
   # -- Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter)
@@ -1516,7 +1516,7 @@ edgeNode:
   deploymentEnabled: true
   # -- Global update strategy will be overwritten by individual component
   updateStrategy:
-    type: RollingUpdate
+    type:
   # -- Number of edge nodes
   replicas: 1
   # -- Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter)
@@ -1713,7 +1713,7 @@ relayNode:
   deploymentEnabled: true
   # -- Global update strategy will be overwritten by individual component
   updateStrategy:
-    type: RollingUpdate
+    type:
   # -- Number of relay nodes
   replicas: 1
   # -- Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter)

--- a/tests/charts/ci/base-auth-ingress-values.yaml
+++ b/tests/charts/ci/base-auth-ingress-values.yaml
@@ -55,4 +55,4 @@ ingress-nginx:
       enabled: true
     kind: DaemonSet
     service:
-      type: ClusterIP
+      type: LoadBalancer

--- a/tests/charts/ci/base-subPath-values.yaml
+++ b/tests/charts/ci/base-subPath-values.yaml
@@ -11,13 +11,6 @@ ingress:
           name: '{{ ternary (include "seleniumGrid.router.fullname" $ ) (include "seleniumGrid.hub.fullname" $ ) $.Values.isolateComponents }}'
           port:
             number: 4444
-    - path: /(/?)(session/.*/element)
-      pathType: ImplementationSpecific
-      backend:
-        service:
-          name: '{{ ternary (include "seleniumGrid.router.fullname" $ ) (include "seleniumGrid.hub.fullname" $ ) $.Values.isolateComponents }}'
-          port:
-            number: 4444
 
 hub:
   subPath: *gridAppRoot

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -185,6 +185,12 @@ HELM_COMMAND_SET_IMAGES=" \
 --set edgeNode.nodeMaxSessions=${MAX_SESSIONS_EDGE} \
 "
 
+if [ -n "${SET_UPDATE_STRATEGY}" ]; then
+  HELM_COMMAND_SET_IMAGES="${HELM_COMMAND_SET_IMAGES} \
+  --set global.seleniumGrid.updateStrategy.type=${SET_UPDATE_STRATEGY} \
+  "
+fi
+
 if [ -n "${TRACING_EXPORTER_ENDPOINT}" ]; then
   HELM_COMMAND_SET_IMAGES="${HELM_COMMAND_SET_IMAGES} \
   --set tracing.exporterEndpoint=\\"${TRACING_EXPORTER_ENDPOINT}\\" \

--- a/tests/charts/refValues/simplex-docker-desktop.yaml
+++ b/tests/charts/refValues/simplex-docker-desktop.yaml
@@ -1,10 +1,7 @@
-# README: This is a sample values for chart deployment in Minikube
-# Chart dependency ingress-nginx is installed together by enabling `ingress-nginx.enabled`
+# README: This is a sample values for chart deployment in K8s cluster started by Docker Desktop
+# Chart dependency ingress-nginx is installed together by enabling `ingress.enableWithController`
 # Chart dependency keda is installed together by enabling `autoscaling.enable`
-# Enabled ingress without hostname, set the subPath `/selenium`. Set K8S_PUBLIC_IP point to the public host IP, where Minikube is running
-# `ingress-nginx.controller.hostNetwork` is set to true to allow access from outside the cluster via http://<K8S_PUBLIC_IP>/selenium
-# Components serviceType is set to NodePort to allow access from outside the cluster via K8S_PUBLIC_IP and NodePort http://<K8S_PUBLIC_IP>:30444/selenium
-# Use this reference values to deploy e.g. `helm upgrade --install test --values tests/charts/refValues/simplex-minikube.yaml docker-selenium/selenium-grid --version <0.26.3_onwards>`
+# Enabled ingress without hostname, set the subPath `/selenium`. NGINX type LoadBalancer to expose access from `http://localhost/selenium`
 global:
   seleniumGrid:
     logLevel: INFO
@@ -69,7 +66,7 @@ edgeNode:
   extraEnvironmentVariables: *extraEnvironmentVariablesNodes
 
 videoRecorder:
-  enabled: false
+  enabled: true
 
 ingress-nginx:
   controller:

--- a/tests/charts/templates/test.py
+++ b/tests/charts/templates/test.py
@@ -269,10 +269,11 @@ class ChartTemplateTests(unittest.TestCase):
                     f'{RELEASE_NAME}selenium-event-bus',
                     f'{RELEASE_NAME}selenium-router',
                     f'{RELEASE_NAME}selenium-session-map',
-                    f'{RELEASE_NAME}selenium-session-queue',]
-        rolling  = [f'{RELEASE_NAME}selenium-node-chrome',
+                    f'{RELEASE_NAME}selenium-session-queue',
+                    f'{RELEASE_NAME}selenium-node-chrome',
                     f'{RELEASE_NAME}selenium-node-edge',
                     f'{RELEASE_NAME}selenium-node-firefox',]
+        rolling = []
         count_recreate = 0
         count_rolling = 0
         for doc in LIST_OF_DOCUMENTS:
@@ -282,7 +283,7 @@ class ChartTemplateTests(unittest.TestCase):
                 count_rolling += 1
             if doc['metadata']['name'] in recreate and doc['kind'] == 'Deployment':
                 logger.info(f"Assert updateStrategy is set in resource {doc['metadata']['name']}")
-                self.assertTrue(doc['spec']['strategy']['type'] == 'RollingUpdate', f"Resource {doc['metadata']['name']} doesn't have strategy RollingUpdate")
+                self.assertTrue(doc['spec']['strategy']['type'] == 'Recreate', f"Resource {doc['metadata']['name']} doesn't have strategy Recreate")
                 count_recreate += 1
         self.assertEqual(count_rolling, len(rolling), "No deployment resources found with strategy RollingUpdate")
         self.assertEqual(count_recreate, len(recreate), "No deployment resources found with strategy Recreate")


### PR DESCRIPTION
### **User description**
Grid components still not support well for RollingUpdate

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Configuration changes


___

### **Description**
- Changed default Kubernetes update strategy to `Recreate` for Selenium Grid components.

- Updated Helm chart configuration and documentation to reflect the new default strategy.

- Modified test scripts to include the `SET_UPDATE_STRATEGY` parameter for testing.

- Adjusted individual node configurations to allow overriding the global update strategy.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>chart_test.sh</strong><dd><code>Add dynamic update strategy parameter in test script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/make/chart_test.sh

<li>Added support for <code>SET_UPDATE_STRATEGY</code> parameter in Helm command.<br> <li> Ensured the update strategy can be dynamically set during tests.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2755/files#diff-811a856b3f51ff08b956e27feb70420c8a8341e610a40eecb06d30c6ffe7f9bc">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>helm-chart-test.yml</strong><dd><code>Update Helm chart test workflow for Recreate strategy</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.github/workflows/helm-chart-test.yml

<li>Included <code>SET_UPDATE_STRATEGY=Recreate</code> in the Helm chart upgrade test <br>command.<br> <li> Ensured the new update strategy is tested during CI workflows.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2755/files#diff-4a8a322b12899fb1d6c3c11d85f3f42b3486d64a25e6a3cd20e521bc94140897">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Update documentation for default Recreate update strategy</code></dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<li>Updated documentation to set <code>Recreate</code> as the default update strategy.<br> <li> Clarified that individual components can override the global strategy.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2755/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Change default update strategy to Recreate in values.yaml</code></dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Changed default update strategy from <code>RollingUpdate</code> to <code>Recreate</code>.<br> <li> Updated individual node configurations to allow nullifying the update <br>strategy.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2755/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>