### PR TITLE
[ci] CHANGELOG for Node/Standalone chrome browser versions with Grid 4.32.0

### DIFF
--- a/CHANGELOG/4.32.0/chrome_101.md
+++ b/CHANGELOG/4.32.0/chrome_101.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 101.0.4951.64
 Short Chrome version -> 101.0
 ChromeDriver version -> 101.0.4951.41
 Short ChromeDriver version -> 101.0
-Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.32.0-20250505
-Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250505
-Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250505
-Tagged selenium/node-chrome:101.0.4951.64-20250505
-Tagged selenium/standalone-chrome:101.0.4951.64-20250505
-Tagged selenium/node-chrome:101.0-chromedriver-101.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:101.0-chromedriver-101.0-20250505
-Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-20250505
-Tagged selenium/node-chrome:101.0-20250505
-Tagged selenium/standalone-chrome:101.0-20250505
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.32.0-20250515
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250515
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250515
+Tagged selenium/node-chrome:101.0.4951.64-20250515
+Tagged selenium/standalone-chrome:101.0.4951.64-20250515
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-20250515
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-20250515
+Tagged selenium/node-chrome:101.0-20250515
+Tagged selenium/standalone-chrome:101.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_102.md
+++ b/CHANGELOG/4.32.0/chrome_102.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 102.0.5005.115
 Short Chrome version -> 102.0
 ChromeDriver version -> 102.0.5005.61
 Short ChromeDriver version -> 102.0
-Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.32.0-20250505
-Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250505
-Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250505
-Tagged selenium/node-chrome:102.0.5005.115-20250505
-Tagged selenium/standalone-chrome:102.0.5005.115-20250505
-Tagged selenium/node-chrome:102.0-chromedriver-102.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:102.0-chromedriver-102.0-20250505
-Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-20250505
-Tagged selenium/node-chrome:102.0-20250505
-Tagged selenium/standalone-chrome:102.0-20250505
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.32.0-20250515
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250515
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250515
+Tagged selenium/node-chrome:102.0.5005.115-20250515
+Tagged selenium/standalone-chrome:102.0.5005.115-20250515
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-20250515
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-20250515
+Tagged selenium/node-chrome:102.0-20250515
+Tagged selenium/standalone-chrome:102.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_103.md
+++ b/CHANGELOG/4.32.0/chrome_103.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
+Chrome version -> 103.0.5060.134
+Short Chrome version -> 103.0
+ChromeDriver version -> 103.0.5060.134
+Short ChromeDriver version -> 103.0
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.32.0-20250515
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250515
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250515
+Tagged selenium/node-chrome:103.0.5060.134-20250515
+Tagged selenium/standalone-chrome:103.0.5060.134-20250515
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-20250515
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-20250515
+Tagged selenium/node-chrome:103.0-20250515
+Tagged selenium/standalone-chrome:103.0-20250515
+```

--- a/CHANGELOG/4.32.0/chrome_104.md
+++ b/CHANGELOG/4.32.0/chrome_104.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 104.0.5112.101
 Short Chrome version -> 104.0
 ChromeDriver version -> 104.0.5112.79
 Short ChromeDriver version -> 104.0
-Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.32.0-20250505
-Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250505
-Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250505
-Tagged selenium/node-chrome:104.0.5112.101-20250505
-Tagged selenium/standalone-chrome:104.0.5112.101-20250505
-Tagged selenium/node-chrome:104.0-chromedriver-104.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:104.0-chromedriver-104.0-20250505
-Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-20250505
-Tagged selenium/node-chrome:104.0-20250505
-Tagged selenium/standalone-chrome:104.0-20250505
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.32.0-20250515
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250515
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250515
+Tagged selenium/node-chrome:104.0.5112.101-20250515
+Tagged selenium/standalone-chrome:104.0.5112.101-20250515
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-20250515
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-20250515
+Tagged selenium/node-chrome:104.0-20250515
+Tagged selenium/standalone-chrome:104.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_105.md
+++ b/CHANGELOG/4.32.0/chrome_105.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 105.0.5195.125
 Short Chrome version -> 105.0
 ChromeDriver version -> 105.0.5195.52
 Short ChromeDriver version -> 105.0
-Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.32.0-20250505
-Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250505
-Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250505
-Tagged selenium/node-chrome:105.0.5195.125-20250505
-Tagged selenium/standalone-chrome:105.0.5195.125-20250505
-Tagged selenium/node-chrome:105.0-chromedriver-105.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:105.0-chromedriver-105.0-20250505
-Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-20250505
-Tagged selenium/node-chrome:105.0-20250505
-Tagged selenium/standalone-chrome:105.0-20250505
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.32.0-20250515
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250515
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250515
+Tagged selenium/node-chrome:105.0.5195.125-20250515
+Tagged selenium/standalone-chrome:105.0.5195.125-20250515
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-20250515
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-20250515
+Tagged selenium/node-chrome:105.0-20250515
+Tagged selenium/standalone-chrome:105.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_106.md
+++ b/CHANGELOG/4.32.0/chrome_106.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 106.0.5249.119
 Short Chrome version -> 106.0
 ChromeDriver version -> 106.0.5249.61
 Short ChromeDriver version -> 106.0
-Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.32.0-20250505
-Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250505
-Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250505
-Tagged selenium/node-chrome:106.0.5249.119-20250505
-Tagged selenium/standalone-chrome:106.0.5249.119-20250505
-Tagged selenium/node-chrome:106.0-chromedriver-106.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:106.0-chromedriver-106.0-20250505
-Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-20250505
-Tagged selenium/node-chrome:106.0-20250505
-Tagged selenium/standalone-chrome:106.0-20250505
+Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-grid-4.32.0-20250515
+Tagged selenium/node-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250515
+Tagged selenium/standalone-chrome:106.0.5249.119-chromedriver-106.0.5249.61-20250515
+Tagged selenium/node-chrome:106.0.5249.119-20250515
+Tagged selenium/standalone-chrome:106.0.5249.119-20250515
+Tagged selenium/node-chrome:106.0-chromedriver-106.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:106.0-chromedriver-106.0-20250515
+Tagged selenium/standalone-chrome:106.0-chromedriver-106.0-20250515
+Tagged selenium/node-chrome:106.0-20250515
+Tagged selenium/standalone-chrome:106.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_107.md
+++ b/CHANGELOG/4.32.0/chrome_107.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 107.0.5304.121
 Short Chrome version -> 107.0
 ChromeDriver version -> 107.0.5304.62
 Short ChromeDriver version -> 107.0
-Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.32.0-20250505
-Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250505
-Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250505
-Tagged selenium/node-chrome:107.0.5304.121-20250505
-Tagged selenium/standalone-chrome:107.0.5304.121-20250505
-Tagged selenium/node-chrome:107.0-chromedriver-107.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:107.0-chromedriver-107.0-20250505
-Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-20250505
-Tagged selenium/node-chrome:107.0-20250505
-Tagged selenium/standalone-chrome:107.0-20250505
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.32.0-20250515
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250515
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250515
+Tagged selenium/node-chrome:107.0.5304.121-20250515
+Tagged selenium/standalone-chrome:107.0.5304.121-20250515
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-20250515
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-20250515
+Tagged selenium/node-chrome:107.0-20250515
+Tagged selenium/standalone-chrome:107.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_108.md
+++ b/CHANGELOG/4.32.0/chrome_108.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 108.0.5359.124
 Short Chrome version -> 108.0
 ChromeDriver version -> 108.0.5359.71
 Short ChromeDriver version -> 108.0
-Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.32.0-20250505
-Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250505
-Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250505
-Tagged selenium/node-chrome:108.0.5359.124-20250505
-Tagged selenium/standalone-chrome:108.0.5359.124-20250505
-Tagged selenium/node-chrome:108.0-chromedriver-108.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:108.0-chromedriver-108.0-20250505
-Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-20250505
-Tagged selenium/node-chrome:108.0-20250505
-Tagged selenium/standalone-chrome:108.0-20250505
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.32.0-20250515
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250515
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250515
+Tagged selenium/node-chrome:108.0.5359.124-20250515
+Tagged selenium/standalone-chrome:108.0.5359.124-20250515
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-20250515
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-20250515
+Tagged selenium/node-chrome:108.0-20250515
+Tagged selenium/standalone-chrome:108.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_109.md
+++ b/CHANGELOG/4.32.0/chrome_109.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 109.0.5414.119
 Short Chrome version -> 109.0
 ChromeDriver version -> 109.0.5414.74
 Short ChromeDriver version -> 109.0
-Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.32.0-20250505
-Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250505
-Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250505
-Tagged selenium/node-chrome:109.0.5414.119-20250505
-Tagged selenium/standalone-chrome:109.0.5414.119-20250505
-Tagged selenium/node-chrome:109.0-chromedriver-109.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:109.0-chromedriver-109.0-20250505
-Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-20250505
-Tagged selenium/node-chrome:109.0-20250505
-Tagged selenium/standalone-chrome:109.0-20250505
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.32.0-20250515
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250515
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250515
+Tagged selenium/node-chrome:109.0.5414.119-20250515
+Tagged selenium/standalone-chrome:109.0.5414.119-20250515
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-20250515
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-20250515
+Tagged selenium/node-chrome:109.0-20250515
+Tagged selenium/standalone-chrome:109.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_110.md
+++ b/CHANGELOG/4.32.0/chrome_110.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 110.0.5481.177
 Short Chrome version -> 110.0
 ChromeDriver version -> 110.0.5481.77
 Short ChromeDriver version -> 110.0
-Tagged selenium/node-chrome:110.0.5481.177-chromedriver-110.0.5481.77-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77-grid-4.32.0-20250505
-Tagged selenium/node-chrome:110.0.5481.177-chromedriver-110.0.5481.77-20250505
-Tagged selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77-20250505
-Tagged selenium/node-chrome:110.0.5481.177-20250505
-Tagged selenium/standalone-chrome:110.0.5481.177-20250505
-Tagged selenium/node-chrome:110.0-chromedriver-110.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:110.0-chromedriver-110.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:110.0-chromedriver-110.0-20250505
-Tagged selenium/standalone-chrome:110.0-chromedriver-110.0-20250505
-Tagged selenium/node-chrome:110.0-20250505
-Tagged selenium/standalone-chrome:110.0-20250505
+Tagged selenium/node-chrome:110.0.5481.177-chromedriver-110.0.5481.77-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77-grid-4.32.0-20250515
+Tagged selenium/node-chrome:110.0.5481.177-chromedriver-110.0.5481.77-20250515
+Tagged selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77-20250515
+Tagged selenium/node-chrome:110.0.5481.177-20250515
+Tagged selenium/standalone-chrome:110.0.5481.177-20250515
+Tagged selenium/node-chrome:110.0-chromedriver-110.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:110.0-chromedriver-110.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:110.0-chromedriver-110.0-20250515
+Tagged selenium/standalone-chrome:110.0-chromedriver-110.0-20250515
+Tagged selenium/node-chrome:110.0-20250515
+Tagged selenium/standalone-chrome:110.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_111.md
+++ b/CHANGELOG/4.32.0/chrome_111.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 111.0.5563.146
 Short Chrome version -> 111.0
 ChromeDriver version -> 111.0.5563.64
 Short ChromeDriver version -> 111.0
-Tagged selenium/node-chrome:111.0.5563.146-chromedriver-111.0.5563.64-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:111.0.5563.146-chromedriver-111.0.5563.64-grid-4.32.0-20250505
-Tagged selenium/node-chrome:111.0.5563.146-chromedriver-111.0.5563.64-20250505
-Tagged selenium/standalone-chrome:111.0.5563.146-chromedriver-111.0.5563.64-20250505
-Tagged selenium/node-chrome:111.0.5563.146-20250505
-Tagged selenium/standalone-chrome:111.0.5563.146-20250505
-Tagged selenium/node-chrome:111.0-chromedriver-111.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:111.0-chromedriver-111.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:111.0-chromedriver-111.0-20250505
-Tagged selenium/standalone-chrome:111.0-chromedriver-111.0-20250505
-Tagged selenium/node-chrome:111.0-20250505
-Tagged selenium/standalone-chrome:111.0-20250505
+Tagged selenium/node-chrome:111.0.5563.146-chromedriver-111.0.5563.64-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:111.0.5563.146-chromedriver-111.0.5563.64-grid-4.32.0-20250515
+Tagged selenium/node-chrome:111.0.5563.146-chromedriver-111.0.5563.64-20250515
+Tagged selenium/standalone-chrome:111.0.5563.146-chromedriver-111.0.5563.64-20250515
+Tagged selenium/node-chrome:111.0.5563.146-20250515
+Tagged selenium/standalone-chrome:111.0.5563.146-20250515
+Tagged selenium/node-chrome:111.0-chromedriver-111.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:111.0-chromedriver-111.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:111.0-chromedriver-111.0-20250515
+Tagged selenium/standalone-chrome:111.0-chromedriver-111.0-20250515
+Tagged selenium/node-chrome:111.0-20250515
+Tagged selenium/standalone-chrome:111.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_112.md
+++ b/CHANGELOG/4.32.0/chrome_112.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 112.0.5615.165
 Short Chrome version -> 112.0
 ChromeDriver version -> 112.0.5615.49
 Short ChromeDriver version -> 112.0
-Tagged selenium/node-chrome:112.0.5615.165-chromedriver-112.0.5615.49-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:112.0.5615.165-chromedriver-112.0.5615.49-grid-4.32.0-20250505
-Tagged selenium/node-chrome:112.0.5615.165-chromedriver-112.0.5615.49-20250505
-Tagged selenium/standalone-chrome:112.0.5615.165-chromedriver-112.0.5615.49-20250505
-Tagged selenium/node-chrome:112.0.5615.165-20250505
-Tagged selenium/standalone-chrome:112.0.5615.165-20250505
-Tagged selenium/node-chrome:112.0-chromedriver-112.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:112.0-chromedriver-112.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:112.0-chromedriver-112.0-20250505
-Tagged selenium/standalone-chrome:112.0-chromedriver-112.0-20250505
-Tagged selenium/node-chrome:112.0-20250505
-Tagged selenium/standalone-chrome:112.0-20250505
+Tagged selenium/node-chrome:112.0.5615.165-chromedriver-112.0.5615.49-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:112.0.5615.165-chromedriver-112.0.5615.49-grid-4.32.0-20250515
+Tagged selenium/node-chrome:112.0.5615.165-chromedriver-112.0.5615.49-20250515
+Tagged selenium/standalone-chrome:112.0.5615.165-chromedriver-112.0.5615.49-20250515
+Tagged selenium/node-chrome:112.0.5615.165-20250515
+Tagged selenium/standalone-chrome:112.0.5615.165-20250515
+Tagged selenium/node-chrome:112.0-chromedriver-112.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:112.0-chromedriver-112.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:112.0-chromedriver-112.0-20250515
+Tagged selenium/standalone-chrome:112.0-chromedriver-112.0-20250515
+Tagged selenium/node-chrome:112.0-20250515
+Tagged selenium/standalone-chrome:112.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_113.md
+++ b/CHANGELOG/4.32.0/chrome_113.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 113.0.5672.126
 Short Chrome version -> 113.0
 ChromeDriver version -> 113.0.5672.63
 Short ChromeDriver version -> 113.0
-Tagged selenium/node-chrome:113.0.5672.126-chromedriver-113.0.5672.63-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:113.0.5672.126-chromedriver-113.0.5672.63-grid-4.32.0-20250505
-Tagged selenium/node-chrome:113.0.5672.126-chromedriver-113.0.5672.63-20250505
-Tagged selenium/standalone-chrome:113.0.5672.126-chromedriver-113.0.5672.63-20250505
-Tagged selenium/node-chrome:113.0.5672.126-20250505
-Tagged selenium/standalone-chrome:113.0.5672.126-20250505
-Tagged selenium/node-chrome:113.0-chromedriver-113.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:113.0-chromedriver-113.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:113.0-chromedriver-113.0-20250505
-Tagged selenium/standalone-chrome:113.0-chromedriver-113.0-20250505
-Tagged selenium/node-chrome:113.0-20250505
-Tagged selenium/standalone-chrome:113.0-20250505
+Tagged selenium/node-chrome:113.0.5672.126-chromedriver-113.0.5672.63-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:113.0.5672.126-chromedriver-113.0.5672.63-grid-4.32.0-20250515
+Tagged selenium/node-chrome:113.0.5672.126-chromedriver-113.0.5672.63-20250515
+Tagged selenium/standalone-chrome:113.0.5672.126-chromedriver-113.0.5672.63-20250515
+Tagged selenium/node-chrome:113.0.5672.126-20250515
+Tagged selenium/standalone-chrome:113.0.5672.126-20250515
+Tagged selenium/node-chrome:113.0-chromedriver-113.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:113.0-chromedriver-113.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:113.0-chromedriver-113.0-20250515
+Tagged selenium/standalone-chrome:113.0-chromedriver-113.0-20250515
+Tagged selenium/node-chrome:113.0-20250515
+Tagged selenium/standalone-chrome:113.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_114.md
+++ b/CHANGELOG/4.32.0/chrome_114.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 114.0.5735.198
 Short Chrome version -> 114.0
 ChromeDriver version -> 114.0.5735.90
 Short ChromeDriver version -> 114.0
-Tagged selenium/node-chrome:114.0.5735.198-chromedriver-114.0.5735.90-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:114.0.5735.198-chromedriver-114.0.5735.90-grid-4.32.0-20250505
-Tagged selenium/node-chrome:114.0.5735.198-chromedriver-114.0.5735.90-20250505
-Tagged selenium/standalone-chrome:114.0.5735.198-chromedriver-114.0.5735.90-20250505
-Tagged selenium/node-chrome:114.0.5735.198-20250505
-Tagged selenium/standalone-chrome:114.0.5735.198-20250505
-Tagged selenium/node-chrome:114.0-chromedriver-114.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:114.0-chromedriver-114.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:114.0-chromedriver-114.0-20250505
-Tagged selenium/standalone-chrome:114.0-chromedriver-114.0-20250505
-Tagged selenium/node-chrome:114.0-20250505
-Tagged selenium/standalone-chrome:114.0-20250505
+Tagged selenium/node-chrome:114.0.5735.198-chromedriver-114.0.5735.90-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:114.0.5735.198-chromedriver-114.0.5735.90-grid-4.32.0-20250515
+Tagged selenium/node-chrome:114.0.5735.198-chromedriver-114.0.5735.90-20250515
+Tagged selenium/standalone-chrome:114.0.5735.198-chromedriver-114.0.5735.90-20250515
+Tagged selenium/node-chrome:114.0.5735.198-20250515
+Tagged selenium/standalone-chrome:114.0.5735.198-20250515
+Tagged selenium/node-chrome:114.0-chromedriver-114.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:114.0-chromedriver-114.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:114.0-chromedriver-114.0-20250515
+Tagged selenium/standalone-chrome:114.0-chromedriver-114.0-20250515
+Tagged selenium/node-chrome:114.0-20250515
+Tagged selenium/standalone-chrome:114.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_115.md
+++ b/CHANGELOG/4.32.0/chrome_115.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 115.0.5790.170
 Short Chrome version -> 115.0
 ChromeDriver version -> 115.0.5790.170
 Short ChromeDriver version -> 115.0
-Tagged selenium/node-chrome:115.0.5790.170-chromedriver-115.0.5790.170-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:115.0.5790.170-chromedriver-115.0.5790.170-grid-4.32.0-20250505
-Tagged selenium/node-chrome:115.0.5790.170-chromedriver-115.0.5790.170-20250505
-Tagged selenium/standalone-chrome:115.0.5790.170-chromedriver-115.0.5790.170-20250505
-Tagged selenium/node-chrome:115.0.5790.170-20250505
-Tagged selenium/standalone-chrome:115.0.5790.170-20250505
-Tagged selenium/node-chrome:115.0-chromedriver-115.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:115.0-chromedriver-115.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:115.0-chromedriver-115.0-20250505
-Tagged selenium/standalone-chrome:115.0-chromedriver-115.0-20250505
-Tagged selenium/node-chrome:115.0-20250505
-Tagged selenium/standalone-chrome:115.0-20250505
+Tagged selenium/node-chrome:115.0.5790.170-chromedriver-115.0.5790.170-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:115.0.5790.170-chromedriver-115.0.5790.170-grid-4.32.0-20250515
+Tagged selenium/node-chrome:115.0.5790.170-chromedriver-115.0.5790.170-20250515
+Tagged selenium/standalone-chrome:115.0.5790.170-chromedriver-115.0.5790.170-20250515
+Tagged selenium/node-chrome:115.0.5790.170-20250515
+Tagged selenium/standalone-chrome:115.0.5790.170-20250515
+Tagged selenium/node-chrome:115.0-chromedriver-115.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:115.0-chromedriver-115.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:115.0-chromedriver-115.0-20250515
+Tagged selenium/standalone-chrome:115.0-chromedriver-115.0-20250515
+Tagged selenium/node-chrome:115.0-20250515
+Tagged selenium/standalone-chrome:115.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_116.md
+++ b/CHANGELOG/4.32.0/chrome_116.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 116.0.5845.187
 Short Chrome version -> 116.0
 ChromeDriver version -> 116.0.5845.96
 Short ChromeDriver version -> 116.0
-Tagged selenium/node-chrome:116.0.5845.187-chromedriver-116.0.5845.96-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:116.0.5845.187-chromedriver-116.0.5845.96-grid-4.32.0-20250505
-Tagged selenium/node-chrome:116.0.5845.187-chromedriver-116.0.5845.96-20250505
-Tagged selenium/standalone-chrome:116.0.5845.187-chromedriver-116.0.5845.96-20250505
-Tagged selenium/node-chrome:116.0.5845.187-20250505
-Tagged selenium/standalone-chrome:116.0.5845.187-20250505
-Tagged selenium/node-chrome:116.0-chromedriver-116.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:116.0-chromedriver-116.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:116.0-chromedriver-116.0-20250505
-Tagged selenium/standalone-chrome:116.0-chromedriver-116.0-20250505
-Tagged selenium/node-chrome:116.0-20250505
-Tagged selenium/standalone-chrome:116.0-20250505
+Tagged selenium/node-chrome:116.0.5845.187-chromedriver-116.0.5845.96-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:116.0.5845.187-chromedriver-116.0.5845.96-grid-4.32.0-20250515
+Tagged selenium/node-chrome:116.0.5845.187-chromedriver-116.0.5845.96-20250515
+Tagged selenium/standalone-chrome:116.0.5845.187-chromedriver-116.0.5845.96-20250515
+Tagged selenium/node-chrome:116.0.5845.187-20250515
+Tagged selenium/standalone-chrome:116.0.5845.187-20250515
+Tagged selenium/node-chrome:116.0-chromedriver-116.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:116.0-chromedriver-116.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:116.0-chromedriver-116.0-20250515
+Tagged selenium/standalone-chrome:116.0-chromedriver-116.0-20250515
+Tagged selenium/node-chrome:116.0-20250515
+Tagged selenium/standalone-chrome:116.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_117.md
+++ b/CHANGELOG/4.32.0/chrome_117.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 117.0.5938.149
 Short Chrome version -> 117.0
 ChromeDriver version -> 117.0.5938.149
 Short ChromeDriver version -> 117.0
-Tagged selenium/node-chrome:117.0.5938.149-chromedriver-117.0.5938.149-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:117.0.5938.149-chromedriver-117.0.5938.149-grid-4.32.0-20250505
-Tagged selenium/node-chrome:117.0.5938.149-chromedriver-117.0.5938.149-20250505
-Tagged selenium/standalone-chrome:117.0.5938.149-chromedriver-117.0.5938.149-20250505
-Tagged selenium/node-chrome:117.0.5938.149-20250505
-Tagged selenium/standalone-chrome:117.0.5938.149-20250505
-Tagged selenium/node-chrome:117.0-chromedriver-117.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:117.0-chromedriver-117.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:117.0-chromedriver-117.0-20250505
-Tagged selenium/standalone-chrome:117.0-chromedriver-117.0-20250505
-Tagged selenium/node-chrome:117.0-20250505
-Tagged selenium/standalone-chrome:117.0-20250505
+Tagged selenium/node-chrome:117.0.5938.149-chromedriver-117.0.5938.149-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:117.0.5938.149-chromedriver-117.0.5938.149-grid-4.32.0-20250515
+Tagged selenium/node-chrome:117.0.5938.149-chromedriver-117.0.5938.149-20250515
+Tagged selenium/standalone-chrome:117.0.5938.149-chromedriver-117.0.5938.149-20250515
+Tagged selenium/node-chrome:117.0.5938.149-20250515
+Tagged selenium/standalone-chrome:117.0.5938.149-20250515
+Tagged selenium/node-chrome:117.0-chromedriver-117.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:117.0-chromedriver-117.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:117.0-chromedriver-117.0-20250515
+Tagged selenium/standalone-chrome:117.0-chromedriver-117.0-20250515
+Tagged selenium/node-chrome:117.0-20250515
+Tagged selenium/standalone-chrome:117.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_118.md
+++ b/CHANGELOG/4.32.0/chrome_118.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 118.0.5993.117
 Short Chrome version -> 118.0
 ChromeDriver version -> 118.0.5993.70
 Short ChromeDriver version -> 118.0
-Tagged selenium/node-chrome:118.0.5993.117-chromedriver-118.0.5993.70-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:118.0.5993.117-chromedriver-118.0.5993.70-grid-4.32.0-20250505
-Tagged selenium/node-chrome:118.0.5993.117-chromedriver-118.0.5993.70-20250505
-Tagged selenium/standalone-chrome:118.0.5993.117-chromedriver-118.0.5993.70-20250505
-Tagged selenium/node-chrome:118.0.5993.117-20250505
-Tagged selenium/standalone-chrome:118.0.5993.117-20250505
-Tagged selenium/node-chrome:118.0-chromedriver-118.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:118.0-chromedriver-118.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:118.0-chromedriver-118.0-20250505
-Tagged selenium/standalone-chrome:118.0-chromedriver-118.0-20250505
-Tagged selenium/node-chrome:118.0-20250505
-Tagged selenium/standalone-chrome:118.0-20250505
+Tagged selenium/node-chrome:118.0.5993.117-chromedriver-118.0.5993.70-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:118.0.5993.117-chromedriver-118.0.5993.70-grid-4.32.0-20250515
+Tagged selenium/node-chrome:118.0.5993.117-chromedriver-118.0.5993.70-20250515
+Tagged selenium/standalone-chrome:118.0.5993.117-chromedriver-118.0.5993.70-20250515
+Tagged selenium/node-chrome:118.0.5993.117-20250515
+Tagged selenium/standalone-chrome:118.0.5993.117-20250515
+Tagged selenium/node-chrome:118.0-chromedriver-118.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:118.0-chromedriver-118.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:118.0-chromedriver-118.0-20250515
+Tagged selenium/standalone-chrome:118.0-chromedriver-118.0-20250515
+Tagged selenium/node-chrome:118.0-20250515
+Tagged selenium/standalone-chrome:118.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_119.md
+++ b/CHANGELOG/4.32.0/chrome_119.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 119.0.6045.199
 Short Chrome version -> 119.0
 ChromeDriver version -> 119.0.6045.105
 Short ChromeDriver version -> 119.0
-Tagged selenium/node-chrome:119.0.6045.199-chromedriver-119.0.6045.105-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:119.0.6045.199-chromedriver-119.0.6045.105-grid-4.32.0-20250505
-Tagged selenium/node-chrome:119.0.6045.199-chromedriver-119.0.6045.105-20250505
-Tagged selenium/standalone-chrome:119.0.6045.199-chromedriver-119.0.6045.105-20250505
-Tagged selenium/node-chrome:119.0.6045.199-20250505
-Tagged selenium/standalone-chrome:119.0.6045.199-20250505
-Tagged selenium/node-chrome:119.0-chromedriver-119.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:119.0-chromedriver-119.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:119.0-chromedriver-119.0-20250505
-Tagged selenium/standalone-chrome:119.0-chromedriver-119.0-20250505
-Tagged selenium/node-chrome:119.0-20250505
-Tagged selenium/standalone-chrome:119.0-20250505
+Tagged selenium/node-chrome:119.0.6045.199-chromedriver-119.0.6045.105-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:119.0.6045.199-chromedriver-119.0.6045.105-grid-4.32.0-20250515
+Tagged selenium/node-chrome:119.0.6045.199-chromedriver-119.0.6045.105-20250515
+Tagged selenium/standalone-chrome:119.0.6045.199-chromedriver-119.0.6045.105-20250515
+Tagged selenium/node-chrome:119.0.6045.199-20250515
+Tagged selenium/standalone-chrome:119.0.6045.199-20250515
+Tagged selenium/node-chrome:119.0-chromedriver-119.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:119.0-chromedriver-119.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:119.0-chromedriver-119.0-20250515
+Tagged selenium/standalone-chrome:119.0-chromedriver-119.0-20250515
+Tagged selenium/node-chrome:119.0-20250515
+Tagged selenium/standalone-chrome:119.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_120.md
+++ b/CHANGELOG/4.32.0/chrome_120.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 120.0.6099.224
 Short Chrome version -> 120.0
 ChromeDriver version -> 120.0.6099.109
 Short ChromeDriver version -> 120.0
-Tagged selenium/node-chrome:120.0.6099.224-chromedriver-120.0.6099.109-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:120.0.6099.224-chromedriver-120.0.6099.109-grid-4.32.0-20250505
-Tagged selenium/node-chrome:120.0.6099.224-chromedriver-120.0.6099.109-20250505
-Tagged selenium/standalone-chrome:120.0.6099.224-chromedriver-120.0.6099.109-20250505
-Tagged selenium/node-chrome:120.0.6099.224-20250505
-Tagged selenium/standalone-chrome:120.0.6099.224-20250505
-Tagged selenium/node-chrome:120.0-chromedriver-120.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:120.0-chromedriver-120.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:120.0-chromedriver-120.0-20250505
-Tagged selenium/standalone-chrome:120.0-chromedriver-120.0-20250505
-Tagged selenium/node-chrome:120.0-20250505
-Tagged selenium/standalone-chrome:120.0-20250505
+Tagged selenium/node-chrome:120.0.6099.224-chromedriver-120.0.6099.109-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:120.0.6099.224-chromedriver-120.0.6099.109-grid-4.32.0-20250515
+Tagged selenium/node-chrome:120.0.6099.224-chromedriver-120.0.6099.109-20250515
+Tagged selenium/standalone-chrome:120.0.6099.224-chromedriver-120.0.6099.109-20250515
+Tagged selenium/node-chrome:120.0.6099.224-20250515
+Tagged selenium/standalone-chrome:120.0.6099.224-20250515
+Tagged selenium/node-chrome:120.0-chromedriver-120.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:120.0-chromedriver-120.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:120.0-chromedriver-120.0-20250515
+Tagged selenium/standalone-chrome:120.0-chromedriver-120.0-20250515
+Tagged selenium/node-chrome:120.0-20250515
+Tagged selenium/standalone-chrome:120.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_121.md
+++ b/CHANGELOG/4.32.0/chrome_121.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 121.0.6167.184
 Short Chrome version -> 121.0
 ChromeDriver version -> 121.0.6167.184
 Short ChromeDriver version -> 121.0
-Tagged selenium/node-chrome:121.0.6167.184-chromedriver-121.0.6167.184-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:121.0.6167.184-chromedriver-121.0.6167.184-grid-4.32.0-20250505
-Tagged selenium/node-chrome:121.0.6167.184-chromedriver-121.0.6167.184-20250505
-Tagged selenium/standalone-chrome:121.0.6167.184-chromedriver-121.0.6167.184-20250505
-Tagged selenium/node-chrome:121.0.6167.184-20250505
-Tagged selenium/standalone-chrome:121.0.6167.184-20250505
-Tagged selenium/node-chrome:121.0-chromedriver-121.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:121.0-chromedriver-121.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:121.0-chromedriver-121.0-20250505
-Tagged selenium/standalone-chrome:121.0-chromedriver-121.0-20250505
-Tagged selenium/node-chrome:121.0-20250505
-Tagged selenium/standalone-chrome:121.0-20250505
+Tagged selenium/node-chrome:121.0.6167.184-chromedriver-121.0.6167.184-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:121.0.6167.184-chromedriver-121.0.6167.184-grid-4.32.0-20250515
+Tagged selenium/node-chrome:121.0.6167.184-chromedriver-121.0.6167.184-20250515
+Tagged selenium/standalone-chrome:121.0.6167.184-chromedriver-121.0.6167.184-20250515
+Tagged selenium/node-chrome:121.0.6167.184-20250515
+Tagged selenium/standalone-chrome:121.0.6167.184-20250515
+Tagged selenium/node-chrome:121.0-chromedriver-121.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:121.0-chromedriver-121.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:121.0-chromedriver-121.0-20250515
+Tagged selenium/standalone-chrome:121.0-chromedriver-121.0-20250515
+Tagged selenium/node-chrome:121.0-20250515
+Tagged selenium/standalone-chrome:121.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_122.md
+++ b/CHANGELOG/4.32.0/chrome_122.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 122.0.6261.128
 Short Chrome version -> 122.0
 ChromeDriver version -> 122.0.6261.128
 Short ChromeDriver version -> 122.0
-Tagged selenium/node-chrome:122.0.6261.128-chromedriver-122.0.6261.128-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:122.0.6261.128-chromedriver-122.0.6261.128-grid-4.32.0-20250505
-Tagged selenium/node-chrome:122.0.6261.128-chromedriver-122.0.6261.128-20250505
-Tagged selenium/standalone-chrome:122.0.6261.128-chromedriver-122.0.6261.128-20250505
-Tagged selenium/node-chrome:122.0.6261.128-20250505
-Tagged selenium/standalone-chrome:122.0.6261.128-20250505
-Tagged selenium/node-chrome:122.0-chromedriver-122.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:122.0-chromedriver-122.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:122.0-chromedriver-122.0-20250505
-Tagged selenium/standalone-chrome:122.0-chromedriver-122.0-20250505
-Tagged selenium/node-chrome:122.0-20250505
-Tagged selenium/standalone-chrome:122.0-20250505
+Tagged selenium/node-chrome:122.0.6261.128-chromedriver-122.0.6261.128-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:122.0.6261.128-chromedriver-122.0.6261.128-grid-4.32.0-20250515
+Tagged selenium/node-chrome:122.0.6261.128-chromedriver-122.0.6261.128-20250515
+Tagged selenium/standalone-chrome:122.0.6261.128-chromedriver-122.0.6261.128-20250515
+Tagged selenium/node-chrome:122.0.6261.128-20250515
+Tagged selenium/standalone-chrome:122.0.6261.128-20250515
+Tagged selenium/node-chrome:122.0-chromedriver-122.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:122.0-chromedriver-122.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:122.0-chromedriver-122.0-20250515
+Tagged selenium/standalone-chrome:122.0-chromedriver-122.0-20250515
+Tagged selenium/node-chrome:122.0-20250515
+Tagged selenium/standalone-chrome:122.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_123.md
+++ b/CHANGELOG/4.32.0/chrome_123.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 123.0.6312.122
 Short Chrome version -> 123.0
 ChromeDriver version -> 123.0.6312.122
 Short ChromeDriver version -> 123.0
-Tagged selenium/node-chrome:123.0.6312.122-chromedriver-123.0.6312.122-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:123.0.6312.122-chromedriver-123.0.6312.122-grid-4.32.0-20250505
-Tagged selenium/node-chrome:123.0.6312.122-chromedriver-123.0.6312.122-20250505
-Tagged selenium/standalone-chrome:123.0.6312.122-chromedriver-123.0.6312.122-20250505
-Tagged selenium/node-chrome:123.0.6312.122-20250505
-Tagged selenium/standalone-chrome:123.0.6312.122-20250505
-Tagged selenium/node-chrome:123.0-chromedriver-123.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:123.0-chromedriver-123.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:123.0-chromedriver-123.0-20250505
-Tagged selenium/standalone-chrome:123.0-chromedriver-123.0-20250505
-Tagged selenium/node-chrome:123.0-20250505
-Tagged selenium/standalone-chrome:123.0-20250505
+Tagged selenium/node-chrome:123.0.6312.122-chromedriver-123.0.6312.122-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:123.0.6312.122-chromedriver-123.0.6312.122-grid-4.32.0-20250515
+Tagged selenium/node-chrome:123.0.6312.122-chromedriver-123.0.6312.122-20250515
+Tagged selenium/standalone-chrome:123.0.6312.122-chromedriver-123.0.6312.122-20250515
+Tagged selenium/node-chrome:123.0.6312.122-20250515
+Tagged selenium/standalone-chrome:123.0.6312.122-20250515
+Tagged selenium/node-chrome:123.0-chromedriver-123.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:123.0-chromedriver-123.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:123.0-chromedriver-123.0-20250515
+Tagged selenium/standalone-chrome:123.0-chromedriver-123.0-20250515
+Tagged selenium/node-chrome:123.0-20250515
+Tagged selenium/standalone-chrome:123.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_124.md
+++ b/CHANGELOG/4.32.0/chrome_124.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 124.0.6367.207
 Short Chrome version -> 124.0
 ChromeDriver version -> 124.0.6367.207
 Short ChromeDriver version -> 124.0
-Tagged selenium/node-chrome:124.0.6367.207-chromedriver-124.0.6367.207-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:124.0.6367.207-chromedriver-124.0.6367.207-grid-4.32.0-20250505
-Tagged selenium/node-chrome:124.0.6367.207-chromedriver-124.0.6367.207-20250505
-Tagged selenium/standalone-chrome:124.0.6367.207-chromedriver-124.0.6367.207-20250505
-Tagged selenium/node-chrome:124.0.6367.207-20250505
-Tagged selenium/standalone-chrome:124.0.6367.207-20250505
-Tagged selenium/node-chrome:124.0-chromedriver-124.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:124.0-chromedriver-124.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:124.0-chromedriver-124.0-20250505
-Tagged selenium/standalone-chrome:124.0-chromedriver-124.0-20250505
-Tagged selenium/node-chrome:124.0-20250505
-Tagged selenium/standalone-chrome:124.0-20250505
+Tagged selenium/node-chrome:124.0.6367.207-chromedriver-124.0.6367.207-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:124.0.6367.207-chromedriver-124.0.6367.207-grid-4.32.0-20250515
+Tagged selenium/node-chrome:124.0.6367.207-chromedriver-124.0.6367.207-20250515
+Tagged selenium/standalone-chrome:124.0.6367.207-chromedriver-124.0.6367.207-20250515
+Tagged selenium/node-chrome:124.0.6367.207-20250515
+Tagged selenium/standalone-chrome:124.0.6367.207-20250515
+Tagged selenium/node-chrome:124.0-chromedriver-124.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:124.0-chromedriver-124.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:124.0-chromedriver-124.0-20250515
+Tagged selenium/standalone-chrome:124.0-chromedriver-124.0-20250515
+Tagged selenium/node-chrome:124.0-20250515
+Tagged selenium/standalone-chrome:124.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_125.md
+++ b/CHANGELOG/4.32.0/chrome_125.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 125.0.6422.141
 Short Chrome version -> 125.0
 ChromeDriver version -> 125.0.6422.141
 Short ChromeDriver version -> 125.0
-Tagged selenium/node-chrome:125.0.6422.141-chromedriver-125.0.6422.141-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:125.0.6422.141-chromedriver-125.0.6422.141-grid-4.32.0-20250505
-Tagged selenium/node-chrome:125.0.6422.141-chromedriver-125.0.6422.141-20250505
-Tagged selenium/standalone-chrome:125.0.6422.141-chromedriver-125.0.6422.141-20250505
-Tagged selenium/node-chrome:125.0.6422.141-20250505
-Tagged selenium/standalone-chrome:125.0.6422.141-20250505
-Tagged selenium/node-chrome:125.0-chromedriver-125.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:125.0-chromedriver-125.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:125.0-chromedriver-125.0-20250505
-Tagged selenium/standalone-chrome:125.0-chromedriver-125.0-20250505
-Tagged selenium/node-chrome:125.0-20250505
-Tagged selenium/standalone-chrome:125.0-20250505
+Tagged selenium/node-chrome:125.0.6422.141-chromedriver-125.0.6422.141-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:125.0.6422.141-chromedriver-125.0.6422.141-grid-4.32.0-20250515
+Tagged selenium/node-chrome:125.0.6422.141-chromedriver-125.0.6422.141-20250515
+Tagged selenium/standalone-chrome:125.0.6422.141-chromedriver-125.0.6422.141-20250515
+Tagged selenium/node-chrome:125.0.6422.141-20250515
+Tagged selenium/standalone-chrome:125.0.6422.141-20250515
+Tagged selenium/node-chrome:125.0-chromedriver-125.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:125.0-chromedriver-125.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:125.0-chromedriver-125.0-20250515
+Tagged selenium/standalone-chrome:125.0-chromedriver-125.0-20250515
+Tagged selenium/node-chrome:125.0-20250515
+Tagged selenium/standalone-chrome:125.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_126.md
+++ b/CHANGELOG/4.32.0/chrome_126.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 126.0.6478.182
 Short Chrome version -> 126.0
 ChromeDriver version -> 126.0.6478.182
 Short ChromeDriver version -> 126.0
-Tagged selenium/node-chrome:126.0.6478.182-chromedriver-126.0.6478.182-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:126.0.6478.182-chromedriver-126.0.6478.182-grid-4.32.0-20250505
-Tagged selenium/node-chrome:126.0.6478.182-chromedriver-126.0.6478.182-20250505
-Tagged selenium/standalone-chrome:126.0.6478.182-chromedriver-126.0.6478.182-20250505
-Tagged selenium/node-chrome:126.0.6478.182-20250505
-Tagged selenium/standalone-chrome:126.0.6478.182-20250505
-Tagged selenium/node-chrome:126.0-chromedriver-126.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:126.0-chromedriver-126.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:126.0-chromedriver-126.0-20250505
-Tagged selenium/standalone-chrome:126.0-chromedriver-126.0-20250505
-Tagged selenium/node-chrome:126.0-20250505
-Tagged selenium/standalone-chrome:126.0-20250505
+Tagged selenium/node-chrome:126.0.6478.182-chromedriver-126.0.6478.182-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:126.0.6478.182-chromedriver-126.0.6478.182-grid-4.32.0-20250515
+Tagged selenium/node-chrome:126.0.6478.182-chromedriver-126.0.6478.182-20250515
+Tagged selenium/standalone-chrome:126.0.6478.182-chromedriver-126.0.6478.182-20250515
+Tagged selenium/node-chrome:126.0.6478.182-20250515
+Tagged selenium/standalone-chrome:126.0.6478.182-20250515
+Tagged selenium/node-chrome:126.0-chromedriver-126.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:126.0-chromedriver-126.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:126.0-chromedriver-126.0-20250515
+Tagged selenium/standalone-chrome:126.0-chromedriver-126.0-20250515
+Tagged selenium/node-chrome:126.0-20250515
+Tagged selenium/standalone-chrome:126.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_127.md
+++ b/CHANGELOG/4.32.0/chrome_127.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 127.0.6533.119
 Short Chrome version -> 127.0
 ChromeDriver version -> 127.0.6533.119
 Short ChromeDriver version -> 127.0
-Tagged selenium/node-chrome:127.0.6533.119-chromedriver-127.0.6533.119-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:127.0.6533.119-chromedriver-127.0.6533.119-grid-4.32.0-20250505
-Tagged selenium/node-chrome:127.0.6533.119-chromedriver-127.0.6533.119-20250505
-Tagged selenium/standalone-chrome:127.0.6533.119-chromedriver-127.0.6533.119-20250505
-Tagged selenium/node-chrome:127.0.6533.119-20250505
-Tagged selenium/standalone-chrome:127.0.6533.119-20250505
-Tagged selenium/node-chrome:127.0-chromedriver-127.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:127.0-chromedriver-127.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:127.0-chromedriver-127.0-20250505
-Tagged selenium/standalone-chrome:127.0-chromedriver-127.0-20250505
-Tagged selenium/node-chrome:127.0-20250505
-Tagged selenium/standalone-chrome:127.0-20250505
+Tagged selenium/node-chrome:127.0.6533.119-chromedriver-127.0.6533.119-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:127.0.6533.119-chromedriver-127.0.6533.119-grid-4.32.0-20250515
+Tagged selenium/node-chrome:127.0.6533.119-chromedriver-127.0.6533.119-20250515
+Tagged selenium/standalone-chrome:127.0.6533.119-chromedriver-127.0.6533.119-20250515
+Tagged selenium/node-chrome:127.0.6533.119-20250515
+Tagged selenium/standalone-chrome:127.0.6533.119-20250515
+Tagged selenium/node-chrome:127.0-chromedriver-127.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:127.0-chromedriver-127.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:127.0-chromedriver-127.0-20250515
+Tagged selenium/standalone-chrome:127.0-chromedriver-127.0-20250515
+Tagged selenium/node-chrome:127.0-20250515
+Tagged selenium/standalone-chrome:127.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_128.md
+++ b/CHANGELOG/4.32.0/chrome_128.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 128.0.6613.137
 Short Chrome version -> 128.0
 ChromeDriver version -> 128.0.6613.137
 Short ChromeDriver version -> 128.0
-Tagged selenium/node-chrome:128.0.6613.137-chromedriver-128.0.6613.137-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:128.0.6613.137-chromedriver-128.0.6613.137-grid-4.32.0-20250505
-Tagged selenium/node-chrome:128.0.6613.137-chromedriver-128.0.6613.137-20250505
-Tagged selenium/standalone-chrome:128.0.6613.137-chromedriver-128.0.6613.137-20250505
-Tagged selenium/node-chrome:128.0.6613.137-20250505
-Tagged selenium/standalone-chrome:128.0.6613.137-20250505
-Tagged selenium/node-chrome:128.0-chromedriver-128.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:128.0-chromedriver-128.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:128.0-chromedriver-128.0-20250505
-Tagged selenium/standalone-chrome:128.0-chromedriver-128.0-20250505
-Tagged selenium/node-chrome:128.0-20250505
-Tagged selenium/standalone-chrome:128.0-20250505
+Tagged selenium/node-chrome:128.0.6613.137-chromedriver-128.0.6613.137-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:128.0.6613.137-chromedriver-128.0.6613.137-grid-4.32.0-20250515
+Tagged selenium/node-chrome:128.0.6613.137-chromedriver-128.0.6613.137-20250515
+Tagged selenium/standalone-chrome:128.0.6613.137-chromedriver-128.0.6613.137-20250515
+Tagged selenium/node-chrome:128.0.6613.137-20250515
+Tagged selenium/standalone-chrome:128.0.6613.137-20250515
+Tagged selenium/node-chrome:128.0-chromedriver-128.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:128.0-chromedriver-128.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:128.0-chromedriver-128.0-20250515
+Tagged selenium/standalone-chrome:128.0-chromedriver-128.0-20250515
+Tagged selenium/node-chrome:128.0-20250515
+Tagged selenium/standalone-chrome:128.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_129.md
+++ b/CHANGELOG/4.32.0/chrome_129.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 129.0.6668.100
 Short Chrome version -> 129.0
 ChromeDriver version -> 129.0.6668.100
 Short ChromeDriver version -> 129.0
-Tagged selenium/node-chrome:129.0.6668.100-chromedriver-129.0.6668.100-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:129.0.6668.100-chromedriver-129.0.6668.100-grid-4.32.0-20250505
-Tagged selenium/node-chrome:129.0.6668.100-chromedriver-129.0.6668.100-20250505
-Tagged selenium/standalone-chrome:129.0.6668.100-chromedriver-129.0.6668.100-20250505
-Tagged selenium/node-chrome:129.0.6668.100-20250505
-Tagged selenium/standalone-chrome:129.0.6668.100-20250505
-Tagged selenium/node-chrome:129.0-chromedriver-129.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:129.0-chromedriver-129.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:129.0-chromedriver-129.0-20250505
-Tagged selenium/standalone-chrome:129.0-chromedriver-129.0-20250505
-Tagged selenium/node-chrome:129.0-20250505
-Tagged selenium/standalone-chrome:129.0-20250505
+Tagged selenium/node-chrome:129.0.6668.100-chromedriver-129.0.6668.100-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:129.0.6668.100-chromedriver-129.0.6668.100-grid-4.32.0-20250515
+Tagged selenium/node-chrome:129.0.6668.100-chromedriver-129.0.6668.100-20250515
+Tagged selenium/standalone-chrome:129.0.6668.100-chromedriver-129.0.6668.100-20250515
+Tagged selenium/node-chrome:129.0.6668.100-20250515
+Tagged selenium/standalone-chrome:129.0.6668.100-20250515
+Tagged selenium/node-chrome:129.0-chromedriver-129.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:129.0-chromedriver-129.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:129.0-chromedriver-129.0-20250515
+Tagged selenium/standalone-chrome:129.0-chromedriver-129.0-20250515
+Tagged selenium/node-chrome:129.0-20250515
+Tagged selenium/standalone-chrome:129.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_130.md
+++ b/CHANGELOG/4.32.0/chrome_130.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 130.0.6723.116
 Short Chrome version -> 130.0
 ChromeDriver version -> 130.0.6723.116
 Short ChromeDriver version -> 130.0
-Tagged selenium/node-chrome:130.0.6723.116-chromedriver-130.0.6723.116-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:130.0.6723.116-chromedriver-130.0.6723.116-grid-4.32.0-20250505
-Tagged selenium/node-chrome:130.0.6723.116-chromedriver-130.0.6723.116-20250505
-Tagged selenium/standalone-chrome:130.0.6723.116-chromedriver-130.0.6723.116-20250505
-Tagged selenium/node-chrome:130.0.6723.116-20250505
-Tagged selenium/standalone-chrome:130.0.6723.116-20250505
-Tagged selenium/node-chrome:130.0-chromedriver-130.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:130.0-chromedriver-130.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:130.0-chromedriver-130.0-20250505
-Tagged selenium/standalone-chrome:130.0-chromedriver-130.0-20250505
-Tagged selenium/node-chrome:130.0-20250505
-Tagged selenium/standalone-chrome:130.0-20250505
+Tagged selenium/node-chrome:130.0.6723.116-chromedriver-130.0.6723.116-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:130.0.6723.116-chromedriver-130.0.6723.116-grid-4.32.0-20250515
+Tagged selenium/node-chrome:130.0.6723.116-chromedriver-130.0.6723.116-20250515
+Tagged selenium/standalone-chrome:130.0.6723.116-chromedriver-130.0.6723.116-20250515
+Tagged selenium/node-chrome:130.0.6723.116-20250515
+Tagged selenium/standalone-chrome:130.0.6723.116-20250515
+Tagged selenium/node-chrome:130.0-chromedriver-130.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:130.0-chromedriver-130.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:130.0-chromedriver-130.0-20250515
+Tagged selenium/standalone-chrome:130.0-chromedriver-130.0-20250515
+Tagged selenium/node-chrome:130.0-20250515
+Tagged selenium/standalone-chrome:130.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_131.md
+++ b/CHANGELOG/4.32.0/chrome_131.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 131.0.6778.264
 Short Chrome version -> 131.0
 ChromeDriver version -> 131.0.6778.264
 Short ChromeDriver version -> 131.0
-Tagged selenium/node-chrome:131.0.6778.264-chromedriver-131.0.6778.264-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:131.0.6778.264-chromedriver-131.0.6778.264-grid-4.32.0-20250505
-Tagged selenium/node-chrome:131.0.6778.264-chromedriver-131.0.6778.264-20250505
-Tagged selenium/standalone-chrome:131.0.6778.264-chromedriver-131.0.6778.264-20250505
-Tagged selenium/node-chrome:131.0.6778.264-20250505
-Tagged selenium/standalone-chrome:131.0.6778.264-20250505
-Tagged selenium/node-chrome:131.0-chromedriver-131.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:131.0-chromedriver-131.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:131.0-chromedriver-131.0-20250505
-Tagged selenium/standalone-chrome:131.0-chromedriver-131.0-20250505
-Tagged selenium/node-chrome:131.0-20250505
-Tagged selenium/standalone-chrome:131.0-20250505
+Tagged selenium/node-chrome:131.0.6778.264-chromedriver-131.0.6778.264-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:131.0.6778.264-chromedriver-131.0.6778.264-grid-4.32.0-20250515
+Tagged selenium/node-chrome:131.0.6778.264-chromedriver-131.0.6778.264-20250515
+Tagged selenium/standalone-chrome:131.0.6778.264-chromedriver-131.0.6778.264-20250515
+Tagged selenium/node-chrome:131.0.6778.264-20250515
+Tagged selenium/standalone-chrome:131.0.6778.264-20250515
+Tagged selenium/node-chrome:131.0-chromedriver-131.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:131.0-chromedriver-131.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:131.0-chromedriver-131.0-20250515
+Tagged selenium/standalone-chrome:131.0-chromedriver-131.0-20250515
+Tagged selenium/node-chrome:131.0-20250515
+Tagged selenium/standalone-chrome:131.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_132.md
+++ b/CHANGELOG/4.32.0/chrome_132.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 132.0.6834.159
 Short Chrome version -> 132.0
 ChromeDriver version -> 132.0.6834.159
 Short ChromeDriver version -> 132.0
-Tagged selenium/node-chrome:132.0.6834.159-chromedriver-132.0.6834.159-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:132.0.6834.159-chromedriver-132.0.6834.159-grid-4.32.0-20250505
-Tagged selenium/node-chrome:132.0.6834.159-chromedriver-132.0.6834.159-20250505
-Tagged selenium/standalone-chrome:132.0.6834.159-chromedriver-132.0.6834.159-20250505
-Tagged selenium/node-chrome:132.0.6834.159-20250505
-Tagged selenium/standalone-chrome:132.0.6834.159-20250505
-Tagged selenium/node-chrome:132.0-chromedriver-132.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:132.0-chromedriver-132.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:132.0-chromedriver-132.0-20250505
-Tagged selenium/standalone-chrome:132.0-chromedriver-132.0-20250505
-Tagged selenium/node-chrome:132.0-20250505
-Tagged selenium/standalone-chrome:132.0-20250505
+Tagged selenium/node-chrome:132.0.6834.159-chromedriver-132.0.6834.159-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:132.0.6834.159-chromedriver-132.0.6834.159-grid-4.32.0-20250515
+Tagged selenium/node-chrome:132.0.6834.159-chromedriver-132.0.6834.159-20250515
+Tagged selenium/standalone-chrome:132.0.6834.159-chromedriver-132.0.6834.159-20250515
+Tagged selenium/node-chrome:132.0.6834.159-20250515
+Tagged selenium/standalone-chrome:132.0.6834.159-20250515
+Tagged selenium/node-chrome:132.0-chromedriver-132.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:132.0-chromedriver-132.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:132.0-chromedriver-132.0-20250515
+Tagged selenium/standalone-chrome:132.0-chromedriver-132.0-20250515
+Tagged selenium/node-chrome:132.0-20250515
+Tagged selenium/standalone-chrome:132.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_133.md
+++ b/CHANGELOG/4.32.0/chrome_133.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 133.0.6943.141
 Short Chrome version -> 133.0
 ChromeDriver version -> 133.0.6943.141
 Short ChromeDriver version -> 133.0
-Tagged selenium/node-chrome:133.0.6943.141-chromedriver-133.0.6943.141-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:133.0.6943.141-chromedriver-133.0.6943.141-grid-4.32.0-20250505
-Tagged selenium/node-chrome:133.0.6943.141-chromedriver-133.0.6943.141-20250505
-Tagged selenium/standalone-chrome:133.0.6943.141-chromedriver-133.0.6943.141-20250505
-Tagged selenium/node-chrome:133.0.6943.141-20250505
-Tagged selenium/standalone-chrome:133.0.6943.141-20250505
-Tagged selenium/node-chrome:133.0-chromedriver-133.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:133.0-chromedriver-133.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:133.0-chromedriver-133.0-20250505
-Tagged selenium/standalone-chrome:133.0-chromedriver-133.0-20250505
-Tagged selenium/node-chrome:133.0-20250505
-Tagged selenium/standalone-chrome:133.0-20250505
+Tagged selenium/node-chrome:133.0.6943.141-chromedriver-133.0.6943.141-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:133.0.6943.141-chromedriver-133.0.6943.141-grid-4.32.0-20250515
+Tagged selenium/node-chrome:133.0.6943.141-chromedriver-133.0.6943.141-20250515
+Tagged selenium/standalone-chrome:133.0.6943.141-chromedriver-133.0.6943.141-20250515
+Tagged selenium/node-chrome:133.0.6943.141-20250515
+Tagged selenium/standalone-chrome:133.0.6943.141-20250515
+Tagged selenium/node-chrome:133.0-chromedriver-133.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:133.0-chromedriver-133.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:133.0-chromedriver-133.0-20250515
+Tagged selenium/standalone-chrome:133.0-chromedriver-133.0-20250515
+Tagged selenium/node-chrome:133.0-20250515
+Tagged selenium/standalone-chrome:133.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_134.md
+++ b/CHANGELOG/4.32.0/chrome_134.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
+Chrome version -> 134.0.6998.165
+Short Chrome version -> 134.0
+ChromeDriver version -> 134.0.6998.165
+Short ChromeDriver version -> 134.0
+Tagged selenium/node-chrome:134.0.6998.165-chromedriver-134.0.6998.165-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:134.0.6998.165-chromedriver-134.0.6998.165-grid-4.32.0-20250515
+Tagged selenium/node-chrome:134.0.6998.165-chromedriver-134.0.6998.165-20250515
+Tagged selenium/standalone-chrome:134.0.6998.165-chromedriver-134.0.6998.165-20250515
+Tagged selenium/node-chrome:134.0.6998.165-20250515
+Tagged selenium/standalone-chrome:134.0.6998.165-20250515
+Tagged selenium/node-chrome:134.0-chromedriver-134.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:134.0-chromedriver-134.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:134.0-chromedriver-134.0-20250515
+Tagged selenium/standalone-chrome:134.0-chromedriver-134.0-20250515
+Tagged selenium/node-chrome:134.0-20250515
+Tagged selenium/standalone-chrome:134.0-20250515
+```

