### PR TITLE
K8s: Node enable readiness probe checks status registered to Hub

### DIFF
--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -38,6 +38,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | global.seleniumGrid.imagePullSecret | string | `""` | Pull secret for all components, can be overridden individually |
 | global.seleniumGrid.logLevel | string | `"INFO"` | Log level for all components. Possible values describe here: https://www.selenium.dev/documentation/grid/configuration/cli_options/#logging |
 | global.seleniumGrid.defaultNodeStartupProbe | string | `"exec"` | Set default startup probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet |
+| global.seleniumGrid.defaultNodeReadinessProbe | string | `"exec"` | Set default readiness probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet |
 | global.seleniumGrid.defaultNodeLivenessProbe | string | `"exec"` | Set default readiness probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet |
 | global.seleniumGrid.defaultComponentLivenessProbe | string | `"exec"` | Set default liveness probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet |
 | global.seleniumGrid.stdoutProbeLog | bool | `false` | Probe logs output can be retrieved using `kubectl logs`. Noted: this will not work if shareProcessNamespace is enabled |
@@ -147,6 +148,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | nodeConfigMap.extraScripts."nodeGridUrl.sh" | string | `""` |  |
 | nodeConfigMap.extraScripts."nodePreStop.sh" | string | `""` |  |
 | nodeConfigMap.extraScripts."nodeProbe.sh" | string | `""` |  |
+| nodeConfigMap.extraScripts."nodeProbeReadiness.sh" | string | `""` |  |
 | nodeConfigMap.scriptVolumeMountName | string | `nil` | Name of volume mount is used to mount scripts in the ConfigMap |
 | nodeConfigMap.leftoversCleanup.enabled | bool | `false` | Enable feature automatic browser leftovers cleanup stuck browser processes, tmp files |
 | nodeConfigMap.leftoversCleanup.jobIntervalInSecs | int | `3600` | Interval in seconds to run the cleanup job |
@@ -454,7 +456,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | chromeNode.dshmVolumeSizeLimit | string | `""` | Size limit for DSH volume mounted in container (if not set, default is disabled, e.g "1Gi") |
 | chromeNode.priorityClassName | string | `""` | Priority class name for chrome-node pods |
 | chromeNode.startupProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":0,"path":"/status","periodSeconds":5,"successThreshold":1,"timeoutSeconds":60}` | Startup probe settings |
