### PR TITLE
Docker: Add Node env var `SE_NODE_CONNECTION_LIMIT_PER_SESSION` and README

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -144,4 +144,6 @@
 | SE_NODE_REGISTER_SHUTDOWN_ON_FAILURE | true | If this flag is enabled, the Node will shut down after the register period is completed. This is useful for container environments to restart and register again. If restarted multiple times, the Node container status will be CrashLoopBackOff | --register-shutdown-on-failure |
 | SE_NODE_RELAY_BROWSER_VERSION |  |  |  |
 | SE_NODE_RELAY_ONLY | true |  |  |
-| SE_EXTRA_LIBS | | Extra jars to add to the classpath | --ext |
+| SE_EXTRA_LIBS |  | Extra jars to add to the classpath in server component bootstrap | --ext |
+| SE_NODE_CONNECTION_LIMIT_PER_SESSION | 10 |  |  |
+| SE_SUPERVISORD_UNIX_SERVER_PASSWORD | secret |  |  |

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -49,6 +49,7 @@ ENV LANG_WHICH=${LANG_WHICH} \
     SE_NODE_REGISTER_PERIOD="120" \
     SE_NODE_REGISTER_CYCLE="10" \
     SE_NODE_REGISTER_SHUTDOWN_ON_FAILURE="true" \
+    SE_NODE_CONNECTION_LIMIT_PER_SESSION="10" \
     SE_OTEL_SERVICE_NAME="selenium-node" \
     SE_NODE_RELAY_ONLY="true" \
     # Setting Selenium Manager to work offline

--- a/README.md
+++ b/README.md
@@ -1901,5 +1901,14 @@ mkdir /tmp/videos
 chown 1200:1201 /tmp/videos
 ```
 
+### Websocket connections per session get exhausted
+
+> org.openqa.selenium.remote.http.ConnectionFailedException: JdkWebSocket initial request execution error`
+
+This was reported in [#2850](https://github.com/SeleniumHQ/docker-selenium/issues/2850).
+Actually, from Grid version v4.26.0+, in Node CLI option `--connection-limit-per-session` (`SE_NODE_CONNECTION_LIMIT_PER_SESSION` environment variable) is set to `10` by default. Let X be the maximum number of websocket connections per session.This will ensure one session is not able to exhaust the connection limit of the host. Websocket connection might come from enable CDP, BiDi.
+
+Your test scenario or test framework implementation might be creating more than `X` connections per session, which will lead to the error above. You can optimize your implementation to use less connections per session, or you can increase the limit by setting the environment variable `SE_NODE_CONNECTION_LIMIT_PER_SESSION` to a value higher than `10` to allow more connections per session.
+
 ## Stargazers over time
 [![Stargazers over time](https://starchart.cc/SeleniumHQ/docker-selenium.svg?variant=adaptive)](https://starchart.cc/SeleniumHQ/docker-selenium)

--- a/scripts/generate_list_env_vars/description.yaml
+++ b/scripts/generate_list_env_vars/description.yaml
@@ -440,3 +440,12 @@
 - name: SE_NODE_RELAY_ONLY
   description: ''
   cli: ''
+- name: SE_EXTRA_LIBS
+  description: Extra jars to add to the classpath in server component bootstrap
+  cli: --ext
+- name: SE_NODE_CONNECTION_LIMIT_PER_SESSION
+  description: ''
+  cli: ''
+- name: SE_SUPERVISORD_UNIX_SERVER_PASSWORD
+  description: ''
+  cli: ''

--- a/scripts/generate_list_env_vars/value.yaml
+++ b/scripts/generate_list_env_vars/value.yaml
@@ -36,6 +36,8 @@
   default: '4443'
 - name: SE_EXTERNAL_URL
   default: ''
+- name: SE_EXTRA_LIBS
+  default: ''
 - name: SE_FRAME_RATE
   default: '15'
 - name: SE_GRID_URL
@@ -78,6 +80,8 @@
   default: ''
 - name: SE_NODE_BROWSER_VERSION
   default: stable
+- name: SE_NODE_CONNECTION_LIMIT_PER_SESSION
+  default: '200'
 - name: SE_NODE_CONTAINER_NAME
   default: ''
 - name: SE_NODE_DOCKER_CONFIG_FILENAME
@@ -240,6 +244,8 @@
   default: /tmp/supervisord.pid
 - name: SE_SUPERVISORD_START_RETRIES
   default: '5'
+- name: SE_SUPERVISORD_UNIX_SERVER_PASSWORD
+  default: secret
 - name: SE_UPLOAD_COMMAND
   default: ''
 - name: SE_UPLOAD_DESTINATION_PREFIX


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #2850 

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
enhancement, documentation


___

### **Description**
- Introduced `SE_NODE_CONNECTION_LIMIT_PER_SESSION` environment variable.
  - Added to Node Dockerfile with default value.
  - Documented in ENV_VARIABLES.md and README.md.
  - Included in environment variable generation scripts.

- Updated documentation to address WebSocket connection exhaustion.
  - Provided troubleshooting and configuration guidance for connection limits.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Add SE_NODE_CONNECTION_LIMIT_PER_SESSION to Node Dockerfile</code></dd></summary>
<hr>

NodeBase/Dockerfile

<li>Added <code>SE_NODE_CONNECTION_LIMIT_PER_SESSION</code> with default value <code>10</code> to <br>Node environment variables.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2855/files#diff-16a06916a1ac13cfa86d64f9a62439648853b0e48f98b68ac36305f31de7f2c4">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>description.yaml</strong><dd><code>Add descriptions for new environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_list_env_vars/description.yaml

<li>Added descriptions for <code>SE_EXTRA_LIBS</code>, <br><code>SE_NODE_CONNECTION_LIMIT_PER_SESSION</code>, and <br><code>SE_SUPERVISORD_UNIX_SERVER_PASSWORD</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2855/files#diff-b3cb49ac37600014419abf1369cf4b5a461d55671b0c6b815b18d7d5030c2352">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>value.yaml</strong><dd><code>Add default values for new environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_list_env_vars/value.yaml

<li>Added default values for <code>SE_EXTRA_LIBS</code>, <br><code>SE_NODE_CONNECTION_LIMIT_PER_SESSION</code>, and <br><code>SE_SUPERVISORD_UNIX_SERVER_PASSWORD</code>.<br> <li> Set default for <code>SE_NODE_CONNECTION_LIMIT_PER_SESSION</code> to <code>200</code>.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2855/files#diff-40c21ad1afd76f2f3afbc05f7c916aebf35417a74feabeaec3d84600944e9e9e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ENV_VARIABLES.md</strong><dd><code>Document new and updated environment variables</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ENV_VARIABLES.md

<li>Documented <code>SE_NODE_CONNECTION_LIMIT_PER_SESSION</code> and <br><code>SE_SUPERVISORD_UNIX_SERVER_PASSWORD</code>.<br> <li> Clarified <code>SE_EXTRA_LIBS</code> description.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2855/files#diff-575787a64e27e14d8c3ef34ad655dde25f38457d2c82335a3cb9f2dd44024035">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add troubleshooting and usage for connection limit per session</code></dd></summary>
<hr>

README.md

<li>Added troubleshooting section for WebSocket connection exhaustion.<br> <li> Explained usage and adjustment of <br><code>SE_NODE_CONNECTION_LIMIT_PER_SESSION</code>.<br> <li> Linked to related issue and described default behavior.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2855/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+9/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>