--- a/CHANGELOG/4.32.0/chrome_95.md
+++ b/CHANGELOG/4.32.0/chrome_95.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 95.0.4638.69
 Short Chrome version -> 95.0
 ChromeDriver version -> 95.0.4638.69
 Short ChromeDriver version -> 95.0
-Tagged selenium/node-chrome:95.0.4638.69-chromedriver-95.0.4638.69-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:95.0.4638.69-chromedriver-95.0.4638.69-grid-4.32.0-20250505
-Tagged selenium/node-chrome:95.0.4638.69-chromedriver-95.0.4638.69-20250505
-Tagged selenium/standalone-chrome:95.0.4638.69-chromedriver-95.0.4638.69-20250505
-Tagged selenium/node-chrome:95.0.4638.69-20250505
-Tagged selenium/standalone-chrome:95.0.4638.69-20250505
-Tagged selenium/node-chrome:95.0-chromedriver-95.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:95.0-chromedriver-95.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:95.0-chromedriver-95.0-20250505
-Tagged selenium/standalone-chrome:95.0-chromedriver-95.0-20250505
-Tagged selenium/node-chrome:95.0-20250505
-Tagged selenium/standalone-chrome:95.0-20250505
+Tagged selenium/node-chrome:95.0.4638.69-chromedriver-95.0.4638.69-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:95.0.4638.69-chromedriver-95.0.4638.69-grid-4.32.0-20250515
+Tagged selenium/node-chrome:95.0.4638.69-chromedriver-95.0.4638.69-20250515
+Tagged selenium/standalone-chrome:95.0.4638.69-chromedriver-95.0.4638.69-20250515
+Tagged selenium/node-chrome:95.0.4638.69-20250515
+Tagged selenium/standalone-chrome:95.0.4638.69-20250515
+Tagged selenium/node-chrome:95.0-chromedriver-95.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:95.0-chromedriver-95.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:95.0-chromedriver-95.0-20250515
+Tagged selenium/standalone-chrome:95.0-chromedriver-95.0-20250515
+Tagged selenium/node-chrome:95.0-20250515
+Tagged selenium/standalone-chrome:95.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_97.md
+++ b/CHANGELOG/4.32.0/chrome_97.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
+Chrome version -> 97.0.4692.99
+Short Chrome version -> 97.0
+ChromeDriver version -> 97.0.4692.71
+Short ChromeDriver version -> 97.0
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.32.0-20250515
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250515
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250515
+Tagged selenium/node-chrome:97.0.4692.99-20250515
+Tagged selenium/standalone-chrome:97.0.4692.99-20250515
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-20250515
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-20250515
+Tagged selenium/node-chrome:97.0-20250515
+Tagged selenium/standalone-chrome:97.0-20250515
+```

--- a/CHANGELOG/4.32.0/chrome_98.md
+++ b/CHANGELOG/4.32.0/chrome_98.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 98.0.4758.102
 Short Chrome version -> 98.0
 ChromeDriver version -> 98.0.4758.102
 Short ChromeDriver version -> 98.0
-Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.32.0-20250505
-Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250505
-Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250505
-Tagged selenium/node-chrome:98.0.4758.102-20250505
-Tagged selenium/standalone-chrome:98.0.4758.102-20250505
-Tagged selenium/node-chrome:98.0-chromedriver-98.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:98.0-chromedriver-98.0-20250505
-Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-20250505
-Tagged selenium/node-chrome:98.0-20250505
-Tagged selenium/standalone-chrome:98.0-20250505
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.32.0-20250515
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250515
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250515
+Tagged selenium/node-chrome:98.0.4758.102-20250515
+Tagged selenium/standalone-chrome:98.0.4758.102-20250515
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-20250515
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-20250515
+Tagged selenium/node-chrome:98.0-20250515
+Tagged selenium/standalone-chrome:98.0-20250515
 ```

