### PR TITLE
Docker: Remove Hub GraphQL dependency from video recorder

### DIFF
--- a/Video/video_nodeQuery.sh
+++ b/Video/video_nodeQuery.sh
@@ -1,0 +1,49 @@
+#!/usr/bin/env bash
+
+# Define parameters
+SESSION_ID=$1
+SESSION_CAPABILITIES=$2
+
+VIDEO_CAP_NAME=${VIDEO_CAP_NAME:-"se:recordVideo"}
+TEST_NAME_CAP=${TEST_NAME_CAP:-"se:name"}
+VIDEO_NAME_CAP=${VIDEO_NAME_CAP:-"se:videoName"}
+VIDEO_FILE_NAME_TRIM=${SE_VIDEO_FILE_NAME_TRIM_REGEX:-"[:alnum:]-_"}
+VIDEO_FILE_NAME_SUFFIX=${SE_VIDEO_FILE_NAME_SUFFIX:-"true"}
+
+if [ -n "${SESSION_CAPABILITIES}" ]; then
+  # Extract the values from the response
+  RECORD_VIDEO=$(jq -r '."'${VIDEO_CAP_NAME}'"' <<<"${SESSION_CAPABILITIES}")
+  TEST_NAME=$(jq -r '."'${TEST_NAME_CAP}'"' <<<"${SESSION_CAPABILITIES}")
+  VIDEO_NAME=$(jq -r '."'${VIDEO_NAME_CAP}'"' <<<"${SESSION_CAPABILITIES}")
+fi
+
+# Check if enabling to record video
+if [ "${RECORD_VIDEO,,}" = "false" ]; then
+  RECORD_VIDEO=false
+else
+  RECORD_VIDEO=true
+fi
+
+# Check if video file name is set via capabilities
+if [ "${VIDEO_NAME}" != "null" ] && [ -n "${VIDEO_NAME}" ]; then
+  TEST_NAME="${VIDEO_NAME}"
+elif [ "${TEST_NAME}" != "null" ] && [ -n "${TEST_NAME}" ]; then
+  TEST_NAME="${TEST_NAME}"
+else
+  TEST_NAME=""
+fi
+
+# Check if append session ID to the video file name suffix
+if [ -z "${TEST_NAME}" ]; then
+  TEST_NAME="${SESSION_ID}"
+elif [ "${VIDEO_FILE_NAME_SUFFIX,,}" = "true" ]; then
+  TEST_NAME="${TEST_NAME}_${SESSION_ID}"
+fi
+
+# Normalize the video file name
+TEST_NAME="$(echo "${TEST_NAME}" | tr ' ' '_' | tr -dc "${VIDEO_FILE_NAME_TRIM}" | cut -c 1-251)"
+
+return_array=("${RECORD_VIDEO}" "${TEST_NAME}")
+
+# stdout the values for other scripts consuming
+echo "${return_array[@]}"


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
After the fix [java] Add "se" prefixed capabilities to session response (https://github.com/SeleniumHQ/selenium/pull/14323) available from version 4.24+
All capabilities with prefix `se:` could be seen in Node `/status` session capabilities.
Video recorder to get file name via cap `se:name`, or `se:videoName` no need to extract from Hub GraphQL anymore.
Container video recorder also no need to pass ENV variable of Hub GraphQL anymore.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Remove Hub GraphQL dependency from video recorder logic
  - Use session capabilities from Node `/status` endpoint
  - Eliminate need for Hub GraphQL ENV variable

- Add new script to extract video recording info from capabilities
  - Determine video file name and recording flag from session capabilities


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>video.sh</strong><dd><code>Refactor video recorder to use Node session capabilities</code>&nbsp; </dd></summary>
<hr>

Video/video.sh

<li>Refactored to fetch session info from Node <code>/status</code> endpoint, not <br>GraphQL<br> <li> Added logic to extract video recording info from session capabilities<br> <li> Removed all Hub GraphQL endpoint and ENV variable usage<br> <li> Integrated new script for video file name and recording flag <br>extraction


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2813/files#diff-7cd0ffe6390f76d290d88e6e4e3c360e9a797096c0b0fb76874303c5ca319f4b">+12/-13</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>video_nodeQuery.sh</strong><dd><code>Add script to parse video recording info from capabilities</code></dd></summary>
<hr>

Video/video_nodeQuery.sh

<li>New script to extract video recording flag and file name from session <br>capabilities<br> <li> Determines file name based on <code>se:name</code> or <code>se:videoName</code> capabilities<br> <li> Normalizes and formats the video file name<br> <li> Outputs recording flag and file name for use by other scripts


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2813/files#diff-aa41f53619b1f2703130233c75ad0040fd0d7f7ae8b4cce01339ce9c7403933e">+49/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>