### PR TITLE
Revert "Docker: Add default value for env var `SE_NODE_GRID_URL`"

### DIFF
--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -23,7 +23,7 @@
 | SE_SUPERVISORD_PID_FILE | /tmp/supervisord.pid | Default pid file will be created by supervisord |  |
 | SE_DRAIN_AFTER_SESSION_COUNT | 0 | Drain and detach node from grid after session count exceeds | --drain-after-session-count |
 | SE_SUB_PATH |  | A sub-path that should be considered for all user facing routes on the Hub/Router/Standalone | --sub-path |
-| SE_NODE_GRID_URL | http://localhost:4444 | Node config, public URL of the Grid as a whole (typically the address of the Hub or the Router) | --grid-url |
+| SE_NODE_GRID_URL |  | Node config, public URL of the Grid as a whole (typically the address of the Hub or the Router) | --grid-url |
 | SE_HUB_HOST |  | Hub config, host address the Hub should listen on | --host |
 | SE_ROUTER_HOST |  | Router config, host address the Router should listen on | --host |
 | SE_HUB_PORT | 4444 | Hub config, port the Hub should listen on (default 4444) | --port |

--- a/NodeBase/Dockerfile
+++ b/NodeBase/Dockerfile
@@ -57,7 +57,6 @@ ENV LANG_WHICH=${LANG_WHICH} \
     SE_NODE_BROWSER_VERSION="stable" \
     SE_NODE_PLATFORM_NAME="Linux" \
     SE_NODE_DELETE_SESSION_ON_UI="true" \
-    SE_NODE_GRID_URL="http://localhost:4444" \
 #============================
 # Some configuration options
 #============================

--- a/scripts/generate_list_env_vars/value.yaml
+++ b/scripts/generate_list_env_vars/value.yaml
@@ -101,7 +101,7 @@
 - name: SE_NODE_GRID_GRAPHQL_URL
   default: ''
 - name: SE_NODE_GRID_URL
-  default: http://localhost:4444
+  default: ''
 - name: SE_NODE_HEARTBEAT_PERIOD
   default: '30'
 - name: SE_NODE_HOST


### PR DESCRIPTION
### **User description**
Reverts SeleniumHQ/docker-selenium#2876

Fixes #2889

1. Use case 1: User starts Grid using docker container, and runs test on host.
With this use case, without set --grid-url, the WS endpoint will use the container IP (for example: http://10.255.25.101:4444/), which could not be reached from the test running on host.
CDP, BiDi function could not work because it could not reach the WS endpoint. So, have to ask the user to start the container with another URL.
2. Use case 2: User starts Grid using container and also runs test in container (which in the same container network)
Recently, in container env var set default `--grid-url` point to `http://localhost:4444`. Use case 1 is resolved, people get started with local run, won't worry, for advanced users, complex networks, they set another value.
But it impacts the user running Grid and testing in the same container network - https://github.com/SeleniumHQ/docker-selenium/issues/2889#issuecomment-3051964251

So, the conclusion is revert to the default value. Keep use case 1 as a README note.


___

### **PR Type**
Bug fix


___

### **Description**
- Revert default `SE_NODE_GRID_URL` environment variable setting

- Fix container network connectivity issues for containerized tests

- Restore original behavior for WebSocket endpoint configuration


___

### **Changes diagram**

```mermaid
flowchart LR
  A["Docker Container"] --> B["Remove SE_NODE_GRID_URL default"]
  B --> C["Fix Container Network Issues"]
  C --> D["Restore Original Behavior"]
```


___



### **Changes walkthrough** 📝
<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Remove SE_NODE_GRID_URL default value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/Dockerfile

<li>Remove default value for <code>SE_NODE_GRID_URL</code> environment variable<br> <li> Eliminate hardcoded <code>http://localhost:4444</code> setting


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2890/files#diff-16a06916a1ac13cfa86d64f9a62439648853b0e48f98b68ac36305f31de7f2c4">+0/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

___

> <details> <summary>  Need help?</summary><li>Type <code>/help how to ...</code> in the comments thread for any questions about Qodo Merge usage.</li><li>Check out the <a href="https://qodo-merge-docs.qodo.ai/usage-guide/">documentation</a> for more information.</li></details>