--- a/CHANGELOG/4.32.0/chrome_99.md
+++ b/CHANGELOG/4.32.0/chrome_99.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false chrome true
-Tagging images for browser chrome, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false chrome true
+Tagging images for browser chrome, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Chrome version -> 99.0.4844.84
 Short Chrome version -> 99.0
 ChromeDriver version -> 99.0.4844.51
 Short ChromeDriver version -> 99.0
-Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.32.0-20250505
-Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250505
-Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250505
-Tagged selenium/node-chrome:99.0.4844.84-20250505
-Tagged selenium/standalone-chrome:99.0.4844.84-20250505
-Tagged selenium/node-chrome:99.0-chromedriver-99.0-grid-4.32.0-20250505
-Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-grid-4.32.0-20250505
-Tagged selenium/node-chrome:99.0-chromedriver-99.0-20250505
-Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-20250505
-Tagged selenium/node-chrome:99.0-20250505
-Tagged selenium/standalone-chrome:99.0-20250505
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.32.0-20250515
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250515
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250515
+Tagged selenium/node-chrome:99.0.4844.84-20250515
+Tagged selenium/standalone-chrome:99.0.4844.84-20250515
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-grid-4.32.0-20250515
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-grid-4.32.0-20250515
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-20250515
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-20250515
+Tagged selenium/node-chrome:99.0-20250515
+Tagged selenium/standalone-chrome:99.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_114.md
+++ b/CHANGELOG/4.32.0/edge_114.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 114.0.1823.82
 Short Edge version -> 114.0
 EdgeDriver version -> 114.0.1823.82
 Short EdgeDriver version -> 114.0
-Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.32.0-20250505
-Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250505
-Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250505
-Tagged selenium/node-edge:114.0.1823.82-20250505
-Tagged selenium/standalone-edge:114.0.1823.82-20250505
-Tagged selenium/node-edge:114.0-edgedriver-114.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:114.0-edgedriver-114.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:114.0-edgedriver-114.0-20250505
-Tagged selenium/standalone-edge:114.0-edgedriver-114.0-20250505
-Tagged selenium/node-edge:114.0-20250505
-Tagged selenium/standalone-edge:114.0-20250505
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.32.0-20250515
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250515
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250515
+Tagged selenium/node-edge:114.0.1823.82-20250515
+Tagged selenium/standalone-edge:114.0.1823.82-20250515
+Tagged selenium/node-edge:114.0-edgedriver-114.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:114.0-edgedriver-114.0-20250515
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-20250515
+Tagged selenium/node-edge:114.0-20250515
+Tagged selenium/standalone-edge:114.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_115.md
+++ b/CHANGELOG/4.32.0/edge_115.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 115.0.1901.203
 Short Edge version -> 115.0
 EdgeDriver version -> 115.0.1901.203
 Short EdgeDriver version -> 115.0
-Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.32.0-20250505
-Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250505
-Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250505
-Tagged selenium/node-edge:115.0.1901.203-20250505
-Tagged selenium/standalone-edge:115.0.1901.203-20250505
-Tagged selenium/node-edge:115.0-edgedriver-115.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:115.0-edgedriver-115.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:115.0-edgedriver-115.0-20250505
-Tagged selenium/standalone-edge:115.0-edgedriver-115.0-20250505
-Tagged selenium/node-edge:115.0-20250505
-Tagged selenium/standalone-edge:115.0-20250505
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.32.0-20250515
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250515
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250515
+Tagged selenium/node-edge:115.0.1901.203-20250515
+Tagged selenium/standalone-edge:115.0.1901.203-20250515
+Tagged selenium/node-edge:115.0-edgedriver-115.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:115.0-edgedriver-115.0-20250515
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-20250515
+Tagged selenium/node-edge:115.0-20250515
+Tagged selenium/standalone-edge:115.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_116.md
+++ b/CHANGELOG/4.32.0/edge_116.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 116.0.1938.81
 Short Edge version -> 116.0
 EdgeDriver version -> 116.0.1938.81
 Short EdgeDriver version -> 116.0
-Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.32.0-20250505
-Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250505
-Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250505
-Tagged selenium/node-edge:116.0.1938.81-20250505
-Tagged selenium/standalone-edge:116.0.1938.81-20250505
-Tagged selenium/node-edge:116.0-edgedriver-116.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:116.0-edgedriver-116.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:116.0-edgedriver-116.0-20250505
-Tagged selenium/standalone-edge:116.0-edgedriver-116.0-20250505
-Tagged selenium/node-edge:116.0-20250505
-Tagged selenium/standalone-edge:116.0-20250505
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.32.0-20250515
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250515
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250515
+Tagged selenium/node-edge:116.0.1938.81-20250515
+Tagged selenium/standalone-edge:116.0.1938.81-20250515
+Tagged selenium/node-edge:116.0-edgedriver-116.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:116.0-edgedriver-116.0-20250515
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-20250515
+Tagged selenium/node-edge:116.0-20250515
+Tagged selenium/standalone-edge:116.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_117.md
+++ b/CHANGELOG/4.32.0/edge_117.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 117.0.2045.55
 Short Edge version -> 117.0
 EdgeDriver version -> 117.0.2045.55
 Short EdgeDriver version -> 117.0
-Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.32.0-20250505
-Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250505
-Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250505
-Tagged selenium/node-edge:117.0.2045.55-20250505
-Tagged selenium/standalone-edge:117.0.2045.55-20250505
-Tagged selenium/node-edge:117.0-edgedriver-117.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:117.0-edgedriver-117.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:117.0-edgedriver-117.0-20250505
-Tagged selenium/standalone-edge:117.0-edgedriver-117.0-20250505
-Tagged selenium/node-edge:117.0-20250505
-Tagged selenium/standalone-edge:117.0-20250505
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.32.0-20250515
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250515
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250515
+Tagged selenium/node-edge:117.0.2045.55-20250515
+Tagged selenium/standalone-edge:117.0.2045.55-20250515
+Tagged selenium/node-edge:117.0-edgedriver-117.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:117.0-edgedriver-117.0-20250515
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-20250515
+Tagged selenium/node-edge:117.0-20250515
+Tagged selenium/standalone-edge:117.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_118.md
+++ b/CHANGELOG/4.32.0/edge_118.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 118.0.2088.76
 Short Edge version -> 118.0
 EdgeDriver version -> 118.0.2088.76
 Short EdgeDriver version -> 118.0
-Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.32.0-20250505
-Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250505
-Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250505
-Tagged selenium/node-edge:118.0.2088.76-20250505
-Tagged selenium/standalone-edge:118.0.2088.76-20250505
-Tagged selenium/node-edge:118.0-edgedriver-118.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:118.0-edgedriver-118.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:118.0-edgedriver-118.0-20250505
-Tagged selenium/standalone-edge:118.0-edgedriver-118.0-20250505
-Tagged selenium/node-edge:118.0-20250505
-Tagged selenium/standalone-edge:118.0-20250505
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.32.0-20250515
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250515
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250515
+Tagged selenium/node-edge:118.0.2088.76-20250515
+Tagged selenium/standalone-edge:118.0.2088.76-20250515
+Tagged selenium/node-edge:118.0-edgedriver-118.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:118.0-edgedriver-118.0-20250515
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-20250515
+Tagged selenium/node-edge:118.0-20250515
+Tagged selenium/standalone-edge:118.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_119.md
+++ b/CHANGELOG/4.32.0/edge_119.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 119.0.2151.97
 Short Edge version -> 119.0
 EdgeDriver version -> 119.0.2151.97
 Short EdgeDriver version -> 119.0
-Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.32.0-20250505
-Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250505
-Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250505
-Tagged selenium/node-edge:119.0.2151.97-20250505
-Tagged selenium/standalone-edge:119.0.2151.97-20250505
-Tagged selenium/node-edge:119.0-edgedriver-119.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:119.0-edgedriver-119.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:119.0-edgedriver-119.0-20250505
-Tagged selenium/standalone-edge:119.0-edgedriver-119.0-20250505
-Tagged selenium/node-edge:119.0-20250505
-Tagged selenium/standalone-edge:119.0-20250505
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.32.0-20250515
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250515
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250515
+Tagged selenium/node-edge:119.0.2151.97-20250515
+Tagged selenium/standalone-edge:119.0.2151.97-20250515
+Tagged selenium/node-edge:119.0-edgedriver-119.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:119.0-edgedriver-119.0-20250515
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-20250515
+Tagged selenium/node-edge:119.0-20250515
+Tagged selenium/standalone-edge:119.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_120.md
+++ b/CHANGELOG/4.32.0/edge_120.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 120.0.2210.144
 Short Edge version -> 120.0
 EdgeDriver version -> 120.0.2210.144
 Short EdgeDriver version -> 120.0
-Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.32.0-20250505
-Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250505
-Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250505
-Tagged selenium/node-edge:120.0.2210.144-20250505
-Tagged selenium/standalone-edge:120.0.2210.144-20250505
-Tagged selenium/node-edge:120.0-edgedriver-120.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:120.0-edgedriver-120.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:120.0-edgedriver-120.0-20250505
-Tagged selenium/standalone-edge:120.0-edgedriver-120.0-20250505
-Tagged selenium/node-edge:120.0-20250505
-Tagged selenium/standalone-edge:120.0-20250505
+Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.32.0-20250515
+Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250515
+Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250515
+Tagged selenium/node-edge:120.0.2210.144-20250515
+Tagged selenium/standalone-edge:120.0.2210.144-20250515
+Tagged selenium/node-edge:120.0-edgedriver-120.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:120.0-edgedriver-120.0-20250515
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-20250515
+Tagged selenium/node-edge:120.0-20250515
+Tagged selenium/standalone-edge:120.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_121.md
+++ b/CHANGELOG/4.32.0/edge_121.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 121.0.2277.128
 Short Edge version -> 121.0
 EdgeDriver version -> 121.0.2277.128
 Short EdgeDriver version -> 121.0
-Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.32.0-20250505
-Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250505
-Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250505
-Tagged selenium/node-edge:121.0.2277.128-20250505
-Tagged selenium/standalone-edge:121.0.2277.128-20250505
-Tagged selenium/node-edge:121.0-edgedriver-121.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:121.0-edgedriver-121.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:121.0-edgedriver-121.0-20250505
-Tagged selenium/standalone-edge:121.0-edgedriver-121.0-20250505
-Tagged selenium/node-edge:121.0-20250505
-Tagged selenium/standalone-edge:121.0-20250505
+Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.32.0-20250515
+Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250515
+Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250515
+Tagged selenium/node-edge:121.0.2277.128-20250515
+Tagged selenium/standalone-edge:121.0.2277.128-20250515
+Tagged selenium/node-edge:121.0-edgedriver-121.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:121.0-edgedriver-121.0-20250515
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-20250515
+Tagged selenium/node-edge:121.0-20250515
+Tagged selenium/standalone-edge:121.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_122.md
+++ b/CHANGELOG/4.32.0/edge_122.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 122.0.2365.92
 Short Edge version -> 122.0
 EdgeDriver version -> 122.0.2365.92
 Short EdgeDriver version -> 122.0
-Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.32.0-20250505
-Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250505
-Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250505
-Tagged selenium/node-edge:122.0.2365.92-20250505
-Tagged selenium/standalone-edge:122.0.2365.92-20250505
-Tagged selenium/node-edge:122.0-edgedriver-122.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:122.0-edgedriver-122.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:122.0-edgedriver-122.0-20250505
-Tagged selenium/standalone-edge:122.0-edgedriver-122.0-20250505
-Tagged selenium/node-edge:122.0-20250505
-Tagged selenium/standalone-edge:122.0-20250505
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.32.0-20250515
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250515
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250515
+Tagged selenium/node-edge:122.0.2365.92-20250515
+Tagged selenium/standalone-edge:122.0.2365.92-20250515
+Tagged selenium/node-edge:122.0-edgedriver-122.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:122.0-edgedriver-122.0-20250515
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-20250515
+Tagged selenium/node-edge:122.0-20250515
+Tagged selenium/standalone-edge:122.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_123.md
+++ b/CHANGELOG/4.32.0/edge_123.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 123.0.2420.97
 Short Edge version -> 123.0
 EdgeDriver version -> 123.0.2420.97
 Short EdgeDriver version -> 123.0
-Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.32.0-20250505
-Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250505
-Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250505
-Tagged selenium/node-edge:123.0.2420.97-20250505
-Tagged selenium/standalone-edge:123.0.2420.97-20250505
-Tagged selenium/node-edge:123.0-edgedriver-123.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:123.0-edgedriver-123.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:123.0-edgedriver-123.0-20250505
-Tagged selenium/standalone-edge:123.0-edgedriver-123.0-20250505
-Tagged selenium/node-edge:123.0-20250505
-Tagged selenium/standalone-edge:123.0-20250505
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.32.0-20250515
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250515
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250515
+Tagged selenium/node-edge:123.0.2420.97-20250515
+Tagged selenium/standalone-edge:123.0.2420.97-20250515
+Tagged selenium/node-edge:123.0-edgedriver-123.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:123.0-edgedriver-123.0-20250515
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-20250515
+Tagged selenium/node-edge:123.0-20250515
+Tagged selenium/standalone-edge:123.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_124.md
+++ b/CHANGELOG/4.32.0/edge_124.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 124.0.2478.109
 Short Edge version -> 124.0
 EdgeDriver version -> 124.0.2478.109
 Short EdgeDriver version -> 124.0
-Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.32.0-20250505
-Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250505
-Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250505
-Tagged selenium/node-edge:124.0.2478.109-20250505
-Tagged selenium/standalone-edge:124.0.2478.109-20250505
-Tagged selenium/node-edge:124.0-edgedriver-124.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:124.0-edgedriver-124.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:124.0-edgedriver-124.0-20250505
-Tagged selenium/standalone-edge:124.0-edgedriver-124.0-20250505
-Tagged selenium/node-edge:124.0-20250505
-Tagged selenium/standalone-edge:124.0-20250505
+Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.32.0-20250515
+Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250515
+Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250515
+Tagged selenium/node-edge:124.0.2478.109-20250515
+Tagged selenium/standalone-edge:124.0.2478.109-20250515
+Tagged selenium/node-edge:124.0-edgedriver-124.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:124.0-edgedriver-124.0-20250515
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-20250515
+Tagged selenium/node-edge:124.0-20250515
+Tagged selenium/standalone-edge:124.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_125.md
+++ b/CHANGELOG/4.32.0/edge_125.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 125.0.2535.92
 Short Edge version -> 125.0
 EdgeDriver version -> 125.0.2535.92
 Short EdgeDriver version -> 125.0
-Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.32.0-20250505
-Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250505
-Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250505
-Tagged selenium/node-edge:125.0.2535.92-20250505
-Tagged selenium/standalone-edge:125.0.2535.92-20250505
-Tagged selenium/node-edge:125.0-edgedriver-125.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:125.0-edgedriver-125.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:125.0-edgedriver-125.0-20250505
-Tagged selenium/standalone-edge:125.0-edgedriver-125.0-20250505
-Tagged selenium/node-edge:125.0-20250505
-Tagged selenium/standalone-edge:125.0-20250505
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.32.0-20250515
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250515
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250515
+Tagged selenium/node-edge:125.0.2535.92-20250515
+Tagged selenium/standalone-edge:125.0.2535.92-20250515
+Tagged selenium/node-edge:125.0-edgedriver-125.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:125.0-edgedriver-125.0-20250515
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-20250515
+Tagged selenium/node-edge:125.0-20250515
+Tagged selenium/standalone-edge:125.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_126.md
+++ b/CHANGELOG/4.32.0/edge_126.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 126.0.2592.113
 Short Edge version -> 126.0
 EdgeDriver version -> 126.0.2592.123
 Short EdgeDriver version -> 126.0
-Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.32.0-20250505
-Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250505
-Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250505
-Tagged selenium/node-edge:126.0.2592.113-20250505
-Tagged selenium/standalone-edge:126.0.2592.113-20250505
-Tagged selenium/node-edge:126.0-edgedriver-126.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:126.0-edgedriver-126.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:126.0-edgedriver-126.0-20250505
-Tagged selenium/standalone-edge:126.0-edgedriver-126.0-20250505
-Tagged selenium/node-edge:126.0-20250505
-Tagged selenium/standalone-edge:126.0-20250505
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.32.0-20250515
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250515
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250515
+Tagged selenium/node-edge:126.0.2592.113-20250515
+Tagged selenium/standalone-edge:126.0.2592.113-20250515
+Tagged selenium/node-edge:126.0-edgedriver-126.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:126.0-edgedriver-126.0-20250515
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-20250515
+Tagged selenium/node-edge:126.0-20250515
+Tagged selenium/standalone-edge:126.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_127.md
+++ b/CHANGELOG/4.32.0/edge_127.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 127.0.2651.105
 Short Edge version -> 127.0
 EdgeDriver version -> 127.0.2651.107
 Short EdgeDriver version -> 127.0
-Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.32.0-20250505
-Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250505
-Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250505
-Tagged selenium/node-edge:127.0.2651.105-20250505
-Tagged selenium/standalone-edge:127.0.2651.105-20250505
-Tagged selenium/node-edge:127.0-edgedriver-127.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:127.0-edgedriver-127.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:127.0-edgedriver-127.0-20250505
-Tagged selenium/standalone-edge:127.0-edgedriver-127.0-20250505
-Tagged selenium/node-edge:127.0-20250505
-Tagged selenium/standalone-edge:127.0-20250505
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.32.0-20250515
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250515
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250515
+Tagged selenium/node-edge:127.0.2651.105-20250515
+Tagged selenium/standalone-edge:127.0.2651.105-20250515
+Tagged selenium/node-edge:127.0-edgedriver-127.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:127.0-edgedriver-127.0-20250515
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-20250515
+Tagged selenium/node-edge:127.0-20250515
+Tagged selenium/standalone-edge:127.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_128.md
+++ b/CHANGELOG/4.32.0/edge_128.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 128.0.2739.79
 Short Edge version -> 128.0
 EdgeDriver version -> 128.0.2739.81
 Short EdgeDriver version -> 128.0
-Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.32.0-20250505
-Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250505
-Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250505
-Tagged selenium/node-edge:128.0.2739.79-20250505
-Tagged selenium/standalone-edge:128.0.2739.79-20250505
-Tagged selenium/node-edge:128.0-edgedriver-128.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:128.0-edgedriver-128.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:128.0-edgedriver-128.0-20250505
-Tagged selenium/standalone-edge:128.0-edgedriver-128.0-20250505
-Tagged selenium/node-edge:128.0-20250505
-Tagged selenium/standalone-edge:128.0-20250505
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.32.0-20250515
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250515
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250515
+Tagged selenium/node-edge:128.0.2739.79-20250515
+Tagged selenium/standalone-edge:128.0.2739.79-20250515
+Tagged selenium/node-edge:128.0-edgedriver-128.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:128.0-edgedriver-128.0-20250515
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-20250515
+Tagged selenium/node-edge:128.0-20250515
+Tagged selenium/standalone-edge:128.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_129.md
+++ b/CHANGELOG/4.32.0/edge_129.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 129.0.2792.89
 Short Edge version -> 129.0
 EdgeDriver version -> 129.0.2792.98
 Short EdgeDriver version -> 129.0
-Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.32.0-20250505
-Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250505
-Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250505
-Tagged selenium/node-edge:129.0.2792.89-20250505
-Tagged selenium/standalone-edge:129.0.2792.89-20250505
-Tagged selenium/node-edge:129.0-edgedriver-129.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:129.0-edgedriver-129.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:129.0-edgedriver-129.0-20250505
-Tagged selenium/standalone-edge:129.0-edgedriver-129.0-20250505
-Tagged selenium/node-edge:129.0-20250505
-Tagged selenium/standalone-edge:129.0-20250505
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.32.0-20250515
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250515
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250515
+Tagged selenium/node-edge:129.0.2792.89-20250515
+Tagged selenium/standalone-edge:129.0.2792.89-20250515
+Tagged selenium/node-edge:129.0-edgedriver-129.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:129.0-edgedriver-129.0-20250515
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-20250515
+Tagged selenium/node-edge:129.0-20250515
+Tagged selenium/standalone-edge:129.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_130.md
+++ b/CHANGELOG/4.32.0/edge_130.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 130.0.2849.80
 Short Edge version -> 130.0
 EdgeDriver version -> 130.0.2849.78
 Short EdgeDriver version -> 130.0
-Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.32.0-20250505
-Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250505
-Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250505
-Tagged selenium/node-edge:130.0.2849.80-20250505
-Tagged selenium/standalone-edge:130.0.2849.80-20250505
-Tagged selenium/node-edge:130.0-edgedriver-130.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:130.0-edgedriver-130.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:130.0-edgedriver-130.0-20250505
-Tagged selenium/standalone-edge:130.0-edgedriver-130.0-20250505
-Tagged selenium/node-edge:130.0-20250505
-Tagged selenium/standalone-edge:130.0-20250505
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.32.0-20250515
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250515
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250515
+Tagged selenium/node-edge:130.0.2849.80-20250515
+Tagged selenium/standalone-edge:130.0.2849.80-20250515
+Tagged selenium/node-edge:130.0-edgedriver-130.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:130.0-edgedriver-130.0-20250515
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-20250515
+Tagged selenium/node-edge:130.0-20250515
+Tagged selenium/standalone-edge:130.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_131.md
+++ b/CHANGELOG/4.32.0/edge_131.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 131.0.2903.147
 Short Edge version -> 131.0
 EdgeDriver version -> 131.0.2903.147
 Short EdgeDriver version -> 131.0
-Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.32.0-20250505
-Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250505
-Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250505
-Tagged selenium/node-edge:131.0.2903.147-20250505
-Tagged selenium/standalone-edge:131.0.2903.147-20250505
-Tagged selenium/node-edge:131.0-edgedriver-131.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:131.0-edgedriver-131.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:131.0-edgedriver-131.0-20250505
-Tagged selenium/standalone-edge:131.0-edgedriver-131.0-20250505
-Tagged selenium/node-edge:131.0-20250505
-Tagged selenium/standalone-edge:131.0-20250505
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.32.0-20250515
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250515
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250515
+Tagged selenium/node-edge:131.0.2903.147-20250515
+Tagged selenium/standalone-edge:131.0.2903.147-20250515
+Tagged selenium/node-edge:131.0-edgedriver-131.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:131.0-edgedriver-131.0-20250515
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-20250515
+Tagged selenium/node-edge:131.0-20250515
+Tagged selenium/standalone-edge:131.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_132.md
+++ b/CHANGELOG/4.32.0/edge_132.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 132.0.2957.140
 Short Edge version -> 132.0
 EdgeDriver version -> 132.0.2957.140
 Short EdgeDriver version -> 132.0
-Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.32.0-20250505
-Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250505
-Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250505
-Tagged selenium/node-edge:132.0.2957.140-20250505
-Tagged selenium/standalone-edge:132.0.2957.140-20250505
-Tagged selenium/node-edge:132.0-edgedriver-132.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:132.0-edgedriver-132.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:132.0-edgedriver-132.0-20250505
-Tagged selenium/standalone-edge:132.0-edgedriver-132.0-20250505
-Tagged selenium/node-edge:132.0-20250505
-Tagged selenium/standalone-edge:132.0-20250505
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.32.0-20250515
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250515
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250515
+Tagged selenium/node-edge:132.0.2957.140-20250515
+Tagged selenium/standalone-edge:132.0.2957.140-20250515
+Tagged selenium/node-edge:132.0-edgedriver-132.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:132.0-edgedriver-132.0-20250515
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-20250515
+Tagged selenium/node-edge:132.0-20250515
+Tagged selenium/standalone-edge:132.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_133.md
+++ b/CHANGELOG/4.32.0/edge_133.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 133.0.3065.92
 Short Edge version -> 133.0
 EdgeDriver version -> 133.0.3065.92
 Short EdgeDriver version -> 133.0
-Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.32.0-20250505
-Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250505
-Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250505
-Tagged selenium/node-edge:133.0.3065.92-20250505
-Tagged selenium/standalone-edge:133.0.3065.92-20250505
-Tagged selenium/node-edge:133.0-edgedriver-133.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:133.0-edgedriver-133.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:133.0-edgedriver-133.0-20250505
-Tagged selenium/standalone-edge:133.0-edgedriver-133.0-20250505
-Tagged selenium/node-edge:133.0-20250505
-Tagged selenium/standalone-edge:133.0-20250505
+Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.32.0-20250515
+Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250515
+Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250515
+Tagged selenium/node-edge:133.0.3065.92-20250515
+Tagged selenium/standalone-edge:133.0.3065.92-20250515
+Tagged selenium/node-edge:133.0-edgedriver-133.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:133.0-edgedriver-133.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:133.0-edgedriver-133.0-20250515
+Tagged selenium/standalone-edge:133.0-edgedriver-133.0-20250515
+Tagged selenium/node-edge:133.0-20250515
+Tagged selenium/standalone-edge:133.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_134.md
+++ b/CHANGELOG/4.32.0/edge_134.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 134.0.3124.95
 Short Edge version -> 134.0
 EdgeDriver version -> 134.0.3124.95
 Short EdgeDriver version -> 134.0
-Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.32.0-20250505
-Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250505
-Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250505
-Tagged selenium/node-edge:134.0.3124.95-20250505
-Tagged selenium/standalone-edge:134.0.3124.95-20250505
-Tagged selenium/node-edge:134.0-edgedriver-134.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:134.0-edgedriver-134.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:134.0-edgedriver-134.0-20250505
-Tagged selenium/standalone-edge:134.0-edgedriver-134.0-20250505
-Tagged selenium/node-edge:134.0-20250505
-Tagged selenium/standalone-edge:134.0-20250505
+Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.32.0-20250515
+Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250515
+Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250515
+Tagged selenium/node-edge:134.0.3124.95-20250515
+Tagged selenium/standalone-edge:134.0.3124.95-20250515
+Tagged selenium/node-edge:134.0-edgedriver-134.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:134.0-edgedriver-134.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:134.0-edgedriver-134.0-20250515
+Tagged selenium/standalone-edge:134.0-edgedriver-134.0-20250515
+Tagged selenium/node-edge:134.0-20250515
+Tagged selenium/standalone-edge:134.0-20250515
 ```

--- a/CHANGELOG/4.32.0/edge_135.md
+++ b/CHANGELOG/4.32.0/edge_135.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false edge true
-Tagging images for browser edge, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false edge true
+Tagging images for browser edge, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Edge version -> 135.0.3179.98
 Short Edge version -> 135.0
 EdgeDriver version -> 135.0.3179.98
 Short EdgeDriver version -> 135.0
-Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.32.0-20250505
-Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250505
-Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250505
-Tagged selenium/node-edge:135.0.3179.98-20250505
-Tagged selenium/standalone-edge:135.0.3179.98-20250505
-Tagged selenium/node-edge:135.0-edgedriver-135.0-grid-4.32.0-20250505
-Tagged selenium/standalone-edge:135.0-edgedriver-135.0-grid-4.32.0-20250505
-Tagged selenium/node-edge:135.0-edgedriver-135.0-20250505
-Tagged selenium/standalone-edge:135.0-edgedriver-135.0-20250505
-Tagged selenium/node-edge:135.0-20250505
-Tagged selenium/standalone-edge:135.0-20250505
+Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.32.0-20250515
+Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250515
+Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250515
+Tagged selenium/node-edge:135.0.3179.98-20250515
+Tagged selenium/standalone-edge:135.0.3179.98-20250515
+Tagged selenium/node-edge:135.0-edgedriver-135.0-grid-4.32.0-20250515
+Tagged selenium/standalone-edge:135.0-edgedriver-135.0-grid-4.32.0-20250515
+Tagged selenium/node-edge:135.0-edgedriver-135.0-20250515
+Tagged selenium/standalone-edge:135.0-edgedriver-135.0-20250515
+Tagged selenium/node-edge:135.0-20250515
+Tagged selenium/standalone-edge:135.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_100.md
+++ b/CHANGELOG/4.32.0/firefox_100.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 100.0.2
 Short Firefox version -> 100.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:100.0.2-20250505
-Tagged selenium/standalone-firefox:100.0.2-20250505
-Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:100.0-20250505
-Tagged selenium/standalone-firefox:100.0-20250505
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:100.0.2-20250515
+Tagged selenium/standalone-firefox:100.0.2-20250515
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:100.0-20250515
+Tagged selenium/standalone-firefox:100.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_101.md
+++ b/CHANGELOG/4.32.0/firefox_101.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 101.0.1
 Short Firefox version -> 101.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:101.0.1-20250505
-Tagged selenium/standalone-firefox:101.0.1-20250505
-Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:101.0-20250505
-Tagged selenium/standalone-firefox:101.0-20250505
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:101.0.1-20250515
+Tagged selenium/standalone-firefox:101.0.1-20250515
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:101.0-20250515
+Tagged selenium/standalone-firefox:101.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_102.md
+++ b/CHANGELOG/4.32.0/firefox_102.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 102.0.1
 Short Firefox version -> 102.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:102.0.1-20250505
-Tagged selenium/standalone-firefox:102.0.1-20250505
-Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:102.0-20250505
-Tagged selenium/standalone-firefox:102.0-20250505
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:102.0.1-20250515
+Tagged selenium/standalone-firefox:102.0.1-20250515
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:102.0-20250515
+Tagged selenium/standalone-firefox:102.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_103.md
+++ b/CHANGELOG/4.32.0/firefox_103.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 103.0.2
 Short Firefox version -> 103.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:103.0.2-20250505
-Tagged selenium/standalone-firefox:103.0.2-20250505
-Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:103.0-20250505
-Tagged selenium/standalone-firefox:103.0-20250505
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:103.0.2-20250515
+Tagged selenium/standalone-firefox:103.0.2-20250515
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:103.0-20250515
+Tagged selenium/standalone-firefox:103.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_104.md
+++ b/CHANGELOG/4.32.0/firefox_104.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 104.0.2
 Short Firefox version -> 104.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:104.0.2-20250505
-Tagged selenium/standalone-firefox:104.0.2-20250505
-Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:104.0-20250505
-Tagged selenium/standalone-firefox:104.0-20250505
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:104.0.2-20250515
+Tagged selenium/standalone-firefox:104.0.2-20250515
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:104.0-20250515
+Tagged selenium/standalone-firefox:104.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_105.md
+++ b/CHANGELOG/4.32.0/firefox_105.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 105.0.3
 Short Firefox version -> 105.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:105.0.3-20250505
-Tagged selenium/standalone-firefox:105.0.3-20250505
-Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:105.0-20250505
-Tagged selenium/standalone-firefox:105.0-20250505
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:105.0.3-20250515
+Tagged selenium/standalone-firefox:105.0.3-20250515
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:105.0-20250515
+Tagged selenium/standalone-firefox:105.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_106.md
+++ b/CHANGELOG/4.32.0/firefox_106.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 106.0.5
 Short Firefox version -> 106.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:106.0.5-20250505
-Tagged selenium/standalone-firefox:106.0.5-20250505
-Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:106.0-20250505
-Tagged selenium/standalone-firefox:106.0-20250505
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:106.0.5-20250515
+Tagged selenium/standalone-firefox:106.0.5-20250515
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:106.0-20250515
+Tagged selenium/standalone-firefox:106.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_108.md
+++ b/CHANGELOG/4.32.0/firefox_108.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 108.0.2
 Short Firefox version -> 108.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:108.0.2-20250505
-Tagged selenium/standalone-firefox:108.0.2-20250505
-Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:108.0-20250505
-Tagged selenium/standalone-firefox:108.0-20250505
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:108.0.2-20250515
+Tagged selenium/standalone-firefox:108.0.2-20250515
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:108.0-20250515
+Tagged selenium/standalone-firefox:108.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_109.md
+++ b/CHANGELOG/4.32.0/firefox_109.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 109.0.1
 Short Firefox version -> 109.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:109.0.1-20250505
-Tagged selenium/standalone-firefox:109.0.1-20250505
-Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:109.0-20250505
-Tagged selenium/standalone-firefox:109.0-20250505
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:109.0.1-20250515
+Tagged selenium/standalone-firefox:109.0.1-20250515
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:109.0-20250515
+Tagged selenium/standalone-firefox:109.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_110.md
+++ b/CHANGELOG/4.32.0/firefox_110.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 110.0.1
 Short Firefox version -> 110.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:110.0.1-20250505
-Tagged selenium/standalone-firefox:110.0.1-20250505
-Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:110.0-20250505
-Tagged selenium/standalone-firefox:110.0-20250505
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:110.0.1-20250515
+Tagged selenium/standalone-firefox:110.0.1-20250515
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:110.0-20250515
+Tagged selenium/standalone-firefox:110.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_111.md
+++ b/CHANGELOG/4.32.0/firefox_111.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 111.0.1
 Short Firefox version -> 111.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:111.0.1-20250505
-Tagged selenium/standalone-firefox:111.0.1-20250505
-Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:111.0-20250505
-Tagged selenium/standalone-firefox:111.0-20250505
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:111.0.1-20250515
+Tagged selenium/standalone-firefox:111.0.1-20250515
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:111.0-20250515
+Tagged selenium/standalone-firefox:111.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_113.md
+++ b/CHANGELOG/4.32.0/firefox_113.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 113.0.2
 Short Firefox version -> 113.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:113.0.2-20250505
-Tagged selenium/standalone-firefox:113.0.2-20250505
-Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:113.0-20250505
-Tagged selenium/standalone-firefox:113.0-20250505
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:113.0.2-20250515
+Tagged selenium/standalone-firefox:113.0.2-20250515
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:113.0-20250515
+Tagged selenium/standalone-firefox:113.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_115.md
+++ b/CHANGELOG/4.32.0/firefox_115.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 115.0.3
 Short Firefox version -> 115.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:115.0.3-20250505
-Tagged selenium/standalone-firefox:115.0.3-20250505
-Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:115.0-20250505
-Tagged selenium/standalone-firefox:115.0-20250505
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:115.0.3-20250515
+Tagged selenium/standalone-firefox:115.0.3-20250515
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:115.0-20250515
+Tagged selenium/standalone-firefox:115.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_116.md
+++ b/CHANGELOG/4.32.0/firefox_116.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 116.0.3
 Short Firefox version -> 116.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:116.0.3-20250505
-Tagged selenium/standalone-firefox:116.0.3-20250505
-Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:116.0-20250505
-Tagged selenium/standalone-firefox:116.0-20250505
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:116.0.3-20250515
+Tagged selenium/standalone-firefox:116.0.3-20250515
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:116.0-20250515
+Tagged selenium/standalone-firefox:116.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_119.md
+++ b/CHANGELOG/4.32.0/firefox_119.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 119.0.1
 Short Firefox version -> 119.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:119.0.1-20250505
-Tagged selenium/standalone-firefox:119.0.1-20250505
-Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:119.0-20250505
-Tagged selenium/standalone-firefox:119.0-20250505
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:119.0.1-20250515
+Tagged selenium/standalone-firefox:119.0.1-20250515
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:119.0-20250515
+Tagged selenium/standalone-firefox:119.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_120.md
+++ b/CHANGELOG/4.32.0/firefox_120.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 120.0.1
 Short Firefox version -> 120.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:120.0.1-20250505
-Tagged selenium/standalone-firefox:120.0.1-20250505
-Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:120.0-20250505
-Tagged selenium/standalone-firefox:120.0-20250505
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:120.0.1-20250515
+Tagged selenium/standalone-firefox:120.0.1-20250515
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:120.0-20250515
+Tagged selenium/standalone-firefox:120.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_121.md
+++ b/CHANGELOG/4.32.0/firefox_121.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 121.0.1
 Short Firefox version -> 121.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:121.0.1-20250505
-Tagged selenium/standalone-firefox:121.0.1-20250505
-Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:121.0-20250505
-Tagged selenium/standalone-firefox:121.0-20250505
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:121.0.1-20250515
+Tagged selenium/standalone-firefox:121.0.1-20250515
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:121.0-20250515
+Tagged selenium/standalone-firefox:121.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_123.md
+++ b/CHANGELOG/4.32.0/firefox_123.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 123.0.1
 Short Firefox version -> 123.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:123.0.1-20250505
-Tagged selenium/standalone-firefox:123.0.1-20250505
-Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:123.0-20250505
-Tagged selenium/standalone-firefox:123.0-20250505
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:123.0.1-20250515
+Tagged selenium/standalone-firefox:123.0.1-20250515
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:123.0-20250515
+Tagged selenium/standalone-firefox:123.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_124.md
+++ b/CHANGELOG/4.32.0/firefox_124.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 124.0.2
 Short Firefox version -> 124.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:124.0.2-20250505
-Tagged selenium/standalone-firefox:124.0.2-20250505
-Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:124.0-20250505
-Tagged selenium/standalone-firefox:124.0-20250505
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:124.0.2-20250515
+Tagged selenium/standalone-firefox:124.0.2-20250515
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:124.0-20250515
+Tagged selenium/standalone-firefox:124.0-20250515
 ```

