### PR TITLE
[ci] CHANGELOG for Node/Standalone firefox browser versions with Grid 4.33.0

### DIFF
--- a/CHANGELOG/4.33.0/firefox_100.md
+++ b/CHANGELOG/4.33.0/firefox_100.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 100.0.2
 Short Firefox version -> 100.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:100.0.2-20250525
-Tagged selenium/standalone-firefox:100.0.2-20250525
-Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:100.0-20250525
-Tagged selenium/standalone-firefox:100.0-20250525
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:100.0.2-20250606
+Tagged selenium/standalone-firefox:100.0.2-20250606
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:100.0-20250606
+Tagged selenium/standalone-firefox:100.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_101.md
+++ b/CHANGELOG/4.33.0/firefox_101.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 101.0.1
 Short Firefox version -> 101.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:101.0.1-20250525
-Tagged selenium/standalone-firefox:101.0.1-20250525
-Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:101.0-20250525
-Tagged selenium/standalone-firefox:101.0-20250525
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:101.0.1-20250606
+Tagged selenium/standalone-firefox:101.0.1-20250606
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:101.0-20250606
+Tagged selenium/standalone-firefox:101.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_102.md
+++ b/CHANGELOG/4.33.0/firefox_102.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 102.0.1
 Short Firefox version -> 102.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:102.0.1-20250525
-Tagged selenium/standalone-firefox:102.0.1-20250525
-Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:102.0-20250525
-Tagged selenium/standalone-firefox:102.0-20250525
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:102.0.1-20250606
+Tagged selenium/standalone-firefox:102.0.1-20250606
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:102.0-20250606
+Tagged selenium/standalone-firefox:102.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_103.md
+++ b/CHANGELOG/4.33.0/firefox_103.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 103.0.2
 Short Firefox version -> 103.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:103.0.2-20250525
-Tagged selenium/standalone-firefox:103.0.2-20250525
-Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:103.0-20250525
-Tagged selenium/standalone-firefox:103.0-20250525
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:103.0.2-20250606
+Tagged selenium/standalone-firefox:103.0.2-20250606
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:103.0-20250606
+Tagged selenium/standalone-firefox:103.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_104.md
+++ b/CHANGELOG/4.33.0/firefox_104.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 104.0.2
 Short Firefox version -> 104.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:104.0.2-20250525
-Tagged selenium/standalone-firefox:104.0.2-20250525
-Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:104.0-20250525
-Tagged selenium/standalone-firefox:104.0-20250525
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:104.0.2-20250606
+Tagged selenium/standalone-firefox:104.0.2-20250606
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:104.0-20250606
+Tagged selenium/standalone-firefox:104.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_105.md
+++ b/CHANGELOG/4.33.0/firefox_105.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 105.0.3
 Short Firefox version -> 105.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:105.0.3-20250525
-Tagged selenium/standalone-firefox:105.0.3-20250525
-Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:105.0-20250525
-Tagged selenium/standalone-firefox:105.0-20250525
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:105.0.3-20250606
+Tagged selenium/standalone-firefox:105.0.3-20250606
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:105.0-20250606
+Tagged selenium/standalone-firefox:105.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_106.md
+++ b/CHANGELOG/4.33.0/firefox_106.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 106.0.5
 Short Firefox version -> 106.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:106.0.5-20250525
-Tagged selenium/standalone-firefox:106.0.5-20250525
-Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:106.0-20250525
-Tagged selenium/standalone-firefox:106.0-20250525
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:106.0.5-20250606
+Tagged selenium/standalone-firefox:106.0.5-20250606
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:106.0-20250606
+Tagged selenium/standalone-firefox:106.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_107.md
+++ b/CHANGELOG/4.33.0/firefox_107.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 107.0.1
 Short Firefox version -> 107.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:107.0.1-20250525
-Tagged selenium/standalone-firefox:107.0.1-20250525
-Tagged selenium/node-firefox:107.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:107.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:107.0-20250525
-Tagged selenium/standalone-firefox:107.0-20250525
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:107.0.1-20250606
+Tagged selenium/standalone-firefox:107.0.1-20250606
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:107.0-20250606
+Tagged selenium/standalone-firefox:107.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_108.md
+++ b/CHANGELOG/4.33.0/firefox_108.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 108.0.2
 Short Firefox version -> 108.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:108.0.2-20250525
