### PR TITLE
Docker: Fix video recording in Node consume high CPU

### DIFF
--- a/tests/docker-compose-v3-dev-arm64.yml
+++ b/tests/docker-compose-v3-dev-arm64.yml
@@ -17,6 +17,7 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_VNC_NO_PASSWORD=true
       - SE_NODE_ENABLE_MANAGED_DOWNLOADS=true
+      - SE_RECORD_VIDEO=true
 
   firefox:
     deploy:
@@ -32,6 +33,7 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_VNC_NO_PASSWORD=true
       - SE_NODE_ENABLE_MANAGED_DOWNLOADS=true
+      - SE_RECORD_VIDEO=true
 
   selenium-hub:
     image: selenium/hub:4.33.0-20250525

--- a/tests/docker-compose-v3-get-started-arm64.yml
+++ b/tests/docker-compose-v3-get-started-arm64.yml
@@ -5,11 +5,9 @@ services:
   chrome:
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 3
     image: selenium/node-chromium:latest
     shm_size: 2gb
-    ports:
-      - "5900:5900"
     depends_on:
       - selenium-hub
     volumes:
@@ -23,11 +21,9 @@ services:
   firefox:
     deploy:
       mode: replicated
-      replicas: 1
+      replicas: 3
     image: selenium/node-firefox:latest
     shm_size: 2gb
-    ports:
-      - "5901:5900"
     depends_on:
       - selenium-hub
     volumes:

--- a/tests/get_started.py
+++ b/tests/get_started.py
@@ -29,7 +29,7 @@ def run_browser_instance(browser, grid_url):
     elif browser == "edge":
         options = EdgeOptions()
     options.enable_bidi = True
-    options.enable_downloads = True
+    options.enable_downloads = False
 
     while True:
         driver = webdriver.Remote(


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/2788

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix, Enhancement


___

### **Description**
- Optimize ffmpeg video recording to reduce Node CPU usage
  - Adjust ffmpeg parameters for efficiency and configurability
  - Lower default ffmpeg thread count and tune encoding settings

- Improve video recording polling and logging logic
  - Increase poll interval and add clearer waiting log messages

- Update test Docker Compose files for video recording
  - Enable video recording in Node services by default
  - Increase Node replicas for Chrome and Firefox in get-started config

- Set browser download capability to false in tests


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>video.sh</strong><dd><code>Optimize ffmpeg usage and polling for video recording</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Video/video.sh

<li>Refactored ffmpeg command to use more efficient parameters and <br>environment variables.<br> <li> Reduced default ffmpeg thread count and added encoding optimizations.<br> <li> Increased polling interval for video recording checks.<br> <li> Improved logging and waiting logic when no session is present.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2856/files#diff-7cd0ffe6390f76d290d88e6e4e3c360e9a797096c0b0fb76874303c5ca319f4b">+14/-5</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>get_started.py</strong><dd><code>Disable browser downloads in test setup</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/get_started.py

<li>Set browser download capability (<code>enable_downloads</code>) to False for all <br>browsers.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2856/files#diff-bbb67b21670eda852bda8a4e9e15c6ab49987f1169b732ab5edc9b6ffc85bafc">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-dev-arm64.yml</strong><dd><code>Enable video recording in dev ARM64 Docker Compose</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/docker-compose-v3-dev-arm64.yml

<li>Enabled video recording (<code>SE_RECORD_VIDEO=true</code>) for Chrome and Firefox <br>Node services.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2856/files#diff-c8b934d053296bab8d27915fcc5f5bde8a3b25725b753aef32cff5feb0c93a3e">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>docker-compose-v3-get-started-arm64.yml</strong><dd><code>Scale up Node replicas and clean up ports in get-started config</code></dd></summary>
<hr>

tests/docker-compose-v3-get-started-arm64.yml

<li>Increased Chrome and Firefox Node replicas from 1 to 3.<br> <li> Removed VNC port mappings for both browsers.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2856/files#diff-f1f675fcb95b7ed5dc5cd04b9bd912ab692d7802f63f31a037ca9ba29925f43f">+2/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>