--- a/CHANGELOG/4.32.0/firefox_98.md
+++ b/CHANGELOG/4.32.0/firefox_98.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.32.0 20250505 selenium false firefox true
-Tagging images for browser firefox, version 4.32.0, build date 20250505, namespace selenium
-Selenium Grid version -> 4.32.0-20250505
+./tag_and_push_browser_images.sh 4.32.0 20250515 selenium false firefox true
+Tagging images for browser firefox, version 4.32.0, build date 20250515, namespace selenium
+Selenium Grid version -> 4.32.0-20250515
 Firefox version -> 98.0.2
 Short Firefox version -> 98.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.32.0-20250505
-Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250505
-Tagged selenium/node-firefox:98.0.2-20250505
-Tagged selenium/standalone-firefox:98.0.2-20250505
-Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.32.0-20250505
-Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250505
-Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250505
-Tagged selenium/node-firefox:98.0-20250505
-Tagged selenium/standalone-firefox:98.0-20250505
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.32.0-20250515
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250515
+Tagged selenium/node-firefox:98.0.2-20250515
+Tagged selenium/standalone-firefox:98.0.2-20250515
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.32.0-20250515
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250515
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250515
+Tagged selenium/node-firefox:98.0-20250515
+Tagged selenium/standalone-firefox:98.0-20250515
 ```

--- a/tests/build-backward-compatible/browser-matrix.yml
+++ b/tests/build-backward-compatible/browser-matrix.yml
@@ -11,7 +11,7 @@ matrix:
       FIREFOX_VERSION: 137.0.2
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '136':
-      EDGE_VERSION: microsoft-edge-stable=136.0.3240.64-1
+      EDGE_VERSION: microsoft-edge-stable=136.0.3240.76-1
       CHROME_VERSION: google-chrome-stable=136.0.7103.113-1
       FIREFOX_VERSION: 136.0.4
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64


### PR DESCRIPTION
### **User description**
This PR contains the CHANGELOG for Node/Standalone chrome with specific browser versions: [95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135]


___

### **PR Type**
Documentation


___

### **Description**
- Updated build date and Selenium Grid version from `20250505` to `20250515` across changelog files for Chrome versions 95 through 135.

- Updated all related Docker image tags in each changelog to reflect the new build date.

- Added new changelog files for Chrome versions 97, 103, and 134, including details for Chrome and ChromeDriver versions, build date, and Docker image tags.

- Documented the tagging process for both node and standalone Chrome images in the new changelog files.

- Updated the Edge browser version for matrix entry `136` in `tests/build-backward-compatible/browser-matrix.yml` from `136.0.3240.64-1` to `136.0.3240.76-1`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>38 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>chrome_95.md</strong><dd><code>Update build date and tags for Chrome 95 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_95.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-73e329eb654c4630a44626905f97141a1e12cccf786a760de007e0c315ea21fc">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_98.md</strong><dd><code>Update build date and tags for Chrome 98 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_98.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-52fb5e5c4b35ec8f990ba7da2f390db291b347bea09bc7875303e7441c3331b8">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_101.md</strong><dd><code>Update build date and tags for Chrome 101 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_101.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-d8272dd76546ad8ce0833f6b98a94a0793c6a3292cda5e4451ff1da9070b1cac">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_102.md</strong><dd><code>Update build date and tags for Chrome 102 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_102.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-1cfdbb7c5c902ec4513c77e6f8ce7f719465a28697f41930f4650f67de25db02">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_103.md</strong><dd><code>Add changelog for Chrome 103 with 20250515 build</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_103.md

<li>Added a new changelog file for Chrome 103 with build date 20250515.<br> <li> Included details for Chrome and ChromeDriver versions and all related <br>Docker image tags.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-8e0eba39f64b1844e7161754205478f9b107a7b304a2d2d7be3ab9504cb9953f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_104.md</strong><dd><code>Update build date and tags for Chrome 104 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_104.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-968fae9c6051c17ff46ed6ca3372722c70560de48f6c55f6ef3804d8bfa67f71">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_105.md</strong><dd><code>Update build date and tags for Chrome 105 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_105.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-fa017402e5c1a4634a63e80fe9e84c73b87f4e8d88701f3b5def2f70f84cd79a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_106.md</strong><dd><code>Update build date and tags for Chrome 106 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_106.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-6f08959575db54aa323e732226540bd8d10150b76b0de665ae57485318593caa">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_107.md</strong><dd><code>Update build date and tags for Chrome 107 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_107.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-47abe103d58ca3a138da962e24be07eea62654927d2a036b920aeea8442e1842">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_108.md</strong><dd><code>Update build date and tags for Chrome 108 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_108.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-6ddb881201b36b2e2315b129144f955dd72b05322828d35d16098b19c74d86ef">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_109.md</strong><dd><code>Update build date and tags for Chrome 109 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_109.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-20f6648515b3ebe06a1791c52bff3bc693dc5125f2653afb6e1daf8902b2dbb9">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_110.md</strong><dd><code>Update build date and tags for Chrome 110 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_110.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-692f3cb1cd218f90456cde84923cfa6dd38d066c68ec05b95293980d0d7722b7">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_111.md</strong><dd><code>Update build date and tags for Chrome 111 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_111.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-558cb1fe57cddce8396d864333eb14e3f946d4b63ccc6b03ff2d7fca593d993c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_112.md</strong><dd><code>Update build date and tags for Chrome 112 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_112.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-1fdfd5ee281e81a2548845aa4a1e7e9402e41d8ef4d479e24cc9e3b581a03c65">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_113.md</strong><dd><code>Update build date and tags for Chrome 113 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_113.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-1db247390bea49cef6ab994af2e46f5c633c894a4578b3599724f87fd4c08700">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_114.md</strong><dd><code>Update build date and tags for Chrome 114 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_114.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-b56443a54ceb3b29d10a3a942269bfd756260b38905d9b2ce63a568174bb929d">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_115.md</strong><dd><code>Update build date and tags for Chrome 115 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_115.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-e5897dc54febb222fbd07ea9a3342ed1a2cce4864f963337206daf8a1dbc0b6a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_116.md</strong><dd><code>Update build date and tags for Chrome 116 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_116.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-808e25a40286fa40703c59aba968f88625b9c0516323e541cbf5eef522625013">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_117.md</strong><dd><code>Update build date and tags for Chrome 117 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_117.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-a332679eba7c7c252c9fb7687d643a0d298fc68de6f772ee6c01f840f8df0466">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_118.md</strong><dd><code>Update build date and tags for Chrome 118 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_118.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-4f7b710397d2b4c3d074a88f73b9d0861badc7bda3631a38988a8eb4022dfa6b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_119.md</strong><dd><code>Update build date and tags for Chrome 119 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_119.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-a058d954b56561e1e9a74a4e768c450b0f00f1d651afdc41ddb3978e94d75224">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_120.md</strong><dd><code>Update build date and tags for Chrome 120 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_120.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-d7428d955910ccf89fff3ba7728445e6ac56a7e4af3e7a8c79ace1c8a1f01617">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_121.md</strong><dd><code>Update build date and tags for Chrome 121 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_121.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-002bd5cd617bcd8c67d341e331779985f47b950fd0a89d0ef155ed2a4fe006d6">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_122.md</strong><dd><code>Update build date and tags for Chrome 122 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_122.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-7b4fcdb4c0c9c254dd5805563f9f66dc1badff292d43fa44eab1cc36f860b754">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_123.md</strong><dd><code>Update build date and tags for Chrome 123 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_123.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-fac6a95acbade9a4d5f9d6d94d9343b7e1cd81dc1ee556bc3cc2d49ac24704f0">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_124.md</strong><dd><code>Update build date and tags for Chrome 124 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_124.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-7efb57d86c3c38cce80fe3a358e37ac97dbd37d7367840f3873c72859069b8bd">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_125.md</strong><dd><code>Update build date and tags for Chrome 125 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_125.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-3e6712e8b8b00166091b2a68fc9eb62763ca458fea34118f9dd1f6e7115eb200">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_126.md</strong><dd><code>Update build date and tags for Chrome 126 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_126.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-ac91ebebf648ad0150450ec2891b95f4a77b1f4403741dfaa827b2e48d81f2d4">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_127.md</strong><dd><code>Update build date and tags for Chrome 127 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_127.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-8207efb3988681630c9d06ed1798d9a097ad9fbd9e5eecebe200cd3d0219932b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_128.md</strong><dd><code>Update build date and tags for Chrome 128 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_128.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-bec23ab8badcb08a20f7bab43113093ce7fdcb894a0a0f9746b8abf412120f4b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_129.md</strong><dd><code>Update build date and tags for Chrome 129 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_129.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-214e50e63132b7cd4d2e6eaa634f7e0465c596f16f07698102d9f0dc702ba0a0">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_130.md</strong><dd><code>Update build date and tags for Chrome 130 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_130.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-b63c4b2fc42b252f3207ee4c613be79ec49a7bf8c2a1d6fd35060f1dc9d692cb">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_131.md</strong><dd><code>Update build date and tags for Chrome 131 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_131.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-b23c66923ebe62be2fc9cb211d9d455d4ffebb081a3d662595bab8160a1be8be">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_132.md</strong><dd><code>Update build date and tags for Chrome 132 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_132.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-6a27bae49b008c52ed74c37c5536c8707221d5b57e21b59e001d9e47e8a2755a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_133.md</strong><dd><code>Update build date and tags for Chrome 133 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_133.md

<li>Updated the build date and Selenium Grid version from 20250505 to <br>20250515.<br> <li> Updated all related Docker image tags to use the new build date <br>20250515.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-b697227f32aaedc5ab7bf9ac24df15c6b2f2f2b64b8de1216506632eaf9c9cfc">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_99.md</strong><dd><code>Update build date and tags for Chrome 99 changelog</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_99.md

<li>Updated the build date from 20250505 to 20250515 in all relevant <br>lines.<br> <li> Updated all Docker image tags to reflect the new build date.<br> <li> Updated the Selenium Grid version to include the new build date.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-4ee2ac80e5e8accf43bbdcf81490044b3140901f5e8af4fb69f8f0b549451772">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_134.md</strong><dd><code>Add changelog for Chrome version 134 with build 20250515</code>&nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_134.md

<li>Added a new changelog file for Chrome version 134.<br> <li> Included details for Chrome and ChromeDriver versions, build date, and <br>all related Docker image tags.<br> <li> Documented the tagging process for both node and standalone Chrome <br>images.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-9b534d4e2fb485c6cbfaad56d95cfe4b4f6a2d9c263f3999dff05b7e636e011b">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>chrome_97.md</strong><dd><code>Add changelog for Chrome version 97 with build 20250515</code>&nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.32.0/chrome_97.md

<li>Added a new changelog file for Chrome version 97.<br> <li> Included details for Chrome and ChromeDriver versions, build date, and <br>all related Docker image tags.<br> <li> Documented the tagging process for both node and standalone Chrome <br>images.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-71ee724b7ff1805cb446d24216dd59bd1e5c56fc45a65f49fcbba43d39f7585f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>browser-matrix.yml</strong><dd><code>Update Edge version for backward compatibility matrix</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/build-backward-compatible/browser-matrix.yml

<li>Updated the Edge browser version for matrix entry '136' from <br>136.0.3240.64-1 to 136.0.3240.76-1.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2836/files#diff-c4ca639aae9c5e4c349b00a84db7b540ca4b0b292704fbf78b668736629d426d">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>