### PR TITLE
Docs: Add note for Chrome 132+ regarding headless mode changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -1268,6 +1268,7 @@ For more information, see this GitHub [issue](https://github.com/SeleniumHQ/dock
 
 Noted:
 - In new Chrome/Chromium versions (v127+), `SE_START_XVFB` is required to be set to `true` to run in `--headless=new` mode.
+- In new Chrome/Chromium versions (v132+), `--headless` only runs in the [`new` mode](https://developer.chrome.com/blog/removing-headless-old-from-chrome), so you need to set `SE_START_XVFB` to `true` when using `--headless` mode.
 
 ### Stopping the Node/Standalone after N sessions have been executed
 


### PR DESCRIPTION
### **User description**
### Description
This PR completes the existing notes, with the addition of Chrome v132+ that completely removes the old behaviour, meaning that you *need* to have `SE_START_XVFB=true` when running headless.

### Motivation and Context
While trying recent versions of Docker Selenium, I noticed an issue with `--headless` and `SE_START_XVFB`.

### Types of changes
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.


___

### **PR Type**
Documentation


___

### **Description**
- Added documentation note for Chrome 132+ headless mode changes

- Clarified requirement for `SE_START_XVFB=true` with new headless mode


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add Chrome 132+ headless mode and XVFB documentation note</code></dd></summary>
<hr>

README.md

<li>Added note about Chrome/Chromium v132+ headless mode behavior<br> <li> Explained necessity of <code>SE_START_XVFB=true</code> for headless mode in v132+


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2832/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>