-Tagged selenium/standalone-firefox:108.0.2-20250525
-Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:108.0-20250525
-Tagged selenium/standalone-firefox:108.0-20250525
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:108.0.2-20250606
+Tagged selenium/standalone-firefox:108.0.2-20250606
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:108.0-20250606
+Tagged selenium/standalone-firefox:108.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_109.md
+++ b/CHANGELOG/4.33.0/firefox_109.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 109.0.1
 Short Firefox version -> 109.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:109.0.1-20250525
-Tagged selenium/standalone-firefox:109.0.1-20250525
-Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:109.0-20250525
-Tagged selenium/standalone-firefox:109.0-20250525
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:109.0.1-20250606
+Tagged selenium/standalone-firefox:109.0.1-20250606
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:109.0-20250606
+Tagged selenium/standalone-firefox:109.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_110.md
+++ b/CHANGELOG/4.33.0/firefox_110.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 110.0.1
 Short Firefox version -> 110.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:110.0.1-20250525
-Tagged selenium/standalone-firefox:110.0.1-20250525
-Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:110.0-20250525
-Tagged selenium/standalone-firefox:110.0-20250525
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:110.0.1-20250606
+Tagged selenium/standalone-firefox:110.0.1-20250606
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:110.0-20250606
+Tagged selenium/standalone-firefox:110.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_111.md
+++ b/CHANGELOG/4.33.0/firefox_111.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 111.0.1
 Short Firefox version -> 111.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:111.0.1-20250525
-Tagged selenium/standalone-firefox:111.0.1-20250525
-Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:111.0-20250525
-Tagged selenium/standalone-firefox:111.0-20250525
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:111.0.1-20250606
+Tagged selenium/standalone-firefox:111.0.1-20250606
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:111.0-20250606
+Tagged selenium/standalone-firefox:111.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_112.md
+++ b/CHANGELOG/4.33.0/firefox_112.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 112.0.2
 Short Firefox version -> 112.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:112.0.2-20250525
-Tagged selenium/standalone-firefox:112.0.2-20250525
-Tagged selenium/node-firefox:112.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:112.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:112.0-20250525
-Tagged selenium/standalone-firefox:112.0-20250525
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:112.0.2-20250606
+Tagged selenium/standalone-firefox:112.0.2-20250606
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:112.0-20250606
+Tagged selenium/standalone-firefox:112.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_113.md
+++ b/CHANGELOG/4.33.0/firefox_113.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 113.0.2
 Short Firefox version -> 113.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:113.0.2-20250525
-Tagged selenium/standalone-firefox:113.0.2-20250525
-Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:113.0-20250525
-Tagged selenium/standalone-firefox:113.0-20250525
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:113.0.2-20250606
+Tagged selenium/standalone-firefox:113.0.2-20250606
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:113.0-20250606
+Tagged selenium/standalone-firefox:113.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_114.md
+++ b/CHANGELOG/4.33.0/firefox_114.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 114.0.2
 Short Firefox version -> 114.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:114.0.2-20250525
-Tagged selenium/standalone-firefox:114.0.2-20250525
-Tagged selenium/node-firefox:114.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:114.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:114.0-20250525
-Tagged selenium/standalone-firefox:114.0-20250525
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:114.0.2-20250606
+Tagged selenium/standalone-firefox:114.0.2-20250606
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:114.0-20250606
+Tagged selenium/standalone-firefox:114.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_115.md
+++ b/CHANGELOG/4.33.0/firefox_115.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 115.0.3
 Short Firefox version -> 115.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:115.0.3-20250525
-Tagged selenium/standalone-firefox:115.0.3-20250525
-Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:115.0-20250525
-Tagged selenium/standalone-firefox:115.0-20250525
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:115.0.3-20250606
+Tagged selenium/standalone-firefox:115.0.3-20250606
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:115.0-20250606
+Tagged selenium/standalone-firefox:115.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_116.md
+++ b/CHANGELOG/4.33.0/firefox_116.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 116.0.3
 Short Firefox version -> 116.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:116.0.3-20250525
