### PR TITLE
Docker: Use tmux to control recording process

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -66,6 +66,7 @@ RUN apt-get -qqy update \
     libnss3-tools \
     openjdk-${JRE_VERSION}-jdk-headless \
     ca-certificates \
+    tmux \
   && rm -rf /var/lib/apt/lists/* /var/cache/apt/*
 
 #========================================

--- a/Video/video.sh
+++ b/Video/video.sh
@@ -20,6 +20,7 @@ file_ready_max_attempts=${SE_VIDEO_FILE_READY_WAIT_ATTEMPTS:-5}
 wait_uploader_shutdown_max_attempts=${SE_VIDEO_WAIT_UPLOADER_SHUTDOWN_ATTEMPTS:-5}
 ts_format=${SE_LOG_TIMESTAMP_FORMAT:-"%Y-%m-%d %H:%M:%S,%3N"}
 process_name="video.recorder"
+tmux_session_name="video_recorder"
 
 if [ "${SE_VIDEO_RECORD_STANDALONE}" = "true" ]; then
   JQ_SESSION_ID_QUERY=".value.nodes[]?.slots[]?.session?.sessionId"
@@ -140,22 +141,28 @@ function exit_on_max_session_reach() {
   fi
 }
 
-function stop_ffmpeg() {
-  while true; do
-    FFMPEG_PID=$(pgrep -f ffmpeg | tr '\n' ' ')
-    if [ -n "$FFMPEG_PID" ]; then
-      kill -SIGTERM $FFMPEG_PID
-      wait $FFMPEG_PID
-    fi
-    if ! pgrep -f ffmpeg >/dev/null; then
-      break
-    fi
-    sleep ${poll_interval}
+function stop_all_recording() {
+  current_record_sessions="$(tmux list-sessions -F "#{session_name}")"
+  echo "$(date -u +"${ts_format}") [${process_name}] - Current recording session(s): $current_record_sessions"
+  for session in $current_record_sessions; do
+    echo "Sending 'q' (quit signal) to session: $session"
+    tmux send-keys -t "$session" 'q'
+  done
+}
+
+function stop_all_recording_and_wait() {
+  stop_all_recording
+  for session in $current_record_sessions; do
+    echo "Waiting for session '$session' to finish..."
+    while tmux has-session -t "$session" 2>/dev/null; do
+      sleep 1
+    done
+    echo "Session '$session' ended."
   done
 }
 
 function stop_recording() {
-  stop_ffmpeg
+  stop_all_recording_and_wait
   echo "$(date -u +"${ts_format}") [${process_name}] - Video recording stopped"
   recorded_count=$((recorded_count + 1))
   recording_started="false"
@@ -166,12 +173,11 @@ function stop_recording() {
   elif [[ "${VIDEO_UPLOAD_ENABLED}" = "true" ]] && [[ -z "${UPLOAD_DESTINATION_PREFIX}" ]]; then
     echo "$(date -u +"${ts_format}") [${process_name}] - Upload destination not known since UPLOAD_DESTINATION_PREFIX is not set. Continue without uploading."
   fi
+  echo "$(date -u +"${ts_format}") [${process_name}] - Waiting for a while to record next coming session if any"
 }
 
-function check_if_ffmpeg_running() {
-  if pgrep -f ffmpeg >/dev/null; then
-    return 0
-  fi
+function check_if_any_session_running() {
+  tmux list-sessions -F "#{session_name}" 2>/dev/null | grep -q . && return 0
   return 1
 }
 
@@ -193,7 +199,7 @@ function wait_for_file_integrity() {
 }
 
 function stop_if_recording_inprogress() {
-  if [[ "$recording_started" = "true" ]] || check_if_ffmpeg_running; then
+  if [[ "$recording_started" = "true" ]] || check_if_any_session_running; then
     stop_recording
   fi
 }
@@ -206,7 +212,7 @@ function log_node_response() {
 
 function graceful_exit() {
   echo "$(date -u +"${ts_format}") [${process_name}] - Trapped SIGTERM/SIGINT/x so shutting down recorder"
-  stop_if_recording_inprogress
+  stop_all_recording_and_wait
   send_exit_signal_to_uploader
   wait_util_uploader_shutdown
 }
@@ -216,6 +222,12 @@ function graceful_exit_force() {
   kill -SIGTERM "$(cat ${SE_SUPERVISORD_PID_FILE})" 2>/dev/null
   echo "$(date -u +"${ts_format}") [${process_name}] - Ready to shutdown the recorder"
   exit 0
+}
+
+function get_tmux_session_unique_index() {
+  tmux_index=$(tmux list-sessions 2>/dev/null | grep -o "${tmux_session_name}:[0-9]*" | cut -d: -f2)
+  tmux_index=${tmux_index:-0}
+  tmux_index=$((tmux_index + 1))
 }
 
 if [ "${SE_RECORD_AUDIO,,}" = "true" ]; then
@@ -229,12 +241,11 @@ if [[ "${VIDEO_UPLOAD_ENABLED}" != "true" ]] && [[ "${VIDEO_FILE_NAME}" != "auto
   wait_for_display
   video_file="$VIDEO_FOLDER/$VIDEO_FILE_NAME"
   # exec replaces the video.sh process with ffmpeg, this makes easier to pass the process termination signal
-  ffmpeg -hide_banner -loglevel warning -flags low_delay -threads 2 -fflags nobuffer+genpts -strict experimental -y -f x11grab \
-    -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY} ${SE_AUDIO_SOURCE} -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p "$video_file" &
-  FFMPEG_PID=$!
-  if ps -p $FFMPEG_PID >/dev/null; then
-    wait $FFMPEG_PID
-  fi
+  get_tmux_session_unique_index
+  tmux new-session -d -s ${tmux_session_name}${tmux_index} "ffmpeg -hide_banner -loglevel warning -flags low_delay -threads 2 -fflags nobuffer+genpts -strict experimental -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY} ${SE_AUDIO_SOURCE} -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p \"$video_file\""
+  while tmux has-session -t "${tmux_session_name}${tmux_index}" 2>/dev/null; do
+    sleep 5
+  done
 
 else
   trap graceful_exit_force SIGTERM SIGINT EXIT
@@ -263,10 +274,9 @@ else
         log_node_response
         video_file="${VIDEO_FOLDER}/$video_file_name"
         echo "$(date -u +"${ts_format}") [${process_name}] - Starting to record video"
-        ffmpeg -hide_banner -loglevel warning -flags low_delay -threads 2 -fflags nobuffer+genpts -strict experimental -y -f x11grab \
-          -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY} ${SE_AUDIO_SOURCE} -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p "$video_file" &
-        FFMPEG_PID=$!
-        if ps -p $FFMPEG_PID >/dev/null; then
+        get_tmux_session_unique_index
+        tmux new-session -d -s ${tmux_session_name}${tmux_index} "ffmpeg -hide_banner -loglevel warning -flags low_delay -threads 2 -fflags nobuffer+genpts -strict experimental -y -f x11grab -video_size ${VIDEO_SIZE} -r ${FRAME_RATE} -i ${DISPLAY} ${SE_AUDIO_SOURCE} -codec:v ${CODEC} ${PRESET} -pix_fmt yuv420p \"$video_file\""
+        if tmux has-session -t ${tmux_session_name}${tmux_index} 2>/dev/null; then
           recording_started="true"
           prev_session_id=$session_id
         fi


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Refactored video recording process to use tmux for session control

- Improved stopping and management of multiple recording sessions

- Added tmux installation to Docker image dependencies

- Enhanced process shutdown and session uniqueness logic


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>video.sh</strong><dd><code>Refactor recording control to use tmux sessions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Video/video.sh

<li>Replaced direct ffmpeg process management with tmux-based session <br>control<br> <li> Added functions to stop, wait for, and check tmux recording sessions<br> <li> Improved shutdown logic to handle all tmux sessions gracefully<br> <li> Introduced unique tmux session naming for concurrent recordings<br> <li> Updated recording start logic to launch ffmpeg in tmux sessions


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2796/files#diff-7cd0ffe6390f76d290d88e6e4e3c360e9a797096c0b0fb76874303c5ca319f4b">+33/-22</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Dependencies</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add tmux to Docker image dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Base/Dockerfile

- Added tmux to the list of installed packages for the base image


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2796/files#diff-c7235ebbda8248c044e6b13da481ae97f4a21846ed2341a056b6b873abaa482b">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>