### PR TITLE
[KEDA] Selenium Grid: Add trigger param `overProvisionRatio` for ability to scale more than queue request

### DIFF
--- a/.keda/README.md
+++ b/.keda/README.md
@@ -13,9 +13,9 @@ The stable implementation will be merged to the upstream KEDA repository frequen
 Replace the image registry and tag of these KEDA components with the patched image tag:
 
 ```bash
-docker pull selenium/keda:2.17.2-selenium-grid-20250717
-docker pull selenium/keda-metrics-apiserver:2.17.2-selenium-grid-20250717
-docker pull selenium/keda-admission-webhooks:2.17.2-selenium-grid-20250717
+docker pull selenium/keda:2.17.2-selenium-grid-20250721
+docker pull selenium/keda-metrics-apiserver:2.17.2-selenium-grid-20250721
+docker pull selenium/keda-admission-webhooks:2.17.2-selenium-grid-20250721
 ```
 
 Besides that, you also can use image tag `latest` or `nightly`.
@@ -27,15 +27,15 @@ If you are deploying KEDA core using their official Helm [chart](https://github.
     keda:
       registry: selenium
       repository: keda
-      tag: "2.17.2-selenium-grid-20250717"
+      tag: "2.17.2-selenium-grid-20250721"
     metricsApiServer:
       registry: selenium
       repository: keda-metrics-apiserver
-      tag: "2.17.2-selenium-grid-20250717"
+      tag: "2.17.2-selenium-grid-20250721"
     webhooks:
       registry: selenium
       repository: keda-admission-webhooks
-      tag: "2.17.2-selenium-grid-20250717"
+      tag: "2.17.2-selenium-grid-20250721"
 ```
 
 If you are deployment Selenium Grid chart with `autoscaling.enabled` is `true` (implies installing KEDA sub-chart), KEDA images registry and tag already set in the `values.yaml`. Refer to list [configuration](../charts/selenium-grid/CONFIGURATION.md).
@@ -48,6 +48,8 @@ Here is list of pull requests that are under testing and will be merged to the u
 You can involve to review and discuss the pull requests to help us early detect and fix any issues.
 
 [kedacore/keda](https://github.com/kedacore/keda)
+
+- https://github.com/kedacore/keda/pull/6920 (planned, v2.18.0)
 
 - ~~https://github.com/kedacore/keda/pull/6772 (merged, v2.17.1)~~
 

--- a/.keda/scalers/selenium-grid-scaler.md
+++ b/.keda/scalers/selenium-grid-scaler.md
@@ -28,6 +28,7 @@ triggers:
       nodeMaxSessions: 1 # Optional.
       enableManagedDownloads: true # Optional.
       capabilities: '' # Optional.
+      overProvisionRatio: '' # Optional.
 ```
 
 **Parameter list:**
@@ -42,12 +43,15 @@ triggers:
 - `nodeMaxSessions` - Number of maximum sessions that can run in parallel on a Node. Update this parameter align with node config `--max-sessions` (`SE_NODE_MAX_SESSIONS`) to have the correct scaling behavior. (Default: `1`, Optional).
 - `enableManagedDownloads`- Set this for Node enabled to auto manage files downloaded for a given session on the Node. When the client requests enabling this feature, it can only be assigned to the Node that also enabled it. Otherwise, the request will wait until it timed out. (Default: `true`, Optional).
 - `capabilities` - Add more custom capabilities for matching specific Nodes. It should be in JSON string, see [example](https://www.selenium.dev/documentation/grid/configuration/toml_options/#setting-custom-capabilities-for-matching-specific-nodes) (Optional)
+- `overProvisionRatio` - The number of overprovisioning ratio to scale more than the actual number of requests. For example, if there are 20 requests for the browser instead of scaling to 20 Nodes, it is able to scale 20% more than the requested, in this case is 24, in this case input value is `0.2` (Optional)
 
 **Trigger Authentication**
 - `username` - Username for basic authentication in GraphQL endpoint instead of embedding in the URL. (Optional)
 - `password` - Password for basic authentication in GraphQL endpoint instead of embedding in the URL. (Optional)
 - `authType` - Type of authentication to be used. This can be set to `Bearer` or `OAuth2` in case Selenium Grid behind an Ingress proxy with other authentication types. (Optional)
 - `accessToken` - Access token. This is required when `authType` is set a value. (Optional)
+
+Noted that trigger authentication parameters are able to set in either trigger metadata or trigger authentication. However, if both are set, the trigger authentication will take precedence.
 
 ### Example
 

--- a/.keda/scalers/selenium_grid_scaler_test.go
+++ b/.keda/scalers/selenium_grid_scaler_test.go
@@ -19,12 +19,14 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 		nodeMaxSessions        int64
 		enableManagedDownloads bool
 		capabilities           string
+		overProvisionRatio     float64
 	}
 	tests := []struct {
 		name                string
 		args                args
 		wantNewRequestNodes int64
 		wantOnGoingSessions int64
+		wantOverProvisioned float64
 		wantErr             bool
 	}{
 		{
@@ -435,6 +437,57 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			},
 			wantNewRequestNodes: 1,
 			wantOnGoingSessions: 0,
+			wantErr:             false,
+		},
+		{
+			name: "Scaled_number_when_set_param_over_provisioned",
+			args: args{
+				b: []byte(`{
+                    "data": {
+                        "grid": {
+                            "sessionCount": 0,
+                            "maxSession": 0,
+                            "totalSlots": 0
+                        },
+                        "nodesInfo": {
+                            "nodes": [
+                                {
+                                    "id": "node-1",
+                                    "status": "UP",
+                                    "sessionCount": 0,
+                                    "maxSession": 1,
+                                    "slotCount": 1,
+                                    "stereotypes": "[{\"slots\": 1, \"stereotype\": {\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"linux\"}}]",
+                                    "sessions": []
+                                },
+                                {
+                                    "id": "node-2",
+                                    "status": "UP",
+                                    "sessionCount": 0,
+                                    "maxSession": 1,
+                                    "slotCount": 1,
+                                    "stereotypes": "[{\"slots\": 1, \"stereotype\": {\"browserName\": \"chrome\", \"browserVersion\": \"\", \"platformName\": \"Windows 11\"}}]",
+                                    "sessions": []
+                                }
+                            ]
+                        },
+                        "sessionsInfo": {
+                            "sessionQueueRequests": [
+                                "{\"browserName\": \"chrome\", \"platformName\": \"linux\"}",
+                                "{\"browserName\": \"chrome\", \"platformName\": \"linux\"}"
+                            ]
+                        }
+                    }
+                }`),
+				browserName:        "chrome",
+				sessionBrowserName: "chrome",
+				browserVersion:     "",
+				platformName:       "linux",
+				overProvisionRatio: 1.2,
+			},
+			wantNewRequestNodes: 1,
+			wantOnGoingSessions: 0,
+			wantOverProvisioned: 2.2,
 			wantErr:             false,
 		},
 		{
@@ -1048,7 +1101,7 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 			wantErr:             false,
 		},
 		{
-			name: "1 queue request without platformName and scaler metadata without platfromName should return 1 new node and 1 ongoing session",
+			name: "1 queue request without platformName and scaler metadata without platformName should return 1 new node and 1 ongoing session",
 			args: args{
 				b: []byte(`{
 					"data": {
@@ -3154,12 +3207,16 @@ func Test_getCountFromSeleniumResponse(t *testing.T) {
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
 			newRequestNodes, onGoingSessions, err := getCountFromSeleniumResponse(tt.args.b, tt.args.browserName, tt.args.browserVersion, tt.args.sessionBrowserName, tt.args.platformName, tt.args.nodeMaxSessions, tt.args.enableManagedDownloads, tt.args.capabilities, logr.Discard())
+			scaledCount := getScaledCount(newRequestNodes, onGoingSessions, tt.args.overProvisionRatio)
 			if (err != nil) != tt.wantErr {
 				t.Errorf("getCountFromSeleniumResponse() error = %v, wantErr %v", err, tt.wantErr)
 				return
 			}
 			if !reflect.DeepEqual(newRequestNodes, tt.wantNewRequestNodes) || !reflect.DeepEqual(onGoingSessions, tt.wantOnGoingSessions) {
 				t.Errorf("getCountFromSeleniumResponse() = [%v, %v], want [%v, %v]", newRequestNodes, onGoingSessions, tt.wantNewRequestNodes, tt.wantOnGoingSessions)
+			}
+			if tt.args.overProvisionRatio > 0 && !reflect.DeepEqual(scaledCount, tt.wantOverProvisioned) {
+				t.Errorf("getCountFromSeleniumResponse() = %v, want over-provisioned %v", scaledCount, tt.wantOverProvisioned)
 			}
 		})
 	}

--- a/Makefile
+++ b/Makefile
@@ -34,8 +34,8 @@ KEDA_TAG_PREV_VERSION := $(or $(KEDA_TAG_PREV_VERSION),$(KEDA_TAG_PREV_VERSION),
 KEDA_CORE_VERSION := $(or $(KEDA_CORE_VERSION),$(KEDA_CORE_VERSION),2.17.2)
 KEDA_TAG_VERSION := $(or $(KEDA_TAG_VERSION),$(KEDA_TAG_VERSION),2.17.2-selenium-grid)
 KEDA_BASED_NAME := $(or $(KEDA_BASED_NAME),$(KEDA_BASED_NAME),ndviet)
-KEDA_BASED_TAG := $(or $(KEDA_BASED_TAG),$(KEDA_BASED_TAG),2.17.2-selenium-grid-20250705)
-TEST_PATCHED_KEDA := $(or $(TEST_PATCHED_KEDA),$(TEST_PATCHED_KEDA),false)
+KEDA_BASED_TAG := $(or $(KEDA_BASED_TAG),$(KEDA_BASED_TAG),2.17.2-selenium-grid-20250721)
+TEST_PATCHED_KEDA := $(or $(TEST_PATCHED_KEDA),$(TEST_PATCHED_KEDA),true)
 
 all: hub \
 	distributor \
@@ -284,7 +284,7 @@ fetch_grid_scaler_resources:
 	&& cd ./.keda/scalers \
 	&& curl -L https://raw.githubusercontent.com/$(KEDA_BASED_NAME)/keda/v$(KEDA_BASED_TAG)/pkg/scalers/selenium_grid_scaler.go -o selenium_grid_scaler.go \
 	&& curl -L https://raw.githubusercontent.com/$(KEDA_BASED_NAME)/keda/v$(KEDA_BASED_TAG)/pkg/scalers/selenium_grid_scaler_test.go -o selenium_grid_scaler_test.go \
-	&& curl -L https://raw.githubusercontent.com/$(KEDA_BASED_NAME)/keda-docs/main/content/docs/2.17/scalers/selenium-grid-scaler.md -o selenium-grid-scaler.md
+	&& curl -L https://raw.githubusercontent.com/$(KEDA_BASED_NAME)/keda-docs/main/content/docs/2.18/scalers/selenium-grid-scaler.md -o selenium-grid-scaler.md
 
 fetch_grid_scaler_images:
 	docker pull --platform linux/amd64 --platform linux/arm64 $(KEDA_BASED_NAME)/keda:$(KEDA_BASED_TAG)

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -482,6 +482,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | chromeNode.hpa.browserVersion | string | `""` | browserVersion should match with Node stereotype and request capability is scaled by this scaler |
 | chromeNode.hpa.platformName | string | `""` | platformName should match with Node stereotype and request capability is scaled by this scaler |
 | chromeNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
+| chromeNode.hpa.overProvisionRatio | string | `""` | The number of overprovisioning ratio to scale more than the actual number of requests. For example, over over-provisioning ratio `0.2` means 20% more than the actual requests |
 | chromeNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | chromeNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
 | chromeNode.videoRecorder | object | `{}` | Override specific video recording settings for chrome node |
@@ -541,6 +542,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | firefoxNode.hpa.browserVersion | string | `""` | browserVersion should match with Node stereotype and request capability is scaled by this scaler |
 | firefoxNode.hpa.platformName | string | `""` | platformName should match with Node stereotype and request capability is scaled by this scaler |
 | firefoxNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
+| firefoxNode.hpa.overProvisionRatio | string | `""` | The number of overprovisioning ratio to scale more than the actual number of requests. For example, over over-provisioning ratio `0.2` means 20% more than the actual requests |
 | firefoxNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | firefoxNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
 | firefoxNode.videoRecorder | object | `{}` | Override specific video recording settings for firefox node |
@@ -600,6 +602,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | edgeNode.hpa.browserVersion | string | `""` | browserVersion should match with Node stereotype and request capability is scaled by this scaler |
 | edgeNode.hpa.platformName | string | `""` | platformName should match with Node stereotype and request capability is scaled by this scaler |
 | edgeNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
+| edgeNode.hpa.overProvisionRatio | string | `""` | The number of overprovisioning ratio to scale more than the actual number of requests. For example, over over-provisioning ratio `0.2` means 20% more than the actual requests |
 | edgeNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | edgeNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
 | edgeNode.videoRecorder | object | `{}` | Override specific video recording settings for edge node |
@@ -660,6 +663,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | relayNode.hpa.browserVersion | string | `""` | browserVersion should match with Node stereotype and request capability is scaled by this scaler |
 | relayNode.hpa.platformName | string | `""` | platformName should match with Node stereotype and request capability is scaled by this scaler |
 | relayNode.hpa.unsafeSsl | string | `"{{ template \"seleniumGrid.graphqlURL.unsafeSsl\" . }}"` | Skip check SSL when connecting to the Graphql endpoint |
+| relayNode.hpa.overProvisionRatio | string | `""` | The number of overprovisioning ratio to scale more than the actual number of requests. For example, over over-provisioning ratio `0.2` means 20% more than the actual requests |
 | relayNode.initContainers | list | `[]` | It is used to add initContainers in the same pod of the browser node. It should be set using the --set-json option |
 | relayNode.sidecars | list | `[]` | It is used to add sidecars proxy in the same pod of the browser node. It means it will add a new container to the deployment itself. It should be set using the --set-json option |
 | relayNode.videoRecorder | object | `{}` | Override specific video recording settings for edge node |
@@ -732,6 +736,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | videoManager.priorityClassName | string | `""` | Priority class name for router pods |
 | videoManager.extraVolumeMounts | list | `[]` |  |
 | videoManager.extraVolumes | list | `[]` | Extra volumes for video recorder pod |
+| keda.image | object | `{"keda":{"registry":"selenium","repository":"keda","tag":"2.17.2-selenium-grid-20250721"},"metricsApiServer":{"registry":"selenium","repository":"keda-metrics-apiserver","tag":"2.17.2-selenium-grid-20250721"},"webhooks":{"registry":"selenium","repository":"keda-admission-webhooks","tag":"2.17.2-selenium-grid-20250721"}}` | Specify image for KEDA components |
 | keda.additionalAnnotations | string | `nil` | Annotations for KEDA resources |
 | keda.http.timeout | int | `60000` |  |
 | keda.webhooks | object | `{"enabled":false}` | Enable KEDA admission webhooks component |

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -254,7 +254,9 @@ triggers:
   - type: selenium-grid
     metadata:
     {{- with .node.hpa }}
-      {{- tpl (toYaml .) $ | nindent 6 }}
+      {{- range $key, $value := . }}
+      {{ $key }}: {{ tpl ($value | toString) $ | quote }}
+      {{- end }}
       {{- if not .nodeMaxSessions }}
       nodeMaxSessions: {{ $nodeMaxSessions | quote }}
       {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -1322,6 +1322,9 @@ chromeNode:
     platformName: ""
     # -- Skip check SSL when connecting to the Graphql endpoint
     unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    # -- The number of overprovisioning ratio to scale more than the actual number of requests.
+    # For example, over over-provisioning ratio `0.2` means 20% more than the actual requests
+    overProvisionRatio: ""
 
   # -- It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1520,6 +1523,9 @@ firefoxNode:
     platformName: ""
     # -- Skip check SSL when connecting to the Graphql endpoint
     unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    # -- The number of overprovisioning ratio to scale more than the actual number of requests.
+    # For example, over over-provisioning ratio `0.2` means 20% more than the actual requests
+    overProvisionRatio: ""
 
   # -- It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1718,6 +1724,9 @@ edgeNode:
     platformName: ""
     # -- Skip check SSL when connecting to the Graphql endpoint
     unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    # -- The number of overprovisioning ratio to scale more than the actual number of requests.
+    # For example, over over-provisioning ratio `0.2` means 20% more than the actual requests
+    overProvisionRatio: ""
 
   # -- It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -1917,6 +1926,9 @@ relayNode:
     platformName: ""
     # -- Skip check SSL when connecting to the Graphql endpoint
     unsafeSsl: '{{ template "seleniumGrid.graphqlURL.unsafeSsl" . }}'  # Optional
+    # -- The number of overprovisioning ratio to scale more than the actual number of requests.
+    # For example, over over-provisioning ratio `0.2` means 20% more than the actual requests
+    overProvisionRatio: ""
 
   # -- It is used to add initContainers in the same pod of the browser node.
   # It should be set using the --set-json option
@@ -2165,19 +2177,19 @@ videoManager:
 keda:
   # enabled: false
   # -- Specify image for KEDA components
-#  image:
-#    keda:
-#      registry: selenium
-#      repository: keda
-#      tag: "2.17.2-selenium-grid-20250717"
-#    metricsApiServer:
-#      registry: selenium
-#      repository: keda-metrics-apiserver
-#      tag: "2.17.2-selenium-grid-20250717"
-#    webhooks:
-#      registry: selenium
-#      repository: keda-admission-webhooks
-#      tag: "2.17.2-selenium-grid-20250717"
+  image:
+    keda:
+      registry: selenium
+      repository: keda
+      tag: "2.17.2-selenium-grid-20250721"
+    metricsApiServer:
+      registry: selenium
+      repository: keda-metrics-apiserver
+      tag: "2.17.2-selenium-grid-20250721"
+    webhooks:
+      registry: selenium
+      repository: keda-admission-webhooks
+      tag: "2.17.2-selenium-grid-20250721"
   # -- Annotations for KEDA resources
   additionalAnnotations:
   http:

--- a/tests/charts/ci/DeploymentAutoscaling-values.yaml
+++ b/tests/charts/ci/DeploymentAutoscaling-values.yaml
@@ -65,6 +65,8 @@ chromeNode:
     - name: logs
       persistentVolumeClaim:
         claimName: selenium-grid-pvc-local
+  hpa:
+    overProvisionRatio: 0.1
 
 # Configuration for edge nodes
 edgeNode:
@@ -100,6 +102,8 @@ firefoxNode:
     enabled: *livenessProbe
   extraVolumeMounts: *extraVolumeMounts
   extraVolumes: *extraVolumes
+  hpa:
+    overProvisionRatio: 0.2
 
 # Configuration for relay nodes
 relayNode:

--- a/tests/charts/templates/render/dummy.yaml
+++ b/tests/charts/templates/render/dummy.yaml
@@ -145,6 +145,8 @@ chromeNode:
   terminationGracePeriodSeconds: 7200
   service:
     enabled: true
+  hpa:
+    overProvisionRatio: 0.2
 
 firefoxNode:
   nodeMaxSessions: 1
@@ -154,6 +156,8 @@ firefoxNode:
   terminationGracePeriodSeconds: 720
   service:
     enabled: true
+  hpa:
+    overProvisionRatio: 0.2
 
 edgeNode:
   annotations:
@@ -163,9 +167,13 @@ edgeNode:
   videoRecorder:
     uploader:
       enabled: false
+  hpa:
+    overProvisionRatio: 0.2
 
 relayNode:
   enabled: true
+  hpa:
+    overProvisionRatio: 0.2
 
 videoRecorder:
   enabled: true

--- a/tests/charts/templates/render/dummy_solution.yaml
+++ b/tests/charts/templates/render/dummy_solution.yaml
@@ -136,6 +136,8 @@ selenium-grid:
     terminationGracePeriodSeconds: 7200
     service:
       enabled: true
+    hpa:
+      overProvisionRatio: 0.2
 
   firefoxNode:
     nodeMaxSessions: 1
@@ -144,6 +146,8 @@ selenium-grid:
     terminationGracePeriodSeconds: 720
     service:
       enabled: true
+    hpa:
+      overProvisionRatio: 0.2
 
   edgeNode:
     affinity: *affinity
@@ -152,9 +156,13 @@ selenium-grid:
     videoRecorder:
       uploader:
         enabled: false
+    hpa:
+      overProvisionRatio: 0.2
 
   relayNode:
     enabled: true
+    hpa:
+      overProvisionRatio: 0.2
 
   videoRecorder:
     enabled: true


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Feature preview of https://github.com/kedacore/keda/pull/6920

Add trigger param `overProvisionRatio` (float64) to add the ability to scale more than the queue request (called over-provisioned). Since this comes from a request #3453, plus 3 votes. Moreover, I believe this helps in autoscaling Deployment, scale Nodes based on request queue with a buffer (warm standby Nodes are available for a while, since process of a Node container from start up, get ready, registered to Hub, and pick up session would take time, a buffer for peak loads period would be an approach that users are prefer).
- For example, if there are 20 requests for the browser instead of scaling to 20 Nodes, it is able to scale 20% more than the requested, in this case is 24.
- With the above example, the trigger param `overProvisionRatio` is set to `0.2` (representing 20% percentage more than base request)
- The trigger param only accepts values greater than 0. Otherwise, it will not take effect.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add `overProvisionRatio` parameter to Selenium Grid KEDA scaler

- Enable scaling beyond queue request count for better resource provisioning

- Update metadata structure with float64 types for scaling parameters

- Update KEDA image tags to latest version (20250721)


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Queue Requests"] --> B["getScaledCount()"]
  B --> C["Apply overProvisionRatio"]
  C --> D["Scaled Metric Value"]
  D --> E["KEDA Scaling Decision"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_grid_scaler.go</strong><dd><code>Add over-provision ratio scaling logic</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.keda/scalers/selenium_grid_scaler.go

<ul><li>Add <code>OverProvisionRatio</code> field to metadata struct<br> <li> Change <code>TargetValue</code> and <code>ActivationThreshold</code> from int64 to float64<br> <li> Implement <code>getScaledCount()</code> function to apply over-provision ratio<br> <li> Update metric generation to use scaled count with ratio</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2907/files#diff-9c5876ecb13ba890ee2ad34fa5b4ac8497195de752159d5294409101b3678d7f">+31/-23</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>selenium_grid_scaler_test.go</strong><dd><code>Update tests for over-provision ratio</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.keda/scalers/selenium_grid_scaler_test.go

<ul><li>Add <code>overProvisionRatio</code> parameter to test arguments<br> <li> Add test case for over-provision ratio functionality<br> <li> Update test assertions to validate scaled count calculations<br> <li> Remove hardcoded <code>TargetValue</code> from expected metadata</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2907/files#diff-c0dcef21af10b50cc86bbc21a82d2cc5771a5431a625f51c908083ece2e8ec0b">+57/-14</a>&nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Update KEDA image tags and documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

.keda/README.md

<ul><li>Update KEDA image tags from 20250717 to 20250721<br> <li> Add reference to upstream PR #6920 for v2.18.0</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2907/files#diff-0780262e3462a749611df2930f59b9eb750d6a6228f263a96e10d9fe646009f1">+8/-6</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Add KEDA image configuration documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<ul><li>Add documentation for <code>keda.image</code> configuration object<br> <li> Document KEDA component image registry and tag settings</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2907/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+1/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Makefile</strong><dd><code>Update KEDA build configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Makefile

<ul><li>Update <code>KEDA_BASED_TAG</code> from 20250705 to 20250721<br> <li> Change <code>TEST_PATCHED_KEDA</code> from false to true</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2907/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Update KEDA image defaults in Helm chart</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<ul><li>Uncomment and update KEDA image configuration<br> <li> Update all KEDA component tags to 20250721<br> <li> Enable KEDA image overrides in default values</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2907/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+13/-13</a>&nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