-| chromeNode.readinessProbe | object | `{"enabled":false,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
+| chromeNode.readinessProbe | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
 | chromeNode.livenessProbe | object | `{"enabled":false,"failureThreshold":6,"initialDelaySeconds":30,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":60}` | Liveness probe settings |
 | chromeNode.terminationGracePeriodSeconds | int | `30` | Time to wait for pod termination |
 | chromeNode.deregisterLifecycle | string | `nil` | Define preStop command to shut down the chrome node gracefully. This overwrites autoscaling.deregisterLifecycle |
@@ -512,7 +514,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | firefoxNode.dshmVolumeSizeLimit | string | `"2Gi"` | Size limit for DSH volume mounted in container (if not set, default is disabled, e.g "1Gi") |
 | firefoxNode.priorityClassName | string | `""` | Priority class name for firefox-node pods |
 | firefoxNode.startupProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":0,"path":"/status","periodSeconds":5,"successThreshold":1,"timeoutSeconds":60}` | Startup probe settings |
-| firefoxNode.readinessProbe | object | `{"enabled":false,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
+| firefoxNode.readinessProbe | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
 | firefoxNode.livenessProbe | object | `{"enabled":false,"failureThreshold":6,"initialDelaySeconds":30,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":60}` | Liveness probe settings |
 | firefoxNode.terminationGracePeriodSeconds | int | `30` | Time to wait for pod termination |
 | firefoxNode.deregisterLifecycle | string | `nil` | Define preStop command to shuts down the chrome node gracefully. This overwrites autoscaling.deregisterLifecycle |
@@ -570,7 +572,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | edgeNode.dshmVolumeSizeLimit | string | `""` | Size limit for DSH volume mounted in container (if not set, default is disabled, e.g "1Gi") |
 | edgeNode.priorityClassName | string | `""` | Priority class name for edge-node pods |
 | edgeNode.startupProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":0,"path":"/status","periodSeconds":5,"successThreshold":1,"timeoutSeconds":60}` | Startup probe settings |
-| edgeNode.readinessProbe | object | `{"enabled":false,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
+| edgeNode.readinessProbe | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
 | edgeNode.livenessProbe | object | `{"enabled":false,"failureThreshold":6,"initialDelaySeconds":30,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":60}` | Liveness probe settings |
 | edgeNode.terminationGracePeriodSeconds | int | `30` | Time to wait for pod termination |
 | edgeNode.deregisterLifecycle | string | `nil` | Define preStop command to shuts down the chrome node gracefully. This overwrites autoscaling.deregisterLifecycle |
@@ -629,7 +631,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | relayNode.dshmVolumeSizeLimit | string | `""` | Size limit for DSH volume mounted in container (if not set, default is disabled, e.g "1Gi") |
 | relayNode.priorityClassName | string | `""` | Priority class name for relay-node pods |
 | relayNode.startupProbe | object | `{"enabled":true,"failureThreshold":12,"initialDelaySeconds":0,"path":"/status","periodSeconds":5,"successThreshold":1,"timeoutSeconds":60}` | Startup probe settings |
-| relayNode.readinessProbe | object | `{"enabled":false,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
+| relayNode.readinessProbe | object | `{"enabled":true,"failureThreshold":10,"initialDelaySeconds":10,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":10}` | Readiness probe settings |
 | relayNode.livenessProbe | object | `{"enabled":false,"failureThreshold":6,"initialDelaySeconds":30,"path":"/status","periodSeconds":10,"successThreshold":1,"timeoutSeconds":60}` | Liveness probe settings |
 | relayNode.terminationGracePeriodSeconds | int | `30` | Time to wait for pod termination |
 | relayNode.deregisterLifecycle | string | `nil` | Define preStop command to shut down the relay node gracefully. This overwrites autoscaling.deregisterLifecycle |

--- a/charts/selenium-grid/configs/node/nodeProbeReadiness.sh
+++ b/charts/selenium-grid/configs/node/nodeProbeReadiness.sh
@@ -1,0 +1,16 @@
+#!/usr/bin/env bash
+
+probe_name="Probe.${1:-"Readiness"}"
+ts_format=${SE_LOG_TIMESTAMP_FORMAT:-"%Y-%m-%d %H:%M:%S,%3N"}
+ENDPOINT="${SE_SERVER_PROTOCOL:-"http"}://localhost:${SE_NODE_PORT:-"5555"}/status"
+
+response=$(curl -skSL --noproxy "*" "${ENDPOINT}")
+
+# Validate the JSON response
+# From v4.31.0 - [grid] Expose register status via Node status response (#15448)
+if echo "$response" | jq -e '.value.registered == true' > /dev/null; then
+  echo "$(date -u +"${ts_format}") [${probe_name}] - Readiness check passed: Node is registered."
+else
+  echo "$(date -u +"${ts_format}") [${probe_name}] - Readiness check failed: Node is not registered."
+  exit 1
+fi

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -491,7 +491,10 @@ template:
       {{- with .node.readinessProbe }}
         readinessProbe:
         {{- if (ne (include "seleniumGrid.probe.fromUserDefine" (dict "values" . "root" $)) "{}") }}
-          {{- include "seleniumGrid.probe.fromUserDefine" (dict "values" . "root" $) | nindent 12 }}
+          {{- include "seleniumGrid.probe.fromUserDefine" (dict "values" . "root" $) | nindent 10 }}
+        {{- else if eq $.Values.global.seleniumGrid.defaultNodeReadinessProbe "exec" }}
+          exec:
+            command: ["bash", "-c", "{{ $.Values.nodeConfigMap.extraScriptsDirectory }}/nodeProbeReadiness.sh Readiness {{ include "seleniumGrid.probe.stdout" $ }}"]
         {{- else }}
           httpGet:
             scheme: {{ default (include "seleniumGrid.probe.httpGet.schema" $) .schema }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -21,6 +21,8 @@ global:
     # -- Set default startup probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet
     defaultNodeStartupProbe: exec
     # -- Set default readiness probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet
+    defaultNodeReadinessProbe: exec
+    # -- Set default readiness probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet
     defaultNodeLivenessProbe: exec
     # -- Set default liveness probe method for all nodes (supplied values: httpGet, exec). If not set, the default is httpGet
     defaultComponentLivenessProbe: exec
@@ -328,6 +330,8 @@ nodeConfigMap:
     nodePreStop.sh: ""
     # -- Key to set contents for script file via --set-file
     nodeProbe.sh: ""
+    # -- Key to set contents for script file via --set-file
+    nodeProbeReadiness.sh: ""
   # -- Name of volume mount is used to mount scripts in the ConfigMap
   scriptVolumeMountName:
   leftoversCleanup:
@@ -1235,7 +1239,7 @@ chromeNode:
 
   # -- Readiness probe settings
   readinessProbe:
-    enabled: false
+    enabled: true
     path: /status
     initialDelaySeconds: 10
     failureThreshold: 10
@@ -1431,7 +1435,7 @@ firefoxNode:
 
   # -- Readiness probe settings
   readinessProbe:
-    enabled: false
+    enabled: true
     path: /status
     initialDelaySeconds: 10
     failureThreshold: 10
@@ -1627,7 +1631,7 @@ edgeNode:
 
   # -- Readiness probe settings
   readinessProbe:
-    enabled: false
+    enabled: true
     path: /status
     initialDelaySeconds: 10
     failureThreshold: 10
@@ -1824,7 +1828,7 @@ relayNode:
 
   # -- Readiness probe settings
   readinessProbe:
-    enabled: false
+    enabled: true
     path: /status
     initialDelaySeconds: 10
     failureThreshold: 10


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
From v4.31.0 - [grid] Expose register status via Node status response (https://github.com/SeleniumHQ/selenium/pull/15448)
By default, enable readiness probe checks in the Node listen on value `true/false` of `$.value.registered`

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement, Documentation


___

### **Description**
- Introduced readiness probe script to check node registration status.
  - Adds `nodeProbeReadiness.sh` for readiness checks via `/status` endpoint.
  - Uses `.value.registered` from node status for probe success.

- Enabled readiness probes by default for all node types.
  - Updates readinessProbe.enabled to true for chrome, firefox, edge, and relay nodes.

- Enhanced Helm chart to support exec-based readiness probes.
  - Adds `defaultNodeReadinessProbe` and script wiring in templates.

- Updated documentation for new readiness probe settings.
  - Documents new values and script options in CONFIGURATION.md.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>nodeProbeReadiness.sh</strong><dd><code>Add readiness probe script for node registration status</code>&nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/configs/node/nodeProbeReadiness.sh

<li>Adds new bash script for readiness probe.<br> <li> Checks node registration via <code>/status</code> endpoint.<br> <li> Exits with failure if node is not registered.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2833/files#diff-cac8b4e86a6b447f20e0b8b8fb4287ad0004b5622bc8eab1151bceaf92526097">+16/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>_helpers.tpl</strong><dd><code>Integrate exec-based readiness probe into Helm templates</code>&nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/_helpers.tpl

<li>Updates readinessProbe logic to support exec-based probe.<br> <li> Integrates <code>nodeProbeReadiness.sh</code> script for readiness checks.<br> <li> Adjusts indentation for probe configuration.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2833/files#diff-a57e8d3d1ad8ed854bf7e00ac004560f3dfe6d1178d5c5d45e455f8eaeb53361">+4/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Enable and configure readiness probes in values.yaml</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<li>Sets <code>defaultNodeReadinessProbe</code> to exec by default.<br> <li> Enables readinessProbe for chrome, firefox, edge, and relay nodes.<br> <li> Adds <code>nodeProbeReadiness.sh</code> to extraScripts.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2833/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+8/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Update documentation for readiness probe enhancements</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<li>Documents new <code>defaultNodeReadinessProbe</code> setting.<br> <li> Adds <code>nodeProbeReadiness.sh</code> to extraScripts documentation.<br> <li> Updates readinessProbe defaults for all node types to enabled.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2833/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+6/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>