-Tagged selenium/standalone-firefox:116.0.3-20250525
-Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:116.0-20250525
-Tagged selenium/standalone-firefox:116.0-20250525
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:116.0.3-20250606
+Tagged selenium/standalone-firefox:116.0.3-20250606
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:116.0-20250606
+Tagged selenium/standalone-firefox:116.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_117.md
+++ b/CHANGELOG/4.33.0/firefox_117.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 117.0.1
 Short Firefox version -> 117.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:117.0.1-20250525
-Tagged selenium/standalone-firefox:117.0.1-20250525
-Tagged selenium/node-firefox:117.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:117.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:117.0-20250525
-Tagged selenium/standalone-firefox:117.0-20250525
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:117.0.1-20250606
+Tagged selenium/standalone-firefox:117.0.1-20250606
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:117.0-20250606
+Tagged selenium/standalone-firefox:117.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_118.md
+++ b/CHANGELOG/4.33.0/firefox_118.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 118.0.2
 Short Firefox version -> 118.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:118.0.2-20250525
-Tagged selenium/standalone-firefox:118.0.2-20250525
-Tagged selenium/node-firefox:118.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:118.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:118.0-20250525
-Tagged selenium/standalone-firefox:118.0-20250525
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:118.0.2-20250606
+Tagged selenium/standalone-firefox:118.0.2-20250606
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:118.0-20250606
+Tagged selenium/standalone-firefox:118.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_119.md
+++ b/CHANGELOG/4.33.0/firefox_119.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 119.0.1
 Short Firefox version -> 119.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:119.0.1-20250525
-Tagged selenium/standalone-firefox:119.0.1-20250525
-Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:119.0-20250525
-Tagged selenium/standalone-firefox:119.0-20250525
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:119.0.1-20250606
+Tagged selenium/standalone-firefox:119.0.1-20250606
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:119.0-20250606
+Tagged selenium/standalone-firefox:119.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_120.md
+++ b/CHANGELOG/4.33.0/firefox_120.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 120.0.1
 Short Firefox version -> 120.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:120.0.1-20250525
-Tagged selenium/standalone-firefox:120.0.1-20250525
-Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:120.0-20250525
-Tagged selenium/standalone-firefox:120.0-20250525
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:120.0.1-20250606
+Tagged selenium/standalone-firefox:120.0.1-20250606
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:120.0-20250606
+Tagged selenium/standalone-firefox:120.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_121.md
+++ b/CHANGELOG/4.33.0/firefox_121.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 121.0.1
 Short Firefox version -> 121.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:121.0.1-20250525
-Tagged selenium/standalone-firefox:121.0.1-20250525
-Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:121.0-20250525
-Tagged selenium/standalone-firefox:121.0-20250525
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:121.0.1-20250606
+Tagged selenium/standalone-firefox:121.0.1-20250606
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:121.0-20250606
+Tagged selenium/standalone-firefox:121.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_122.md
+++ b/CHANGELOG/4.33.0/firefox_122.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 122.0.1
 Short Firefox version -> 122.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:122.0.1-20250525
-Tagged selenium/standalone-firefox:122.0.1-20250525
-Tagged selenium/node-firefox:122.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:122.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:122.0-20250525
-Tagged selenium/standalone-firefox:122.0-20250525
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:122.0.1-20250606
+Tagged selenium/standalone-firefox:122.0.1-20250606
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:122.0-20250606
+Tagged selenium/standalone-firefox:122.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_123.md
+++ b/CHANGELOG/4.33.0/firefox_123.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 123.0.1
 Short Firefox version -> 123.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:123.0.1-20250525
-Tagged selenium/standalone-firefox:123.0.1-20250525
-Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:123.0-20250525
-Tagged selenium/standalone-firefox:123.0-20250525
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:123.0.1-20250606
+Tagged selenium/standalone-firefox:123.0.1-20250606
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:123.0-20250606
+Tagged selenium/standalone-firefox:123.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_124.md
+++ b/CHANGELOG/4.33.0/firefox_124.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 124.0.2
 Short Firefox version -> 124.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:124.0.2-20250525
-Tagged selenium/standalone-firefox:124.0.2-20250525
-Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:124.0-20250525
-Tagged selenium/standalone-firefox:124.0-20250525
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:124.0.2-20250606
+Tagged selenium/standalone-firefox:124.0.2-20250606
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:124.0-20250606
+Tagged selenium/standalone-firefox:124.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_125.md
+++ b/CHANGELOG/4.33.0/firefox_125.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 125.0.3
 Short Firefox version -> 125.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:125.0.3-20250525
-Tagged selenium/standalone-firefox:125.0.3-20250525
-Tagged selenium/node-firefox:125.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:125.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:125.0-20250525
-Tagged selenium/standalone-firefox:125.0-20250525
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:125.0.3-20250606
+Tagged selenium/standalone-firefox:125.0.3-20250606
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:125.0-20250606
+Tagged selenium/standalone-firefox:125.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_126.md
+++ b/CHANGELOG/4.33.0/firefox_126.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 126.0.1
 Short Firefox version -> 126.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:126.0.1-20250525
-Tagged selenium/standalone-firefox:126.0.1-20250525
-Tagged selenium/node-firefox:126.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:126.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:126.0-20250525
-Tagged selenium/standalone-firefox:126.0-20250525
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:126.0.1-20250606
+Tagged selenium/standalone-firefox:126.0.1-20250606
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:126.0-20250606
+Tagged selenium/standalone-firefox:126.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_127.md
+++ b/CHANGELOG/4.33.0/firefox_127.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 127.0.2
 Short Firefox version -> 127.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:127.0.2-20250525
-Tagged selenium/standalone-firefox:127.0.2-20250525
-Tagged selenium/node-firefox:127.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:127.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:127.0-20250525
-Tagged selenium/standalone-firefox:127.0-20250525
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:127.0.2-20250606
+Tagged selenium/standalone-firefox:127.0.2-20250606
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:127.0-20250606
+Tagged selenium/standalone-firefox:127.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_128.md
+++ b/CHANGELOG/4.33.0/firefox_128.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 128.0.3
 Short Firefox version -> 128.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:128.0.3-20250525
-Tagged selenium/standalone-firefox:128.0.3-20250525
-Tagged selenium/node-firefox:128.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:128.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:128.0-20250525
-Tagged selenium/standalone-firefox:128.0-20250525
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:128.0.3-20250606
+Tagged selenium/standalone-firefox:128.0.3-20250606
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:128.0-20250606
+Tagged selenium/standalone-firefox:128.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_129.md
+++ b/CHANGELOG/4.33.0/firefox_129.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 129.0.2
 Short Firefox version -> 129.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:129.0.2-20250525
-Tagged selenium/standalone-firefox:129.0.2-20250525
-Tagged selenium/node-firefox:129.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:129.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:129.0-20250525
-Tagged selenium/standalone-firefox:129.0-20250525
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:129.0.2-20250606
+Tagged selenium/standalone-firefox:129.0.2-20250606
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:129.0-20250606
+Tagged selenium/standalone-firefox:129.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_130.md
+++ b/CHANGELOG/4.33.0/firefox_130.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 130.0.1
 Short Firefox version -> 130.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:130.0.1-20250525
-Tagged selenium/standalone-firefox:130.0.1-20250525
-Tagged selenium/node-firefox:130.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:130.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:130.0-20250525
-Tagged selenium/standalone-firefox:130.0-20250525
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:130.0.1-20250606
+Tagged selenium/standalone-firefox:130.0.1-20250606
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:130.0-20250606
+Tagged selenium/standalone-firefox:130.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_131.md
+++ b/CHANGELOG/4.33.0/firefox_131.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 131.0.3
 Short Firefox version -> 131.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:131.0.3-20250525
-Tagged selenium/standalone-firefox:131.0.3-20250525
-Tagged selenium/node-firefox:131.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:131.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:131.0-20250525
-Tagged selenium/standalone-firefox:131.0-20250525
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:131.0.3-20250606
+Tagged selenium/standalone-firefox:131.0.3-20250606
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:131.0-20250606
+Tagged selenium/standalone-firefox:131.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_132.md
+++ b/CHANGELOG/4.33.0/firefox_132.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 132.0.2
 Short Firefox version -> 132.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:132.0.2-20250525
-Tagged selenium/standalone-firefox:132.0.2-20250525
-Tagged selenium/node-firefox:132.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:132.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:132.0-20250525
-Tagged selenium/standalone-firefox:132.0-20250525
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:132.0.2-20250606
+Tagged selenium/standalone-firefox:132.0.2-20250606
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:132.0-20250606
+Tagged selenium/standalone-firefox:132.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_133.md
+++ b/CHANGELOG/4.33.0/firefox_133.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 133.0.3
 Short Firefox version -> 133.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:133.0.3-20250525
-Tagged selenium/standalone-firefox:133.0.3-20250525
-Tagged selenium/node-firefox:133.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:133.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:133.0-20250525
-Tagged selenium/standalone-firefox:133.0-20250525
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:133.0.3-20250606
+Tagged selenium/standalone-firefox:133.0.3-20250606
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:133.0-20250606
+Tagged selenium/standalone-firefox:133.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_134.md
+++ b/CHANGELOG/4.33.0/firefox_134.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 134.0.2
 Short Firefox version -> 134.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:134.0.2-20250525
-Tagged selenium/standalone-firefox:134.0.2-20250525
-Tagged selenium/node-firefox:134.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:134.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:134.0-20250525
-Tagged selenium/standalone-firefox:134.0-20250525
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:134.0.2-20250606
+Tagged selenium/standalone-firefox:134.0.2-20250606
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:134.0-20250606
+Tagged selenium/standalone-firefox:134.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_135.md
+++ b/CHANGELOG/4.33.0/firefox_135.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 135.0.1
 Short Firefox version -> 135.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:135.0.1-20250525
-Tagged selenium/standalone-firefox:135.0.1-20250525
-Tagged selenium/node-firefox:135.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:135.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:135.0-20250525
-Tagged selenium/standalone-firefox:135.0-20250525
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:135.0.1-20250606
+Tagged selenium/standalone-firefox:135.0.1-20250606
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:135.0-20250606
+Tagged selenium/standalone-firefox:135.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_136.md
+++ b/CHANGELOG/4.33.0/firefox_136.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 136.0.4
 Short Firefox version -> 136.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:136.0.4-20250525
-Tagged selenium/standalone-firefox:136.0.4-20250525
-Tagged selenium/node-firefox:136.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:136.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:136.0-20250525
-Tagged selenium/standalone-firefox:136.0-20250525
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:136.0.4-20250606
+Tagged selenium/standalone-firefox:136.0.4-20250606
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:136.0-20250606
+Tagged selenium/standalone-firefox:136.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_137.md
+++ b/CHANGELOG/4.33.0/firefox_137.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 137.0.2
 Short Firefox version -> 137.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:137.0.2-20250525
-Tagged selenium/standalone-firefox:137.0.2-20250525
-Tagged selenium/node-firefox:137.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:137.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:137.0-20250525
-Tagged selenium/standalone-firefox:137.0-20250525
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:137.0.2-20250606
+Tagged selenium/standalone-firefox:137.0.2-20250606
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:137.0-20250606
+Tagged selenium/standalone-firefox:137.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_138.md
+++ b/CHANGELOG/4.33.0/firefox_138.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
+Firefox version -> 138.0.4
+Short Firefox version -> 138.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:138.0.4-20250606
+Tagged selenium/standalone-firefox:138.0.4-20250606
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:138.0-20250606
+Tagged selenium/standalone-firefox:138.0-20250606
+```

--- a/CHANGELOG/4.33.0/firefox_98.md
+++ b/CHANGELOG/4.33.0/firefox_98.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 98.0.2
 Short Firefox version -> 98.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:98.0.2-20250525
-Tagged selenium/standalone-firefox:98.0.2-20250525
-Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:98.0-20250525
-Tagged selenium/standalone-firefox:98.0-20250525
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:98.0.2-20250606
+Tagged selenium/standalone-firefox:98.0.2-20250606
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:98.0-20250606
+Tagged selenium/standalone-firefox:98.0-20250606
 ```

--- a/CHANGELOG/4.33.0/firefox_99.md
+++ b/CHANGELOG/4.33.0/firefox_99.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.33.0 20250525 selenium false firefox true
-Tagging images for browser firefox, version 4.33.0, build date 20250525, namespace selenium
-Selenium Grid version -> 4.33.0-20250525
+./tag_and_push_browser_images.sh 4.33.0 20250606 selenium false firefox true
+Tagging images for browser firefox, version 4.33.0, build date 20250606, namespace selenium
+Selenium Grid version -> 4.33.0-20250606
 Firefox version -> 99.0.1
 Short Firefox version -> 99.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-grid-4.33.0-20250525
-Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-20250525
-Tagged selenium/node-firefox:99.0.1-20250525
-Tagged selenium/standalone-firefox:99.0.1-20250525
-Tagged selenium/node-firefox:99.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-grid-4.33.0-20250525
-Tagged selenium/node-firefox:99.0-geckodriver-0.36-20250525
-Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-20250525
-Tagged selenium/node-firefox:99.0-20250525
-Tagged selenium/standalone-firefox:99.0-20250525
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-grid-4.33.0-20250606
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-20250606
+Tagged selenium/node-firefox:99.0.1-20250606
+Tagged selenium/standalone-firefox:99.0.1-20250606
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-grid-4.33.0-20250606
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-20250606
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-20250606
+Tagged selenium/node-firefox:99.0-20250606
+Tagged selenium/standalone-firefox:99.0-20250606
 ```

--- a/tests/build-backward-compatible/browser-matrix.yml
+++ b/tests/build-backward-compatible/browser-matrix.yml
@@ -6,8 +6,8 @@ matrix:
       FIREFOX_VERSION: 138.0.4
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '137':
-      EDGE_VERSION: null
-      CHROME_VERSION: null
+      EDGE_VERSION: microsoft-edge-stable=137.0.3296.68-1
+      CHROME_VERSION: google-chrome-stable=137.0.7151.68-1
       FIREFOX_VERSION: 137.0.2
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '136':

--- a/tests/build-backward-compatible/firefox-matrix.yml
+++ b/tests/build-backward-compatible/firefox-matrix.yml
@@ -1,7 +1,7 @@
 matrix:
   browser:
     '139':
-      FIREFOX_VERSION: '139.0'
+      FIREFOX_VERSION: 139.0.1
     '138':
       FIREFOX_VERSION: 138.0.4
     '137':


### PR DESCRIPTION
### **User description**
This PR contains the CHANGELOG for Node/Standalone firefox with specific browser versions: [98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138]


___

### **PR Type**
Documentation


___

### **Description**
- Updated changelog files for Firefox versions 98 through 138 under Selenium Grid 4.33.0:
  - Changed build date and Selenium Grid version from 20250525 to 20250606.
  - Updated all Docker image tags to reflect the new build date.
  - Added a new changelog entry for Firefox 138.0.4.

- Updated backward compatibility test matrices:
  - Specified Edge and Chrome versions for Firefox 137 in `browser-matrix.yml`.
  - Updated Firefox 139 version from `139.0` to `139.0.1` in `firefox-matrix.yml`.


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>41 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox_100.md</strong><dd><code>Update build date and image tags for Firefox 100 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_100.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-b7efd369d2046354c50404fd8122fb6875b1885baf43e57376d9d8f786ca9d57">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_101.md</strong><dd><code>Update build date and image tags for Firefox 101 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_101.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-333a05e92b60ed8d4a6a2fef447811d685b5b90dfa840f60cbbcb1e2b7d0d31a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_102.md</strong><dd><code>Update build date and image tags for Firefox 102 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_102.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-b4417697dd58273227c25760032021166cb8b08659ecd5b3afb710fd4fcbbf4c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_103.md</strong><dd><code>Update build date and image tags for Firefox 103 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_103.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-e2e33fb07c10f1c1250517e90d72f2c82aa3eda6ef730849c1044b8fc7f310c6">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_104.md</strong><dd><code>Update build date and image tags for Firefox 104 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_104.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-68e93c99ef8a49fdb16dc917625cc2499ace74f9f88282e8839862111d873b4b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_105.md</strong><dd><code>Update build date and image tags for Firefox 105 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_105.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-0d975805d43ffa4cc288b2c9c2c15ef3537f67c9e8ef7393dad88313798a947d">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_106.md</strong><dd><code>Update build date and image tags for Firefox 106 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_106.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-744105b6ed0353ac8b71fe2b046fc334ef4d6a202d10fc2566886b37b98833e2">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_107.md</strong><dd><code>Update build date and image tags for Firefox 107 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_107.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-edd7be95bba2d87445421843a48c83d9f120ed627fa497b657eb36b6e66ac3aa">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_108.md</strong><dd><code>Update build date and image tags for Firefox 108 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_108.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-411074835a11561a12630ef8248a95d24e413cb8ddf53276599cc7502fcae0be">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_109.md</strong><dd><code>Update build date and image tags for Firefox 109 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_109.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-f1b79494e29866a14016efaab05c0a028885453911c5e25f23169d87172c93cd">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_110.md</strong><dd><code>Update build date and image tags for Firefox 110 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_110.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-9999c7c0257af8e7d3eb566a21cadd31a4ea3f82acde8bfb89ed70e867d5f937">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_111.md</strong><dd><code>Update build date and image tags for Firefox 111 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_111.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-375a72e1bc83c3efdc410de3a24a856816c0bd04898818895825b3cff5e3aa2c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_112.md</strong><dd><code>Update build date and image tags for Firefox 112 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_112.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-531db740fdc7dc02d4fb4745e8a86bb26a2fd87387d84746a9227cc5e1816c36">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_113.md</strong><dd><code>Update build date and image tags for Firefox 113 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_113.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-4a79c74d3a9535352017f1ab34b9f3321b960e0c53cf9b3c83a2494440e346d1">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_114.md</strong><dd><code>Update build date and image tags for Firefox 114 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_114.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-390d63472d7dcef042399053261b92b00ee2266c7fcc9e77432172e03a60f28f">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_115.md</strong><dd><code>Update build date and image tags for Firefox 115 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_115.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-88258e7cdee27bfe4634ca61b89b05a5a87c53a43f5a8b2abe10d7674856e632">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_116.md</strong><dd><code>Update build date and image tags for Firefox 116 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_116.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-0c4ca6b34582d8d5c94c71acf33f8cbad316cfd84903095d1756217206d55ea0">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_117.md</strong><dd><code>Update build date and image tags for Firefox 117 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_117.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-bc3a3a0400fb8a93d707166469d00903a2a6d58e9ab77d4ba2cbf29da43a0c5b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_118.md</strong><dd><code>Update build date and image tags for Firefox 118 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_118.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-bd49cdd0b13599476d1aacbc460494688bcffae30dedd68cfe6d6b8c5597254e">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_119.md</strong><dd><code>Update build date and image tags for Firefox 119 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_119.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-6b4df384d1bd2a7c3c7d2f755e147b035fdeb15fba31733259be22a7f525c9ce">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_120.md</strong><dd><code>Update build date and image tags for Firefox 120 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_120.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-f3b715278fa66b84ea1d09dd2de445d1b280040677710dbd31faab0265191964">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_121.md</strong><dd><code>Update build date and image tags for Firefox 121 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_121.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-0203f01340232931be5517ebe573ff0d83ff1526693cccfb1eccf768c525da2c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_122.md</strong><dd><code>Update build date and image tags for Firefox 122 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_122.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-cfb8a4a87c4c511299b574476eaf06ef5ff2fc3919cb18aace913d293cca5c5e">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_123.md</strong><dd><code>Update build date and image tags for Firefox 123 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_123.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-467d3cd77d1275ef6d73aa793fd5689532d0474bf4962d40074e898588454f0c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_124.md</strong><dd><code>Update build date and image tags for Firefox 124 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_124.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-9108dcfffdab80d9d5d926098cebdfc0f729c76848ca40d645a785e71ffb3fba">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_125.md</strong><dd><code>Update build date and image tags for Firefox 125 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_125.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-5f280028323920ed838ecb58a771f0327c17ae437dc07281ab9399a4648116b0">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_126.md</strong><dd><code>Update build date and image tags for Firefox 126 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_126.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-46a396b83e10eca5aea9b30735f075199ec4a4ea4c2f9c5fe3242d0dc072cc9a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_127.md</strong><dd><code>Update build date and image tags for Firefox 127 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_127.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-7844f8c5ac2376c6523a44b46298e265a09354424e787e24bdc0281e8bd73667">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_128.md</strong><dd><code>Update build date and image tags for Firefox 128 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_128.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-e7f5bd32d20c36e15a0be0b4a1cd840e16361ab1a63d1b0324851b2b38703788">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_129.md</strong><dd><code>Update build date and image tags for Firefox 129 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_129.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-ce249c1fb51c3797be80f5681972d27441fae98ea4e2ebf062e0355dd9ff53ff">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_130.md</strong><dd><code>Update build date and image tags for Firefox 130 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_130.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-222c67988329b8bf191dfcaffe1c78788648e35d84096ca9e4a18f9e7a40da1f">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_131.md</strong><dd><code>Update build date and image tags for Firefox 131 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_131.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-f911cd9596b6ea2296da6a393b4b27a73e76ad1a32a6694f421f04204d07326b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_132.md</strong><dd><code>Update build date and image tags for Firefox 132 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_132.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-df2a1b3aacf31c92b95efbc1b1de9a8362fb39e5c084919ed8fb0137e248f536">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_133.md</strong><dd><code>Update build date and image tags for Firefox 133 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_133.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-f744e2d6bf22ad5861e869ee9ad3953d9c1018dcd30d7669d3fd47dbcff7e6d9">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_134.md</strong><dd><code>Update build date and image tags for Firefox 134 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_134.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-520c00cdcad776f42db8adb58b7227a781975ed7f63f551e58e018c0a7a2b872">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_135.md</strong><dd><code>Update build date and image tags for Firefox 135 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_135.md

<li>Updated the build date and Selenium Grid version from 20250525 to <br>20250606.<br> <li> Updated all Docker image tags to use the new build date 20250606.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-7874429c25f27ad39660235c5678cd89d7988c850378b481320df3cdeb744a5d">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_138.md</strong><dd><code>Add changelog for Firefox 138.0.4 with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_138.md

<li>Added a new changelog file for Firefox version 138.0.4 with build date <br>20250606.<br> <li> Included all relevant Docker image tags and version information for <br>this new version.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-20deb1bbb17c69999198509ddab7b8d06f0344a1e7bf01a6afc4ee325ff3bb2f">+21/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_136.md</strong><dd><code>Update build date and image tags for Firefox 136 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_136.md

<li>Updated the build date from 20250525 to 20250606 in all relevant <br>lines.<br> <li> Changed all Docker image tags to use the new build date (20250606).<br> <li> Updated the Selenium Grid version string to reflect the new build <br>date.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-9cb83298a9dbc0a8b18178c892a44a35ca1fb98757b9ae4ce5b47488d7328e18">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_137.md</strong><dd><code>Update build date and image tags for Firefox 137 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_137.md

<li>Updated the build date from 20250525 to 20250606 in all relevant <br>lines.<br> <li> Changed all Docker image tags to use the new build date (20250606).<br> <li> Updated the Selenium Grid version string to reflect the new build <br>date.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-3bc80b12eda640f61e3ff145fcbf460c2f604a4baad999125d81fb5071a5fc29">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_98.md</strong><dd><code>Update build date and image tags for Firefox 98 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_98.md

<li>Updated the build date from 20250525 to 20250606 in all relevant <br>lines.<br> <li> Changed all Docker image tags to use the new build date (20250606).<br> <li> Updated the Selenium Grid version string to reflect the new build <br>date.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-9a92b20fdfe40a4c22b96cd93b8a20947eb4a881c9d1da632fa0ac767ff748ac">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_99.md</strong><dd><code>Update build date and image tags for Firefox 99 changelog</code></dd></summary>
<hr>

CHANGELOG/4.33.0/firefox_99.md

<li>Updated the build date from 20250525 to 20250606 in all relevant <br>lines.<br> <li> Changed all Docker image tags to use the new build date (20250606).<br> <li> Updated the Selenium Grid version string to reflect the new build <br>date.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-58427b3413c8b540058d8c8c736a2eeb6c8baa8b98218d706a297b46474496ef">+15/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>browser-matrix.yml</strong><dd><code>Specify Edge and Chrome versions for Firefox 137 in matrix</code></dd></summary>
<hr>

tests/build-backward-compatible/browser-matrix.yml

<li>Added specific version numbers for EDGE_VERSION and CHROME_VERSION for <br>Firefox 137.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-c4ca639aae9c5e4c349b00a84db7b540ca4b0b292704fbf78b668736629d426d">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox-matrix.yml</strong><dd><code>Update Firefox 139 version in backward compatibility matrix</code></dd></summary>
<hr>

tests/build-backward-compatible/firefox-matrix.yml

- Updated the Firefox version for 139 from '139.0' to '139.0.1'.


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2862/files#diff-39f1a5ceaf6677e17418ed72ee32a68cf0bdff37562b2c7b9d787a95a72a39a6">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>