### PR TITLE
[ci] CHANGELOG for Node/Standalone chrome browser versions with Grid 4.35.0

### DIFF
--- a/CHANGELOG/4.35.0/chrome_100.md
+++ b/CHANGELOG/4.35.0/chrome_100.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 100.0.4896.127
+Short Chrome version -> 100.0
+ChromeDriver version -> 100.0.4896.60
+Short ChromeDriver version -> 100.0
+Tagged selenium/node-chrome:100.0.4896.127-chromedriver-100.0.4896.60-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:100.0.4896.127-chromedriver-100.0.4896.60-grid-4.35.0-20250808
+Tagged selenium/node-chrome:100.0.4896.127-chromedriver-100.0.4896.60-20250808
+Tagged selenium/standalone-chrome:100.0.4896.127-chromedriver-100.0.4896.60-20250808
+Tagged selenium/node-chrome:100.0.4896.127-20250808
+Tagged selenium/standalone-chrome:100.0.4896.127-20250808
+Tagged selenium/node-chrome:100.0-chromedriver-100.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:100.0-chromedriver-100.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:100.0-chromedriver-100.0-20250808
+Tagged selenium/standalone-chrome:100.0-chromedriver-100.0-20250808
+Tagged selenium/node-chrome:100.0-20250808
+Tagged selenium/standalone-chrome:100.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_101.md
+++ b/CHANGELOG/4.35.0/chrome_101.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 101.0.4951.64
+Short Chrome version -> 101.0
+ChromeDriver version -> 101.0.4951.41
+Short ChromeDriver version -> 101.0
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-grid-4.35.0-20250808
+Tagged selenium/node-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250808
+Tagged selenium/standalone-chrome:101.0.4951.64-chromedriver-101.0.4951.41-20250808
+Tagged selenium/node-chrome:101.0.4951.64-20250808
+Tagged selenium/standalone-chrome:101.0.4951.64-20250808
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:101.0-chromedriver-101.0-20250808
+Tagged selenium/standalone-chrome:101.0-chromedriver-101.0-20250808
+Tagged selenium/node-chrome:101.0-20250808
+Tagged selenium/standalone-chrome:101.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_102.md
+++ b/CHANGELOG/4.35.0/chrome_102.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 102.0.5005.115
+Short Chrome version -> 102.0
+ChromeDriver version -> 102.0.5005.61
+Short ChromeDriver version -> 102.0
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-grid-4.35.0-20250808
+Tagged selenium/node-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250808
+Tagged selenium/standalone-chrome:102.0.5005.115-chromedriver-102.0.5005.61-20250808
+Tagged selenium/node-chrome:102.0.5005.115-20250808
+Tagged selenium/standalone-chrome:102.0.5005.115-20250808
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:102.0-chromedriver-102.0-20250808
+Tagged selenium/standalone-chrome:102.0-chromedriver-102.0-20250808
+Tagged selenium/node-chrome:102.0-20250808
+Tagged selenium/standalone-chrome:102.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_103.md
+++ b/CHANGELOG/4.35.0/chrome_103.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 103.0.5060.134
+Short Chrome version -> 103.0
+ChromeDriver version -> 103.0.5060.134
+Short ChromeDriver version -> 103.0
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-grid-4.35.0-20250808
+Tagged selenium/node-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250808
+Tagged selenium/standalone-chrome:103.0.5060.134-chromedriver-103.0.5060.134-20250808
+Tagged selenium/node-chrome:103.0.5060.134-20250808
+Tagged selenium/standalone-chrome:103.0.5060.134-20250808
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:103.0-chromedriver-103.0-20250808
+Tagged selenium/standalone-chrome:103.0-chromedriver-103.0-20250808
+Tagged selenium/node-chrome:103.0-20250808
+Tagged selenium/standalone-chrome:103.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_104.md
+++ b/CHANGELOG/4.35.0/chrome_104.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 104.0.5112.101
+Short Chrome version -> 104.0
+ChromeDriver version -> 104.0.5112.79
+Short ChromeDriver version -> 104.0
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-grid-4.35.0-20250808
+Tagged selenium/node-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250808
+Tagged selenium/standalone-chrome:104.0.5112.101-chromedriver-104.0.5112.79-20250808
+Tagged selenium/node-chrome:104.0.5112.101-20250808
+Tagged selenium/standalone-chrome:104.0.5112.101-20250808
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:104.0-chromedriver-104.0-20250808
+Tagged selenium/standalone-chrome:104.0-chromedriver-104.0-20250808
+Tagged selenium/node-chrome:104.0-20250808
+Tagged selenium/standalone-chrome:104.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_105.md
+++ b/CHANGELOG/4.35.0/chrome_105.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 105.0.5195.125
+Short Chrome version -> 105.0
+ChromeDriver version -> 105.0.5195.52
+Short ChromeDriver version -> 105.0
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-grid-4.35.0-20250808
+Tagged selenium/node-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250808
+Tagged selenium/standalone-chrome:105.0.5195.125-chromedriver-105.0.5195.52-20250808
+Tagged selenium/node-chrome:105.0.5195.125-20250808
+Tagged selenium/standalone-chrome:105.0.5195.125-20250808
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:105.0-chromedriver-105.0-20250808
+Tagged selenium/standalone-chrome:105.0-chromedriver-105.0-20250808
+Tagged selenium/node-chrome:105.0-20250808
+Tagged selenium/standalone-chrome:105.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_107.md
+++ b/CHANGELOG/4.35.0/chrome_107.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 107.0.5304.121
+Short Chrome version -> 107.0
+ChromeDriver version -> 107.0.5304.62
+Short ChromeDriver version -> 107.0
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-grid-4.35.0-20250808
+Tagged selenium/node-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250808
+Tagged selenium/standalone-chrome:107.0.5304.121-chromedriver-107.0.5304.62-20250808
+Tagged selenium/node-chrome:107.0.5304.121-20250808
+Tagged selenium/standalone-chrome:107.0.5304.121-20250808
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:107.0-chromedriver-107.0-20250808
+Tagged selenium/standalone-chrome:107.0-chromedriver-107.0-20250808
+Tagged selenium/node-chrome:107.0-20250808
+Tagged selenium/standalone-chrome:107.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_108.md
+++ b/CHANGELOG/4.35.0/chrome_108.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 108.0.5359.124
+Short Chrome version -> 108.0
+ChromeDriver version -> 108.0.5359.71
+Short ChromeDriver version -> 108.0
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-grid-4.35.0-20250808
+Tagged selenium/node-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250808
+Tagged selenium/standalone-chrome:108.0.5359.124-chromedriver-108.0.5359.71-20250808
+Tagged selenium/node-chrome:108.0.5359.124-20250808
+Tagged selenium/standalone-chrome:108.0.5359.124-20250808
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:108.0-chromedriver-108.0-20250808
+Tagged selenium/standalone-chrome:108.0-chromedriver-108.0-20250808
+Tagged selenium/node-chrome:108.0-20250808
+Tagged selenium/standalone-chrome:108.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_109.md
+++ b/CHANGELOG/4.35.0/chrome_109.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 109.0.5414.119
+Short Chrome version -> 109.0
+ChromeDriver version -> 109.0.5414.74
+Short ChromeDriver version -> 109.0
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-grid-4.35.0-20250808
+Tagged selenium/node-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250808
+Tagged selenium/standalone-chrome:109.0.5414.119-chromedriver-109.0.5414.74-20250808
+Tagged selenium/node-chrome:109.0.5414.119-20250808
+Tagged selenium/standalone-chrome:109.0.5414.119-20250808
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:109.0-chromedriver-109.0-20250808
+Tagged selenium/standalone-chrome:109.0-chromedriver-109.0-20250808
+Tagged selenium/node-chrome:109.0-20250808
+Tagged selenium/standalone-chrome:109.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_110.md
+++ b/CHANGELOG/4.35.0/chrome_110.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 110.0.5481.177
+Short Chrome version -> 110.0
+ChromeDriver version -> 110.0.5481.77
+Short ChromeDriver version -> 110.0
+Tagged selenium/node-chrome:110.0.5481.177-chromedriver-110.0.5481.77-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77-grid-4.35.0-20250808
+Tagged selenium/node-chrome:110.0.5481.177-chromedriver-110.0.5481.77-20250808
+Tagged selenium/standalone-chrome:110.0.5481.177-chromedriver-110.0.5481.77-20250808
+Tagged selenium/node-chrome:110.0.5481.177-20250808
+Tagged selenium/standalone-chrome:110.0.5481.177-20250808
+Tagged selenium/node-chrome:110.0-chromedriver-110.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:110.0-chromedriver-110.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:110.0-chromedriver-110.0-20250808
+Tagged selenium/standalone-chrome:110.0-chromedriver-110.0-20250808
+Tagged selenium/node-chrome:110.0-20250808
+Tagged selenium/standalone-chrome:110.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_111.md
+++ b/CHANGELOG/4.35.0/chrome_111.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 111.0.5563.146
+Short Chrome version -> 111.0
+ChromeDriver version -> 111.0.5563.64
+Short ChromeDriver version -> 111.0
+Tagged selenium/node-chrome:111.0.5563.146-chromedriver-111.0.5563.64-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:111.0.5563.146-chromedriver-111.0.5563.64-grid-4.35.0-20250808
+Tagged selenium/node-chrome:111.0.5563.146-chromedriver-111.0.5563.64-20250808
+Tagged selenium/standalone-chrome:111.0.5563.146-chromedriver-111.0.5563.64-20250808
+Tagged selenium/node-chrome:111.0.5563.146-20250808
+Tagged selenium/standalone-chrome:111.0.5563.146-20250808
+Tagged selenium/node-chrome:111.0-chromedriver-111.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:111.0-chromedriver-111.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:111.0-chromedriver-111.0-20250808
+Tagged selenium/standalone-chrome:111.0-chromedriver-111.0-20250808
+Tagged selenium/node-chrome:111.0-20250808
+Tagged selenium/standalone-chrome:111.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_112.md
+++ b/CHANGELOG/4.35.0/chrome_112.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 112.0.5615.165
+Short Chrome version -> 112.0
+ChromeDriver version -> 112.0.5615.49
+Short ChromeDriver version -> 112.0
+Tagged selenium/node-chrome:112.0.5615.165-chromedriver-112.0.5615.49-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:112.0.5615.165-chromedriver-112.0.5615.49-grid-4.35.0-20250808
+Tagged selenium/node-chrome:112.0.5615.165-chromedriver-112.0.5615.49-20250808
+Tagged selenium/standalone-chrome:112.0.5615.165-chromedriver-112.0.5615.49-20250808
+Tagged selenium/node-chrome:112.0.5615.165-20250808
+Tagged selenium/standalone-chrome:112.0.5615.165-20250808
+Tagged selenium/node-chrome:112.0-chromedriver-112.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:112.0-chromedriver-112.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:112.0-chromedriver-112.0-20250808
+Tagged selenium/standalone-chrome:112.0-chromedriver-112.0-20250808
+Tagged selenium/node-chrome:112.0-20250808
+Tagged selenium/standalone-chrome:112.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_113.md
+++ b/CHANGELOG/4.35.0/chrome_113.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 113.0.5672.126
+Short Chrome version -> 113.0
+ChromeDriver version -> 113.0.5672.63
+Short ChromeDriver version -> 113.0
+Tagged selenium/node-chrome:113.0.5672.126-chromedriver-113.0.5672.63-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:113.0.5672.126-chromedriver-113.0.5672.63-grid-4.35.0-20250808
+Tagged selenium/node-chrome:113.0.5672.126-chromedriver-113.0.5672.63-20250808
+Tagged selenium/standalone-chrome:113.0.5672.126-chromedriver-113.0.5672.63-20250808
+Tagged selenium/node-chrome:113.0.5672.126-20250808
+Tagged selenium/standalone-chrome:113.0.5672.126-20250808
+Tagged selenium/node-chrome:113.0-chromedriver-113.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:113.0-chromedriver-113.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:113.0-chromedriver-113.0-20250808
+Tagged selenium/standalone-chrome:113.0-chromedriver-113.0-20250808
+Tagged selenium/node-chrome:113.0-20250808
+Tagged selenium/standalone-chrome:113.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_114.md
+++ b/CHANGELOG/4.35.0/chrome_114.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 114.0.5735.198
+Short Chrome version -> 114.0
+ChromeDriver version -> 114.0.5735.90
+Short ChromeDriver version -> 114.0
+Tagged selenium/node-chrome:114.0.5735.198-chromedriver-114.0.5735.90-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:114.0.5735.198-chromedriver-114.0.5735.90-grid-4.35.0-20250808
+Tagged selenium/node-chrome:114.0.5735.198-chromedriver-114.0.5735.90-20250808
+Tagged selenium/standalone-chrome:114.0.5735.198-chromedriver-114.0.5735.90-20250808
+Tagged selenium/node-chrome:114.0.5735.198-20250808
+Tagged selenium/standalone-chrome:114.0.5735.198-20250808
+Tagged selenium/node-chrome:114.0-chromedriver-114.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:114.0-chromedriver-114.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:114.0-chromedriver-114.0-20250808
+Tagged selenium/standalone-chrome:114.0-chromedriver-114.0-20250808
+Tagged selenium/node-chrome:114.0-20250808
+Tagged selenium/standalone-chrome:114.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_115.md
+++ b/CHANGELOG/4.35.0/chrome_115.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 115.0.5790.170
+Short Chrome version -> 115.0
+ChromeDriver version -> 115.0.5790.170
+Short ChromeDriver version -> 115.0
+Tagged selenium/node-chrome:115.0.5790.170-chromedriver-115.0.5790.170-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:115.0.5790.170-chromedriver-115.0.5790.170-grid-4.35.0-20250808
+Tagged selenium/node-chrome:115.0.5790.170-chromedriver-115.0.5790.170-20250808
+Tagged selenium/standalone-chrome:115.0.5790.170-chromedriver-115.0.5790.170-20250808
+Tagged selenium/node-chrome:115.0.5790.170-20250808
+Tagged selenium/standalone-chrome:115.0.5790.170-20250808
+Tagged selenium/node-chrome:115.0-chromedriver-115.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:115.0-chromedriver-115.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:115.0-chromedriver-115.0-20250808
+Tagged selenium/standalone-chrome:115.0-chromedriver-115.0-20250808
+Tagged selenium/node-chrome:115.0-20250808
+Tagged selenium/standalone-chrome:115.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_116.md
+++ b/CHANGELOG/4.35.0/chrome_116.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 116.0.5845.187
+Short Chrome version -> 116.0
+ChromeDriver version -> 116.0.5845.96
+Short ChromeDriver version -> 116.0
+Tagged selenium/node-chrome:116.0.5845.187-chromedriver-116.0.5845.96-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:116.0.5845.187-chromedriver-116.0.5845.96-grid-4.35.0-20250808
+Tagged selenium/node-chrome:116.0.5845.187-chromedriver-116.0.5845.96-20250808
+Tagged selenium/standalone-chrome:116.0.5845.187-chromedriver-116.0.5845.96-20250808
+Tagged selenium/node-chrome:116.0.5845.187-20250808
+Tagged selenium/standalone-chrome:116.0.5845.187-20250808
+Tagged selenium/node-chrome:116.0-chromedriver-116.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:116.0-chromedriver-116.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:116.0-chromedriver-116.0-20250808
+Tagged selenium/standalone-chrome:116.0-chromedriver-116.0-20250808
+Tagged selenium/node-chrome:116.0-20250808
+Tagged selenium/standalone-chrome:116.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_117.md
+++ b/CHANGELOG/4.35.0/chrome_117.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 117.0.5938.149
+Short Chrome version -> 117.0
+ChromeDriver version -> 117.0.5938.149
+Short ChromeDriver version -> 117.0
+Tagged selenium/node-chrome:117.0.5938.149-chromedriver-117.0.5938.149-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:117.0.5938.149-chromedriver-117.0.5938.149-grid-4.35.0-20250808
+Tagged selenium/node-chrome:117.0.5938.149-chromedriver-117.0.5938.149-20250808
+Tagged selenium/standalone-chrome:117.0.5938.149-chromedriver-117.0.5938.149-20250808
+Tagged selenium/node-chrome:117.0.5938.149-20250808
+Tagged selenium/standalone-chrome:117.0.5938.149-20250808
+Tagged selenium/node-chrome:117.0-chromedriver-117.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:117.0-chromedriver-117.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:117.0-chromedriver-117.0-20250808
+Tagged selenium/standalone-chrome:117.0-chromedriver-117.0-20250808
+Tagged selenium/node-chrome:117.0-20250808
+Tagged selenium/standalone-chrome:117.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_118.md
+++ b/CHANGELOG/4.35.0/chrome_118.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 118.0.5993.117
+Short Chrome version -> 118.0
+ChromeDriver version -> 118.0.5993.70
+Short ChromeDriver version -> 118.0
+Tagged selenium/node-chrome:118.0.5993.117-chromedriver-118.0.5993.70-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:118.0.5993.117-chromedriver-118.0.5993.70-grid-4.35.0-20250808
+Tagged selenium/node-chrome:118.0.5993.117-chromedriver-118.0.5993.70-20250808
+Tagged selenium/standalone-chrome:118.0.5993.117-chromedriver-118.0.5993.70-20250808
+Tagged selenium/node-chrome:118.0.5993.117-20250808
+Tagged selenium/standalone-chrome:118.0.5993.117-20250808
+Tagged selenium/node-chrome:118.0-chromedriver-118.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:118.0-chromedriver-118.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:118.0-chromedriver-118.0-20250808
+Tagged selenium/standalone-chrome:118.0-chromedriver-118.0-20250808
+Tagged selenium/node-chrome:118.0-20250808
+Tagged selenium/standalone-chrome:118.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_119.md
+++ b/CHANGELOG/4.35.0/chrome_119.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 119.0.6045.199
+Short Chrome version -> 119.0
+ChromeDriver version -> 119.0.6045.105
+Short ChromeDriver version -> 119.0
+Tagged selenium/node-chrome:119.0.6045.199-chromedriver-119.0.6045.105-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:119.0.6045.199-chromedriver-119.0.6045.105-grid-4.35.0-20250808
+Tagged selenium/node-chrome:119.0.6045.199-chromedriver-119.0.6045.105-20250808
+Tagged selenium/standalone-chrome:119.0.6045.199-chromedriver-119.0.6045.105-20250808
+Tagged selenium/node-chrome:119.0.6045.199-20250808
+Tagged selenium/standalone-chrome:119.0.6045.199-20250808
+Tagged selenium/node-chrome:119.0-chromedriver-119.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:119.0-chromedriver-119.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:119.0-chromedriver-119.0-20250808
+Tagged selenium/standalone-chrome:119.0-chromedriver-119.0-20250808
+Tagged selenium/node-chrome:119.0-20250808
+Tagged selenium/standalone-chrome:119.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_120.md
+++ b/CHANGELOG/4.35.0/chrome_120.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 120.0.6099.224
+Short Chrome version -> 120.0
+ChromeDriver version -> 120.0.6099.109
+Short ChromeDriver version -> 120.0
+Tagged selenium/node-chrome:120.0.6099.224-chromedriver-120.0.6099.109-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:120.0.6099.224-chromedriver-120.0.6099.109-grid-4.35.0-20250808
+Tagged selenium/node-chrome:120.0.6099.224-chromedriver-120.0.6099.109-20250808
+Tagged selenium/standalone-chrome:120.0.6099.224-chromedriver-120.0.6099.109-20250808
+Tagged selenium/node-chrome:120.0.6099.224-20250808
+Tagged selenium/standalone-chrome:120.0.6099.224-20250808
+Tagged selenium/node-chrome:120.0-chromedriver-120.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:120.0-chromedriver-120.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:120.0-chromedriver-120.0-20250808
+Tagged selenium/standalone-chrome:120.0-chromedriver-120.0-20250808
+Tagged selenium/node-chrome:120.0-20250808
+Tagged selenium/standalone-chrome:120.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_121.md
+++ b/CHANGELOG/4.35.0/chrome_121.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 121.0.6167.184
+Short Chrome version -> 121.0
+ChromeDriver version -> 121.0.6167.184
+Short ChromeDriver version -> 121.0
+Tagged selenium/node-chrome:121.0.6167.184-chromedriver-121.0.6167.184-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:121.0.6167.184-chromedriver-121.0.6167.184-grid-4.35.0-20250808
+Tagged selenium/node-chrome:121.0.6167.184-chromedriver-121.0.6167.184-20250808
+Tagged selenium/standalone-chrome:121.0.6167.184-chromedriver-121.0.6167.184-20250808
+Tagged selenium/node-chrome:121.0.6167.184-20250808
+Tagged selenium/standalone-chrome:121.0.6167.184-20250808
+Tagged selenium/node-chrome:121.0-chromedriver-121.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:121.0-chromedriver-121.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:121.0-chromedriver-121.0-20250808
+Tagged selenium/standalone-chrome:121.0-chromedriver-121.0-20250808
+Tagged selenium/node-chrome:121.0-20250808
+Tagged selenium/standalone-chrome:121.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_122.md
+++ b/CHANGELOG/4.35.0/chrome_122.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 122.0.6261.128
+Short Chrome version -> 122.0
+ChromeDriver version -> 122.0.6261.128
+Short ChromeDriver version -> 122.0
+Tagged selenium/node-chrome:122.0.6261.128-chromedriver-122.0.6261.128-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:122.0.6261.128-chromedriver-122.0.6261.128-grid-4.35.0-20250808
+Tagged selenium/node-chrome:122.0.6261.128-chromedriver-122.0.6261.128-20250808
+Tagged selenium/standalone-chrome:122.0.6261.128-chromedriver-122.0.6261.128-20250808
+Tagged selenium/node-chrome:122.0.6261.128-20250808
+Tagged selenium/standalone-chrome:122.0.6261.128-20250808
+Tagged selenium/node-chrome:122.0-chromedriver-122.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:122.0-chromedriver-122.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:122.0-chromedriver-122.0-20250808
+Tagged selenium/standalone-chrome:122.0-chromedriver-122.0-20250808
+Tagged selenium/node-chrome:122.0-20250808
+Tagged selenium/standalone-chrome:122.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_123.md
+++ b/CHANGELOG/4.35.0/chrome_123.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 123.0.6312.122
+Short Chrome version -> 123.0
+ChromeDriver version -> 123.0.6312.122
+Short ChromeDriver version -> 123.0
+Tagged selenium/node-chrome:123.0.6312.122-chromedriver-123.0.6312.122-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:123.0.6312.122-chromedriver-123.0.6312.122-grid-4.35.0-20250808
+Tagged selenium/node-chrome:123.0.6312.122-chromedriver-123.0.6312.122-20250808
+Tagged selenium/standalone-chrome:123.0.6312.122-chromedriver-123.0.6312.122-20250808
+Tagged selenium/node-chrome:123.0.6312.122-20250808
+Tagged selenium/standalone-chrome:123.0.6312.122-20250808
+Tagged selenium/node-chrome:123.0-chromedriver-123.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:123.0-chromedriver-123.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:123.0-chromedriver-123.0-20250808
+Tagged selenium/standalone-chrome:123.0-chromedriver-123.0-20250808
+Tagged selenium/node-chrome:123.0-20250808
+Tagged selenium/standalone-chrome:123.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_124.md
+++ b/CHANGELOG/4.35.0/chrome_124.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 124.0.6367.207
+Short Chrome version -> 124.0
+ChromeDriver version -> 124.0.6367.207
+Short ChromeDriver version -> 124.0
+Tagged selenium/node-chrome:124.0.6367.207-chromedriver-124.0.6367.207-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:124.0.6367.207-chromedriver-124.0.6367.207-grid-4.35.0-20250808
+Tagged selenium/node-chrome:124.0.6367.207-chromedriver-124.0.6367.207-20250808
+Tagged selenium/standalone-chrome:124.0.6367.207-chromedriver-124.0.6367.207-20250808
+Tagged selenium/node-chrome:124.0.6367.207-20250808
+Tagged selenium/standalone-chrome:124.0.6367.207-20250808
+Tagged selenium/node-chrome:124.0-chromedriver-124.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:124.0-chromedriver-124.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:124.0-chromedriver-124.0-20250808
+Tagged selenium/standalone-chrome:124.0-chromedriver-124.0-20250808
+Tagged selenium/node-chrome:124.0-20250808
+Tagged selenium/standalone-chrome:124.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_125.md
+++ b/CHANGELOG/4.35.0/chrome_125.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 125.0.6422.141
+Short Chrome version -> 125.0
+ChromeDriver version -> 125.0.6422.141
+Short ChromeDriver version -> 125.0
+Tagged selenium/node-chrome:125.0.6422.141-chromedriver-125.0.6422.141-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:125.0.6422.141-chromedriver-125.0.6422.141-grid-4.35.0-20250808
+Tagged selenium/node-chrome:125.0.6422.141-chromedriver-125.0.6422.141-20250808
+Tagged selenium/standalone-chrome:125.0.6422.141-chromedriver-125.0.6422.141-20250808
+Tagged selenium/node-chrome:125.0.6422.141-20250808
+Tagged selenium/standalone-chrome:125.0.6422.141-20250808
+Tagged selenium/node-chrome:125.0-chromedriver-125.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:125.0-chromedriver-125.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:125.0-chromedriver-125.0-20250808
+Tagged selenium/standalone-chrome:125.0-chromedriver-125.0-20250808
+Tagged selenium/node-chrome:125.0-20250808
+Tagged selenium/standalone-chrome:125.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_126.md
+++ b/CHANGELOG/4.35.0/chrome_126.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 126.0.6478.182
+Short Chrome version -> 126.0
+ChromeDriver version -> 126.0.6478.182
+Short ChromeDriver version -> 126.0
+Tagged selenium/node-chrome:126.0.6478.182-chromedriver-126.0.6478.182-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:126.0.6478.182-chromedriver-126.0.6478.182-grid-4.35.0-20250808
+Tagged selenium/node-chrome:126.0.6478.182-chromedriver-126.0.6478.182-20250808
+Tagged selenium/standalone-chrome:126.0.6478.182-chromedriver-126.0.6478.182-20250808
+Tagged selenium/node-chrome:126.0.6478.182-20250808
+Tagged selenium/standalone-chrome:126.0.6478.182-20250808
+Tagged selenium/node-chrome:126.0-chromedriver-126.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:126.0-chromedriver-126.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:126.0-chromedriver-126.0-20250808
+Tagged selenium/standalone-chrome:126.0-chromedriver-126.0-20250808
+Tagged selenium/node-chrome:126.0-20250808
+Tagged selenium/standalone-chrome:126.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_127.md
+++ b/CHANGELOG/4.35.0/chrome_127.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 127.0.6533.119
+Short Chrome version -> 127.0
+ChromeDriver version -> 127.0.6533.119
+Short ChromeDriver version -> 127.0
+Tagged selenium/node-chrome:127.0.6533.119-chromedriver-127.0.6533.119-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:127.0.6533.119-chromedriver-127.0.6533.119-grid-4.35.0-20250808
+Tagged selenium/node-chrome:127.0.6533.119-chromedriver-127.0.6533.119-20250808
+Tagged selenium/standalone-chrome:127.0.6533.119-chromedriver-127.0.6533.119-20250808
+Tagged selenium/node-chrome:127.0.6533.119-20250808
+Tagged selenium/standalone-chrome:127.0.6533.119-20250808
+Tagged selenium/node-chrome:127.0-chromedriver-127.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:127.0-chromedriver-127.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:127.0-chromedriver-127.0-20250808
+Tagged selenium/standalone-chrome:127.0-chromedriver-127.0-20250808
+Tagged selenium/node-chrome:127.0-20250808
+Tagged selenium/standalone-chrome:127.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_128.md
+++ b/CHANGELOG/4.35.0/chrome_128.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 128.0.6613.137
+Short Chrome version -> 128.0
+ChromeDriver version -> 128.0.6613.137
+Short ChromeDriver version -> 128.0
+Tagged selenium/node-chrome:128.0.6613.137-chromedriver-128.0.6613.137-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:128.0.6613.137-chromedriver-128.0.6613.137-grid-4.35.0-20250808
+Tagged selenium/node-chrome:128.0.6613.137-chromedriver-128.0.6613.137-20250808
+Tagged selenium/standalone-chrome:128.0.6613.137-chromedriver-128.0.6613.137-20250808
+Tagged selenium/node-chrome:128.0.6613.137-20250808
+Tagged selenium/standalone-chrome:128.0.6613.137-20250808
+Tagged selenium/node-chrome:128.0-chromedriver-128.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:128.0-chromedriver-128.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:128.0-chromedriver-128.0-20250808
+Tagged selenium/standalone-chrome:128.0-chromedriver-128.0-20250808
+Tagged selenium/node-chrome:128.0-20250808
+Tagged selenium/standalone-chrome:128.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_129.md
+++ b/CHANGELOG/4.35.0/chrome_129.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 129.0.6668.100
+Short Chrome version -> 129.0
+ChromeDriver version -> 129.0.6668.100
+Short ChromeDriver version -> 129.0
+Tagged selenium/node-chrome:129.0.6668.100-chromedriver-129.0.6668.100-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:129.0.6668.100-chromedriver-129.0.6668.100-grid-4.35.0-20250808
+Tagged selenium/node-chrome:129.0.6668.100-chromedriver-129.0.6668.100-20250808
+Tagged selenium/standalone-chrome:129.0.6668.100-chromedriver-129.0.6668.100-20250808
+Tagged selenium/node-chrome:129.0.6668.100-20250808
+Tagged selenium/standalone-chrome:129.0.6668.100-20250808
+Tagged selenium/node-chrome:129.0-chromedriver-129.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:129.0-chromedriver-129.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:129.0-chromedriver-129.0-20250808
+Tagged selenium/standalone-chrome:129.0-chromedriver-129.0-20250808
+Tagged selenium/node-chrome:129.0-20250808
+Tagged selenium/standalone-chrome:129.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_130.md
+++ b/CHANGELOG/4.35.0/chrome_130.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 130.0.6723.116
+Short Chrome version -> 130.0
+ChromeDriver version -> 130.0.6723.116
+Short ChromeDriver version -> 130.0
+Tagged selenium/node-chrome:130.0.6723.116-chromedriver-130.0.6723.116-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:130.0.6723.116-chromedriver-130.0.6723.116-grid-4.35.0-20250808
+Tagged selenium/node-chrome:130.0.6723.116-chromedriver-130.0.6723.116-20250808
+Tagged selenium/standalone-chrome:130.0.6723.116-chromedriver-130.0.6723.116-20250808
+Tagged selenium/node-chrome:130.0.6723.116-20250808
+Tagged selenium/standalone-chrome:130.0.6723.116-20250808
+Tagged selenium/node-chrome:130.0-chromedriver-130.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:130.0-chromedriver-130.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:130.0-chromedriver-130.0-20250808
+Tagged selenium/standalone-chrome:130.0-chromedriver-130.0-20250808
+Tagged selenium/node-chrome:130.0-20250808
+Tagged selenium/standalone-chrome:130.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_131.md
+++ b/CHANGELOG/4.35.0/chrome_131.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 131.0.6778.264
+Short Chrome version -> 131.0
+ChromeDriver version -> 131.0.6778.264
+Short ChromeDriver version -> 131.0
+Tagged selenium/node-chrome:131.0.6778.264-chromedriver-131.0.6778.264-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:131.0.6778.264-chromedriver-131.0.6778.264-grid-4.35.0-20250808
+Tagged selenium/node-chrome:131.0.6778.264-chromedriver-131.0.6778.264-20250808
+Tagged selenium/standalone-chrome:131.0.6778.264-chromedriver-131.0.6778.264-20250808
+Tagged selenium/node-chrome:131.0.6778.264-20250808
+Tagged selenium/standalone-chrome:131.0.6778.264-20250808
+Tagged selenium/node-chrome:131.0-chromedriver-131.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:131.0-chromedriver-131.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:131.0-chromedriver-131.0-20250808
+Tagged selenium/standalone-chrome:131.0-chromedriver-131.0-20250808
+Tagged selenium/node-chrome:131.0-20250808
+Tagged selenium/standalone-chrome:131.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_132.md
+++ b/CHANGELOG/4.35.0/chrome_132.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 132.0.6834.159
+Short Chrome version -> 132.0
+ChromeDriver version -> 132.0.6834.159
+Short ChromeDriver version -> 132.0
+Tagged selenium/node-chrome:132.0.6834.159-chromedriver-132.0.6834.159-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:132.0.6834.159-chromedriver-132.0.6834.159-grid-4.35.0-20250808
+Tagged selenium/node-chrome:132.0.6834.159-chromedriver-132.0.6834.159-20250808
+Tagged selenium/standalone-chrome:132.0.6834.159-chromedriver-132.0.6834.159-20250808
+Tagged selenium/node-chrome:132.0.6834.159-20250808
+Tagged selenium/standalone-chrome:132.0.6834.159-20250808
+Tagged selenium/node-chrome:132.0-chromedriver-132.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:132.0-chromedriver-132.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:132.0-chromedriver-132.0-20250808
+Tagged selenium/standalone-chrome:132.0-chromedriver-132.0-20250808
+Tagged selenium/node-chrome:132.0-20250808
+Tagged selenium/standalone-chrome:132.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_133.md
+++ b/CHANGELOG/4.35.0/chrome_133.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 133.0.6943.141
+Short Chrome version -> 133.0
+ChromeDriver version -> 133.0.6943.141
+Short ChromeDriver version -> 133.0
+Tagged selenium/node-chrome:133.0.6943.141-chromedriver-133.0.6943.141-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:133.0.6943.141-chromedriver-133.0.6943.141-grid-4.35.0-20250808
+Tagged selenium/node-chrome:133.0.6943.141-chromedriver-133.0.6943.141-20250808
+Tagged selenium/standalone-chrome:133.0.6943.141-chromedriver-133.0.6943.141-20250808
+Tagged selenium/node-chrome:133.0.6943.141-20250808
+Tagged selenium/standalone-chrome:133.0.6943.141-20250808
+Tagged selenium/node-chrome:133.0-chromedriver-133.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:133.0-chromedriver-133.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:133.0-chromedriver-133.0-20250808
+Tagged selenium/standalone-chrome:133.0-chromedriver-133.0-20250808
+Tagged selenium/node-chrome:133.0-20250808
+Tagged selenium/standalone-chrome:133.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_134.md
+++ b/CHANGELOG/4.35.0/chrome_134.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 134.0.6998.165
+Short Chrome version -> 134.0
+ChromeDriver version -> 134.0.6998.165
+Short ChromeDriver version -> 134.0
+Tagged selenium/node-chrome:134.0.6998.165-chromedriver-134.0.6998.165-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:134.0.6998.165-chromedriver-134.0.6998.165-grid-4.35.0-20250808
+Tagged selenium/node-chrome:134.0.6998.165-chromedriver-134.0.6998.165-20250808
+Tagged selenium/standalone-chrome:134.0.6998.165-chromedriver-134.0.6998.165-20250808
+Tagged selenium/node-chrome:134.0.6998.165-20250808
+Tagged selenium/standalone-chrome:134.0.6998.165-20250808
+Tagged selenium/node-chrome:134.0-chromedriver-134.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:134.0-chromedriver-134.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:134.0-chromedriver-134.0-20250808
+Tagged selenium/standalone-chrome:134.0-chromedriver-134.0-20250808
+Tagged selenium/node-chrome:134.0-20250808
+Tagged selenium/standalone-chrome:134.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_136.md
+++ b/CHANGELOG/4.35.0/chrome_136.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 136.0.7103.113
+Short Chrome version -> 136.0
+ChromeDriver version -> 136.0.7103.113
+Short ChromeDriver version -> 136.0
+Tagged selenium/node-chrome:136.0.7103.113-chromedriver-136.0.7103.113-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:136.0.7103.113-chromedriver-136.0.7103.113-grid-4.35.0-20250808
+Tagged selenium/node-chrome:136.0.7103.113-chromedriver-136.0.7103.113-20250808
+Tagged selenium/standalone-chrome:136.0.7103.113-chromedriver-136.0.7103.113-20250808
+Tagged selenium/node-chrome:136.0.7103.113-20250808
+Tagged selenium/standalone-chrome:136.0.7103.113-20250808
+Tagged selenium/node-chrome:136.0-chromedriver-136.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:136.0-chromedriver-136.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:136.0-chromedriver-136.0-20250808
+Tagged selenium/standalone-chrome:136.0-chromedriver-136.0-20250808
+Tagged selenium/node-chrome:136.0-20250808
+Tagged selenium/standalone-chrome:136.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_137.md
+++ b/CHANGELOG/4.35.0/chrome_137.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 137.0.7151.119
+Short Chrome version -> 137.0
+ChromeDriver version -> 137.0.7151.119
+Short ChromeDriver version -> 137.0
+Tagged selenium/node-chrome:137.0.7151.119-chromedriver-137.0.7151.119-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:137.0.7151.119-chromedriver-137.0.7151.119-grid-4.35.0-20250808
+Tagged selenium/node-chrome:137.0.7151.119-chromedriver-137.0.7151.119-20250808
+Tagged selenium/standalone-chrome:137.0.7151.119-chromedriver-137.0.7151.119-20250808
+Tagged selenium/node-chrome:137.0.7151.119-20250808
+Tagged selenium/standalone-chrome:137.0.7151.119-20250808
+Tagged selenium/node-chrome:137.0-chromedriver-137.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:137.0-chromedriver-137.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:137.0-chromedriver-137.0-20250808
+Tagged selenium/standalone-chrome:137.0-chromedriver-137.0-20250808
+Tagged selenium/node-chrome:137.0-20250808
+Tagged selenium/standalone-chrome:137.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_138.md
+++ b/CHANGELOG/4.35.0/chrome_138.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 138.0.7204.183
+Short Chrome version -> 138.0
+ChromeDriver version -> 138.0.7204.183
+Short ChromeDriver version -> 138.0
+Tagged selenium/node-chrome:138.0.7204.183-chromedriver-138.0.7204.183-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:138.0.7204.183-chromedriver-138.0.7204.183-grid-4.35.0-20250808
+Tagged selenium/node-chrome:138.0.7204.183-chromedriver-138.0.7204.183-20250808
+Tagged selenium/standalone-chrome:138.0.7204.183-chromedriver-138.0.7204.183-20250808
+Tagged selenium/node-chrome:138.0.7204.183-20250808
+Tagged selenium/standalone-chrome:138.0.7204.183-20250808
+Tagged selenium/node-chrome:138.0-chromedriver-138.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:138.0-chromedriver-138.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:138.0-chromedriver-138.0-20250808
+Tagged selenium/standalone-chrome:138.0-chromedriver-138.0-20250808
+Tagged selenium/node-chrome:138.0-20250808
+Tagged selenium/standalone-chrome:138.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_95.md
+++ b/CHANGELOG/4.35.0/chrome_95.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 95.0.4638.69
+Short Chrome version -> 95.0
+ChromeDriver version -> 95.0.4638.69
+Short ChromeDriver version -> 95.0
+Tagged selenium/node-chrome:95.0.4638.69-chromedriver-95.0.4638.69-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:95.0.4638.69-chromedriver-95.0.4638.69-grid-4.35.0-20250808
+Tagged selenium/node-chrome:95.0.4638.69-chromedriver-95.0.4638.69-20250808
+Tagged selenium/standalone-chrome:95.0.4638.69-chromedriver-95.0.4638.69-20250808
+Tagged selenium/node-chrome:95.0.4638.69-20250808
+Tagged selenium/standalone-chrome:95.0.4638.69-20250808
+Tagged selenium/node-chrome:95.0-chromedriver-95.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:95.0-chromedriver-95.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:95.0-chromedriver-95.0-20250808
+Tagged selenium/standalone-chrome:95.0-chromedriver-95.0-20250808
+Tagged selenium/node-chrome:95.0-20250808
+Tagged selenium/standalone-chrome:95.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_96.md
+++ b/CHANGELOG/4.35.0/chrome_96.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 96.0.4664.110
+Short Chrome version -> 96.0
+ChromeDriver version -> 96.0.4664.45
+Short ChromeDriver version -> 96.0
+Tagged selenium/node-chrome:96.0.4664.110-chromedriver-96.0.4664.45-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:96.0.4664.110-chromedriver-96.0.4664.45-grid-4.35.0-20250808
+Tagged selenium/node-chrome:96.0.4664.110-chromedriver-96.0.4664.45-20250808
+Tagged selenium/standalone-chrome:96.0.4664.110-chromedriver-96.0.4664.45-20250808
+Tagged selenium/node-chrome:96.0.4664.110-20250808
+Tagged selenium/standalone-chrome:96.0.4664.110-20250808
+Tagged selenium/node-chrome:96.0-chromedriver-96.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:96.0-chromedriver-96.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:96.0-chromedriver-96.0-20250808
+Tagged selenium/standalone-chrome:96.0-chromedriver-96.0-20250808
+Tagged selenium/node-chrome:96.0-20250808
+Tagged selenium/standalone-chrome:96.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_97.md
+++ b/CHANGELOG/4.35.0/chrome_97.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 97.0.4692.99
+Short Chrome version -> 97.0
+ChromeDriver version -> 97.0.4692.71
+Short ChromeDriver version -> 97.0
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-grid-4.35.0-20250808
+Tagged selenium/node-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250808
+Tagged selenium/standalone-chrome:97.0.4692.99-chromedriver-97.0.4692.71-20250808
+Tagged selenium/node-chrome:97.0.4692.99-20250808
+Tagged selenium/standalone-chrome:97.0.4692.99-20250808
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:97.0-chromedriver-97.0-20250808
+Tagged selenium/standalone-chrome:97.0-chromedriver-97.0-20250808
+Tagged selenium/node-chrome:97.0-20250808
+Tagged selenium/standalone-chrome:97.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_98.md
+++ b/CHANGELOG/4.35.0/chrome_98.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 98.0.4758.102
+Short Chrome version -> 98.0
+ChromeDriver version -> 98.0.4758.102
+Short ChromeDriver version -> 98.0
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-grid-4.35.0-20250808
+Tagged selenium/node-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250808
+Tagged selenium/standalone-chrome:98.0.4758.102-chromedriver-98.0.4758.102-20250808
+Tagged selenium/node-chrome:98.0.4758.102-20250808
+Tagged selenium/standalone-chrome:98.0.4758.102-20250808
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:98.0-chromedriver-98.0-20250808
+Tagged selenium/standalone-chrome:98.0-chromedriver-98.0-20250808
+Tagged selenium/node-chrome:98.0-20250808
+Tagged selenium/standalone-chrome:98.0-20250808
+```

--- a/CHANGELOG/4.35.0/chrome_99.md
+++ b/CHANGELOG/4.35.0/chrome_99.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false chrome true
+Tagging images for browser chrome, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Chrome version -> 99.0.4844.84
+Short Chrome version -> 99.0
+ChromeDriver version -> 99.0.4844.51
+Short ChromeDriver version -> 99.0
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-grid-4.35.0-20250808
+Tagged selenium/node-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250808
+Tagged selenium/standalone-chrome:99.0.4844.84-chromedriver-99.0.4844.51-20250808
+Tagged selenium/node-chrome:99.0.4844.84-20250808
+Tagged selenium/standalone-chrome:99.0.4844.84-20250808
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-grid-4.35.0-20250808
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-grid-4.35.0-20250808
+Tagged selenium/node-chrome:99.0-chromedriver-99.0-20250808
+Tagged selenium/standalone-chrome:99.0-chromedriver-99.0-20250808
+Tagged selenium/node-chrome:99.0-20250808
+Tagged selenium/standalone-chrome:99.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_114.md
+++ b/CHANGELOG/4.35.0/edge_114.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 114.0.1823.82
+Short Edge version -> 114.0
+EdgeDriver version -> 114.0.1823.82
+Short EdgeDriver version -> 114.0
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.35.0-20250808
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250808
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250808
+Tagged selenium/node-edge:114.0.1823.82-20250808
+Tagged selenium/standalone-edge:114.0.1823.82-20250808
+Tagged selenium/node-edge:114.0-edgedriver-114.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:114.0-edgedriver-114.0-20250808
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-20250808
+Tagged selenium/node-edge:114.0-20250808
+Tagged selenium/standalone-edge:114.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_115.md
+++ b/CHANGELOG/4.35.0/edge_115.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 115.0.1901.203
+Short Edge version -> 115.0
+EdgeDriver version -> 115.0.1901.203
+Short EdgeDriver version -> 115.0
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.35.0-20250808
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250808
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250808
+Tagged selenium/node-edge:115.0.1901.203-20250808
+Tagged selenium/standalone-edge:115.0.1901.203-20250808
+Tagged selenium/node-edge:115.0-edgedriver-115.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:115.0-edgedriver-115.0-20250808
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-20250808
+Tagged selenium/node-edge:115.0-20250808
+Tagged selenium/standalone-edge:115.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_116.md
+++ b/CHANGELOG/4.35.0/edge_116.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 116.0.1938.81
+Short Edge version -> 116.0
+EdgeDriver version -> 116.0.1938.81
+Short EdgeDriver version -> 116.0
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.35.0-20250808
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250808
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250808
+Tagged selenium/node-edge:116.0.1938.81-20250808
+Tagged selenium/standalone-edge:116.0.1938.81-20250808
+Tagged selenium/node-edge:116.0-edgedriver-116.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:116.0-edgedriver-116.0-20250808
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-20250808
+Tagged selenium/node-edge:116.0-20250808
+Tagged selenium/standalone-edge:116.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_117.md
+++ b/CHANGELOG/4.35.0/edge_117.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 117.0.2045.55
+Short Edge version -> 117.0
+EdgeDriver version -> 117.0.2045.55
+Short EdgeDriver version -> 117.0
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.35.0-20250808
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250808
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250808
+Tagged selenium/node-edge:117.0.2045.55-20250808
+Tagged selenium/standalone-edge:117.0.2045.55-20250808
+Tagged selenium/node-edge:117.0-edgedriver-117.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:117.0-edgedriver-117.0-20250808
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-20250808
+Tagged selenium/node-edge:117.0-20250808
+Tagged selenium/standalone-edge:117.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_118.md
+++ b/CHANGELOG/4.35.0/edge_118.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 118.0.2088.76
+Short Edge version -> 118.0
+EdgeDriver version -> 118.0.2088.76
+Short EdgeDriver version -> 118.0
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.35.0-20250808
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250808
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250808
+Tagged selenium/node-edge:118.0.2088.76-20250808
+Tagged selenium/standalone-edge:118.0.2088.76-20250808
+Tagged selenium/node-edge:118.0-edgedriver-118.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:118.0-edgedriver-118.0-20250808
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-20250808
+Tagged selenium/node-edge:118.0-20250808
+Tagged selenium/standalone-edge:118.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_119.md
+++ b/CHANGELOG/4.35.0/edge_119.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 119.0.2151.97
+Short Edge version -> 119.0
+EdgeDriver version -> 119.0.2151.97
+Short EdgeDriver version -> 119.0
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.35.0-20250808
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250808
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250808
+Tagged selenium/node-edge:119.0.2151.97-20250808
+Tagged selenium/standalone-edge:119.0.2151.97-20250808
+Tagged selenium/node-edge:119.0-edgedriver-119.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:119.0-edgedriver-119.0-20250808
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-20250808
+Tagged selenium/node-edge:119.0-20250808
+Tagged selenium/standalone-edge:119.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_120.md
+++ b/CHANGELOG/4.35.0/edge_120.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 120.0.2210.144
+Short Edge version -> 120.0
+EdgeDriver version -> 120.0.2210.144
+Short EdgeDriver version -> 120.0
+Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.35.0-20250808
+Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250808
+Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250808
+Tagged selenium/node-edge:120.0.2210.144-20250808
+Tagged selenium/standalone-edge:120.0.2210.144-20250808
+Tagged selenium/node-edge:120.0-edgedriver-120.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:120.0-edgedriver-120.0-20250808
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-20250808
+Tagged selenium/node-edge:120.0-20250808
+Tagged selenium/standalone-edge:120.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_121.md
+++ b/CHANGELOG/4.35.0/edge_121.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 121.0.2277.128
+Short Edge version -> 121.0
+EdgeDriver version -> 121.0.2277.128
+Short EdgeDriver version -> 121.0
+Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.35.0-20250808
+Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250808
+Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250808
+Tagged selenium/node-edge:121.0.2277.128-20250808
+Tagged selenium/standalone-edge:121.0.2277.128-20250808
+Tagged selenium/node-edge:121.0-edgedriver-121.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:121.0-edgedriver-121.0-20250808
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-20250808
+Tagged selenium/node-edge:121.0-20250808
+Tagged selenium/standalone-edge:121.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_122.md
+++ b/CHANGELOG/4.35.0/edge_122.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 122.0.2365.92
+Short Edge version -> 122.0
+EdgeDriver version -> 122.0.2365.92
+Short EdgeDriver version -> 122.0
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250808
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250808
+Tagged selenium/node-edge:122.0.2365.92-20250808
+Tagged selenium/standalone-edge:122.0.2365.92-20250808
+Tagged selenium/node-edge:122.0-edgedriver-122.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:122.0-edgedriver-122.0-20250808
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-20250808
+Tagged selenium/node-edge:122.0-20250808
+Tagged selenium/standalone-edge:122.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_123.md
+++ b/CHANGELOG/4.35.0/edge_123.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 123.0.2420.97
+Short Edge version -> 123.0
+EdgeDriver version -> 123.0.2420.97
+Short EdgeDriver version -> 123.0
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.35.0-20250808
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250808
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250808
+Tagged selenium/node-edge:123.0.2420.97-20250808
+Tagged selenium/standalone-edge:123.0.2420.97-20250808
+Tagged selenium/node-edge:123.0-edgedriver-123.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:123.0-edgedriver-123.0-20250808
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-20250808
+Tagged selenium/node-edge:123.0-20250808
+Tagged selenium/standalone-edge:123.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_124.md
+++ b/CHANGELOG/4.35.0/edge_124.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 124.0.2478.109
+Short Edge version -> 124.0
+EdgeDriver version -> 124.0.2478.109
+Short EdgeDriver version -> 124.0
+Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.35.0-20250808
+Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250808
+Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250808
+Tagged selenium/node-edge:124.0.2478.109-20250808
+Tagged selenium/standalone-edge:124.0.2478.109-20250808
+Tagged selenium/node-edge:124.0-edgedriver-124.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:124.0-edgedriver-124.0-20250808
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-20250808
+Tagged selenium/node-edge:124.0-20250808
+Tagged selenium/standalone-edge:124.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_125.md
+++ b/CHANGELOG/4.35.0/edge_125.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 125.0.2535.92
+Short Edge version -> 125.0
+EdgeDriver version -> 125.0.2535.92
+Short EdgeDriver version -> 125.0
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250808
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250808
+Tagged selenium/node-edge:125.0.2535.92-20250808
+Tagged selenium/standalone-edge:125.0.2535.92-20250808
+Tagged selenium/node-edge:125.0-edgedriver-125.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:125.0-edgedriver-125.0-20250808
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-20250808
+Tagged selenium/node-edge:125.0-20250808
+Tagged selenium/standalone-edge:125.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_126.md
+++ b/CHANGELOG/4.35.0/edge_126.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 126.0.2592.113
+Short Edge version -> 126.0
+EdgeDriver version -> 126.0.2592.123
+Short EdgeDriver version -> 126.0
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.35.0-20250808
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250808
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250808
+Tagged selenium/node-edge:126.0.2592.113-20250808
+Tagged selenium/standalone-edge:126.0.2592.113-20250808
+Tagged selenium/node-edge:126.0-edgedriver-126.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:126.0-edgedriver-126.0-20250808
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-20250808
+Tagged selenium/node-edge:126.0-20250808
+Tagged selenium/standalone-edge:126.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_127.md
+++ b/CHANGELOG/4.35.0/edge_127.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 127.0.2651.105
+Short Edge version -> 127.0
+EdgeDriver version -> 127.0.2651.107
+Short EdgeDriver version -> 127.0
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.35.0-20250808
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250808
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250808
+Tagged selenium/node-edge:127.0.2651.105-20250808
+Tagged selenium/standalone-edge:127.0.2651.105-20250808
+Tagged selenium/node-edge:127.0-edgedriver-127.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:127.0-edgedriver-127.0-20250808
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-20250808
+Tagged selenium/node-edge:127.0-20250808
+Tagged selenium/standalone-edge:127.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_128.md
+++ b/CHANGELOG/4.35.0/edge_128.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 128.0.2739.79
+Short Edge version -> 128.0
+EdgeDriver version -> 128.0.2739.81
+Short EdgeDriver version -> 128.0
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.35.0-20250808
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250808
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250808
+Tagged selenium/node-edge:128.0.2739.79-20250808
+Tagged selenium/standalone-edge:128.0.2739.79-20250808
+Tagged selenium/node-edge:128.0-edgedriver-128.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:128.0-edgedriver-128.0-20250808
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-20250808
+Tagged selenium/node-edge:128.0-20250808
+Tagged selenium/standalone-edge:128.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_129.md
+++ b/CHANGELOG/4.35.0/edge_129.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 129.0.2792.89
+Short Edge version -> 129.0
+EdgeDriver version -> 129.0.2792.98
+Short EdgeDriver version -> 129.0
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.35.0-20250808
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250808
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250808
+Tagged selenium/node-edge:129.0.2792.89-20250808
+Tagged selenium/standalone-edge:129.0.2792.89-20250808
+Tagged selenium/node-edge:129.0-edgedriver-129.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:129.0-edgedriver-129.0-20250808
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-20250808
+Tagged selenium/node-edge:129.0-20250808
+Tagged selenium/standalone-edge:129.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_130.md
+++ b/CHANGELOG/4.35.0/edge_130.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 130.0.2849.80
+Short Edge version -> 130.0
+EdgeDriver version -> 130.0.2849.78
+Short EdgeDriver version -> 130.0
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.35.0-20250808
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250808
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250808
+Tagged selenium/node-edge:130.0.2849.80-20250808
+Tagged selenium/standalone-edge:130.0.2849.80-20250808
+Tagged selenium/node-edge:130.0-edgedriver-130.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:130.0-edgedriver-130.0-20250808
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-20250808
+Tagged selenium/node-edge:130.0-20250808
+Tagged selenium/standalone-edge:130.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_131.md
+++ b/CHANGELOG/4.35.0/edge_131.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 131.0.2903.147
+Short Edge version -> 131.0
+EdgeDriver version -> 131.0.2903.147
+Short EdgeDriver version -> 131.0
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.35.0-20250808
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250808
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250808
+Tagged selenium/node-edge:131.0.2903.147-20250808
+Tagged selenium/standalone-edge:131.0.2903.147-20250808
+Tagged selenium/node-edge:131.0-edgedriver-131.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:131.0-edgedriver-131.0-20250808
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-20250808
+Tagged selenium/node-edge:131.0-20250808
+Tagged selenium/standalone-edge:131.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_132.md
+++ b/CHANGELOG/4.35.0/edge_132.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 132.0.2957.140
+Short Edge version -> 132.0
+EdgeDriver version -> 132.0.2957.140
+Short EdgeDriver version -> 132.0
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.35.0-20250808
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250808
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250808
+Tagged selenium/node-edge:132.0.2957.140-20250808
+Tagged selenium/standalone-edge:132.0.2957.140-20250808
+Tagged selenium/node-edge:132.0-edgedriver-132.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:132.0-edgedriver-132.0-20250808
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-20250808
+Tagged selenium/node-edge:132.0-20250808
+Tagged selenium/standalone-edge:132.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_133.md
+++ b/CHANGELOG/4.35.0/edge_133.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 133.0.3065.92
+Short Edge version -> 133.0
+EdgeDriver version -> 133.0.3065.92
+Short EdgeDriver version -> 133.0
+Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250808
+Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250808
+Tagged selenium/node-edge:133.0.3065.92-20250808
+Tagged selenium/standalone-edge:133.0.3065.92-20250808
+Tagged selenium/node-edge:133.0-edgedriver-133.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:133.0-edgedriver-133.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:133.0-edgedriver-133.0-20250808
+Tagged selenium/standalone-edge:133.0-edgedriver-133.0-20250808
+Tagged selenium/node-edge:133.0-20250808
+Tagged selenium/standalone-edge:133.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_134.md
+++ b/CHANGELOG/4.35.0/edge_134.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 134.0.3124.95
+Short Edge version -> 134.0
+EdgeDriver version -> 134.0.3124.95
+Short EdgeDriver version -> 134.0
+Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.35.0-20250808
+Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250808
+Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250808
+Tagged selenium/node-edge:134.0.3124.95-20250808
+Tagged selenium/standalone-edge:134.0.3124.95-20250808
+Tagged selenium/node-edge:134.0-edgedriver-134.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:134.0-edgedriver-134.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:134.0-edgedriver-134.0-20250808
+Tagged selenium/standalone-edge:134.0-edgedriver-134.0-20250808
+Tagged selenium/node-edge:134.0-20250808
+Tagged selenium/standalone-edge:134.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_135.md
+++ b/CHANGELOG/4.35.0/edge_135.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 135.0.3179.98
+Short Edge version -> 135.0
+EdgeDriver version -> 135.0.3179.98
+Short EdgeDriver version -> 135.0
+Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.35.0-20250808
+Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250808
+Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250808
+Tagged selenium/node-edge:135.0.3179.98-20250808
+Tagged selenium/standalone-edge:135.0.3179.98-20250808
+Tagged selenium/node-edge:135.0-edgedriver-135.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:135.0-edgedriver-135.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:135.0-edgedriver-135.0-20250808
+Tagged selenium/standalone-edge:135.0-edgedriver-135.0-20250808
+Tagged selenium/node-edge:135.0-20250808
+Tagged selenium/standalone-edge:135.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_136.md
+++ b/CHANGELOG/4.35.0/edge_136.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 136.0.3240.92
+Short Edge version -> 136.0
+EdgeDriver version -> 136.0.3240.92
+Short EdgeDriver version -> 136.0
+Tagged selenium/node-edge:136.0.3240.92-edgedriver-136.0.3240.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:136.0.3240.92-edgedriver-136.0.3240.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:136.0.3240.92-edgedriver-136.0.3240.92-20250808
+Tagged selenium/standalone-edge:136.0.3240.92-edgedriver-136.0.3240.92-20250808
+Tagged selenium/node-edge:136.0.3240.92-20250808
+Tagged selenium/standalone-edge:136.0.3240.92-20250808
+Tagged selenium/node-edge:136.0-edgedriver-136.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:136.0-edgedriver-136.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:136.0-edgedriver-136.0-20250808
+Tagged selenium/standalone-edge:136.0-edgedriver-136.0-20250808
+Tagged selenium/node-edge:136.0-20250808
+Tagged selenium/standalone-edge:136.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_137.md
+++ b/CHANGELOG/4.35.0/edge_137.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 137.0.3296.93
+Short Edge version -> 137.0
+EdgeDriver version -> 137.0.3296.93
+Short EdgeDriver version -> 137.0
+Tagged selenium/node-edge:137.0.3296.93-edgedriver-137.0.3296.93-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:137.0.3296.93-edgedriver-137.0.3296.93-grid-4.35.0-20250808
+Tagged selenium/node-edge:137.0.3296.93-edgedriver-137.0.3296.93-20250808
+Tagged selenium/standalone-edge:137.0.3296.93-edgedriver-137.0.3296.93-20250808
+Tagged selenium/node-edge:137.0.3296.93-20250808
+Tagged selenium/standalone-edge:137.0.3296.93-20250808
+Tagged selenium/node-edge:137.0-edgedriver-137.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:137.0-edgedriver-137.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:137.0-edgedriver-137.0-20250808
+Tagged selenium/standalone-edge:137.0-edgedriver-137.0-20250808
+Tagged selenium/node-edge:137.0-20250808
+Tagged selenium/standalone-edge:137.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_138.md
+++ b/CHANGELOG/4.35.0/edge_138.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 138.0.3351.121
+Short Edge version -> 138.0
+EdgeDriver version -> 138.0.3351.121
+Short EdgeDriver version -> 138.0
+Tagged selenium/node-edge:138.0.3351.121-edgedriver-138.0.3351.121-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:138.0.3351.121-edgedriver-138.0.3351.121-grid-4.35.0-20250808
+Tagged selenium/node-edge:138.0.3351.121-edgedriver-138.0.3351.121-20250808
+Tagged selenium/standalone-edge:138.0.3351.121-edgedriver-138.0.3351.121-20250808
+Tagged selenium/node-edge:138.0.3351.121-20250808
+Tagged selenium/standalone-edge:138.0.3351.121-20250808
+Tagged selenium/node-edge:138.0-edgedriver-138.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:138.0-edgedriver-138.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:138.0-edgedriver-138.0-20250808
+Tagged selenium/standalone-edge:138.0-edgedriver-138.0-20250808
+Tagged selenium/node-edge:138.0-20250808
+Tagged selenium/standalone-edge:138.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_100.md
+++ b/CHANGELOG/4.35.0/firefox_100.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 100.0.2
+Short Firefox version -> 100.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:100.0.2-20250808
+Tagged selenium/standalone-firefox:100.0.2-20250808
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:100.0-20250808
+Tagged selenium/standalone-firefox:100.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_101.md
+++ b/CHANGELOG/4.35.0/firefox_101.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 101.0.1
+Short Firefox version -> 101.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:101.0.1-20250808
+Tagged selenium/standalone-firefox:101.0.1-20250808
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:101.0-20250808
+Tagged selenium/standalone-firefox:101.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_102.md
+++ b/CHANGELOG/4.35.0/firefox_102.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 102.0.1
+Short Firefox version -> 102.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:102.0.1-20250808
+Tagged selenium/standalone-firefox:102.0.1-20250808
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:102.0-20250808
+Tagged selenium/standalone-firefox:102.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_103.md
+++ b/CHANGELOG/4.35.0/firefox_103.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 103.0.2
+Short Firefox version -> 103.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:103.0.2-20250808
+Tagged selenium/standalone-firefox:103.0.2-20250808
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:103.0-20250808
+Tagged selenium/standalone-firefox:103.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_104.md
+++ b/CHANGELOG/4.35.0/firefox_104.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 104.0.2
+Short Firefox version -> 104.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:104.0.2-20250808
+Tagged selenium/standalone-firefox:104.0.2-20250808
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:104.0-20250808
+Tagged selenium/standalone-firefox:104.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_105.md
+++ b/CHANGELOG/4.35.0/firefox_105.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 105.0.3
+Short Firefox version -> 105.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:105.0.3-20250808
+Tagged selenium/standalone-firefox:105.0.3-20250808
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:105.0-20250808
+Tagged selenium/standalone-firefox:105.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_106.md
+++ b/CHANGELOG/4.35.0/firefox_106.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 106.0.5
+Short Firefox version -> 106.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:106.0.5-20250808
+Tagged selenium/standalone-firefox:106.0.5-20250808
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:106.0-20250808
+Tagged selenium/standalone-firefox:106.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_107.md
+++ b/CHANGELOG/4.35.0/firefox_107.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 107.0.1
+Short Firefox version -> 107.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:107.0.1-20250808
+Tagged selenium/standalone-firefox:107.0.1-20250808
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:107.0-20250808
+Tagged selenium/standalone-firefox:107.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_108.md
+++ b/CHANGELOG/4.35.0/firefox_108.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 108.0.2
+Short Firefox version -> 108.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:108.0.2-20250808
+Tagged selenium/standalone-firefox:108.0.2-20250808
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:108.0-20250808
+Tagged selenium/standalone-firefox:108.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_109.md
+++ b/CHANGELOG/4.35.0/firefox_109.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 109.0.1
+Short Firefox version -> 109.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:109.0.1-20250808
+Tagged selenium/standalone-firefox:109.0.1-20250808
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:109.0-20250808
+Tagged selenium/standalone-firefox:109.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_110.md
+++ b/CHANGELOG/4.35.0/firefox_110.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 110.0.1
+Short Firefox version -> 110.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:110.0.1-20250808
+Tagged selenium/standalone-firefox:110.0.1-20250808
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:110.0-20250808
+Tagged selenium/standalone-firefox:110.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_111.md
+++ b/CHANGELOG/4.35.0/firefox_111.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 111.0.1
+Short Firefox version -> 111.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:111.0.1-20250808
+Tagged selenium/standalone-firefox:111.0.1-20250808
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:111.0-20250808
+Tagged selenium/standalone-firefox:111.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_112.md
+++ b/CHANGELOG/4.35.0/firefox_112.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 112.0.2
+Short Firefox version -> 112.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:112.0.2-20250808
+Tagged selenium/standalone-firefox:112.0.2-20250808
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:112.0-20250808
+Tagged selenium/standalone-firefox:112.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_113.md
+++ b/CHANGELOG/4.35.0/firefox_113.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 113.0.2
+Short Firefox version -> 113.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:113.0.2-20250808
+Tagged selenium/standalone-firefox:113.0.2-20250808
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:113.0-20250808
+Tagged selenium/standalone-firefox:113.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_114.md
+++ b/CHANGELOG/4.35.0/firefox_114.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 114.0.2
+Short Firefox version -> 114.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:114.0.2-20250808
+Tagged selenium/standalone-firefox:114.0.2-20250808
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:114.0-20250808
+Tagged selenium/standalone-firefox:114.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_115.md
+++ b/CHANGELOG/4.35.0/firefox_115.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 115.0.3
+Short Firefox version -> 115.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:115.0.3-20250808
+Tagged selenium/standalone-firefox:115.0.3-20250808
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:115.0-20250808
+Tagged selenium/standalone-firefox:115.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_116.md
+++ b/CHANGELOG/4.35.0/firefox_116.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 116.0.3
+Short Firefox version -> 116.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:116.0.3-20250808
+Tagged selenium/standalone-firefox:116.0.3-20250808
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:116.0-20250808
+Tagged selenium/standalone-firefox:116.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_117.md
+++ b/CHANGELOG/4.35.0/firefox_117.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 117.0.1
+Short Firefox version -> 117.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:117.0.1-20250808
+Tagged selenium/standalone-firefox:117.0.1-20250808
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:117.0-20250808
+Tagged selenium/standalone-firefox:117.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_118.md
+++ b/CHANGELOG/4.35.0/firefox_118.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 118.0.2
+Short Firefox version -> 118.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:118.0.2-20250808
+Tagged selenium/standalone-firefox:118.0.2-20250808
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:118.0-20250808
+Tagged selenium/standalone-firefox:118.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_119.md
+++ b/CHANGELOG/4.35.0/firefox_119.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 119.0.1
+Short Firefox version -> 119.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:119.0.1-20250808
+Tagged selenium/standalone-firefox:119.0.1-20250808
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:119.0-20250808
+Tagged selenium/standalone-firefox:119.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_120.md
+++ b/CHANGELOG/4.35.0/firefox_120.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 120.0.1
+Short Firefox version -> 120.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:120.0.1-20250808
+Tagged selenium/standalone-firefox:120.0.1-20250808
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:120.0-20250808
+Tagged selenium/standalone-firefox:120.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_121.md
+++ b/CHANGELOG/4.35.0/firefox_121.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 121.0.1
+Short Firefox version -> 121.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:121.0.1-20250808
+Tagged selenium/standalone-firefox:121.0.1-20250808
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:121.0-20250808
+Tagged selenium/standalone-firefox:121.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_122.md
+++ b/CHANGELOG/4.35.0/firefox_122.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 122.0.1
+Short Firefox version -> 122.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:122.0.1-20250808
+Tagged selenium/standalone-firefox:122.0.1-20250808
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:122.0-20250808
+Tagged selenium/standalone-firefox:122.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_123.md
+++ b/CHANGELOG/4.35.0/firefox_123.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 123.0.1
+Short Firefox version -> 123.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:123.0.1-20250808
+Tagged selenium/standalone-firefox:123.0.1-20250808
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:123.0-20250808
+Tagged selenium/standalone-firefox:123.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_124.md
+++ b/CHANGELOG/4.35.0/firefox_124.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 124.0.2
+Short Firefox version -> 124.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:124.0.2-20250808
+Tagged selenium/standalone-firefox:124.0.2-20250808
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:124.0-20250808
+Tagged selenium/standalone-firefox:124.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_125.md
+++ b/CHANGELOG/4.35.0/firefox_125.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 125.0.3
+Short Firefox version -> 125.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:125.0.3-20250808
+Tagged selenium/standalone-firefox:125.0.3-20250808
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:125.0-20250808
+Tagged selenium/standalone-firefox:125.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_126.md
+++ b/CHANGELOG/4.35.0/firefox_126.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 126.0.1
+Short Firefox version -> 126.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:126.0.1-20250808
+Tagged selenium/standalone-firefox:126.0.1-20250808
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:126.0-20250808
+Tagged selenium/standalone-firefox:126.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_127.md
+++ b/CHANGELOG/4.35.0/firefox_127.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 127.0.2
+Short Firefox version -> 127.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:127.0.2-20250808
+Tagged selenium/standalone-firefox:127.0.2-20250808
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:127.0-20250808
+Tagged selenium/standalone-firefox:127.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_128.md
+++ b/CHANGELOG/4.35.0/firefox_128.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 128.0.3
+Short Firefox version -> 128.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:128.0.3-20250808
+Tagged selenium/standalone-firefox:128.0.3-20250808
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:128.0-20250808
+Tagged selenium/standalone-firefox:128.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_129.md
+++ b/CHANGELOG/4.35.0/firefox_129.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 129.0.2
+Short Firefox version -> 129.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:129.0.2-20250808
+Tagged selenium/standalone-firefox:129.0.2-20250808
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:129.0-20250808
+Tagged selenium/standalone-firefox:129.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_130.md
+++ b/CHANGELOG/4.35.0/firefox_130.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 130.0.1
+Short Firefox version -> 130.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:130.0.1-20250808
+Tagged selenium/standalone-firefox:130.0.1-20250808
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:130.0-20250808
+Tagged selenium/standalone-firefox:130.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_131.md
+++ b/CHANGELOG/4.35.0/firefox_131.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 131.0.3
+Short Firefox version -> 131.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:131.0.3-20250808
+Tagged selenium/standalone-firefox:131.0.3-20250808
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:131.0-20250808
+Tagged selenium/standalone-firefox:131.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_132.md
+++ b/CHANGELOG/4.35.0/firefox_132.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 132.0.2
+Short Firefox version -> 132.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:132.0.2-20250808
+Tagged selenium/standalone-firefox:132.0.2-20250808
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:132.0-20250808
+Tagged selenium/standalone-firefox:132.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_133.md
+++ b/CHANGELOG/4.35.0/firefox_133.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 133.0.3
+Short Firefox version -> 133.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:133.0.3-20250808
+Tagged selenium/standalone-firefox:133.0.3-20250808
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:133.0-20250808
+Tagged selenium/standalone-firefox:133.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_134.md
+++ b/CHANGELOG/4.35.0/firefox_134.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 134.0.2
+Short Firefox version -> 134.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:134.0.2-20250808
+Tagged selenium/standalone-firefox:134.0.2-20250808
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:134.0-20250808
+Tagged selenium/standalone-firefox:134.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_135.md
+++ b/CHANGELOG/4.35.0/firefox_135.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 135.0.1
+Short Firefox version -> 135.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:135.0.1-20250808
+Tagged selenium/standalone-firefox:135.0.1-20250808
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:135.0-20250808
+Tagged selenium/standalone-firefox:135.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_136.md
+++ b/CHANGELOG/4.35.0/firefox_136.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 136.0.4
+Short Firefox version -> 136.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:136.0.4-20250808
+Tagged selenium/standalone-firefox:136.0.4-20250808
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:136.0-20250808
+Tagged selenium/standalone-firefox:136.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_137.md
+++ b/CHANGELOG/4.35.0/firefox_137.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 137.0.2
+Short Firefox version -> 137.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:137.0.2-20250808
+Tagged selenium/standalone-firefox:137.0.2-20250808
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:137.0-20250808
+Tagged selenium/standalone-firefox:137.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_138.md
+++ b/CHANGELOG/4.35.0/firefox_138.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 138.0.4
+Short Firefox version -> 138.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:138.0.4-20250808
+Tagged selenium/standalone-firefox:138.0.4-20250808
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:138.0-20250808
+Tagged selenium/standalone-firefox:138.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_139.md
+++ b/CHANGELOG/4.35.0/firefox_139.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 139.0.4
+Short Firefox version -> 139.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:139.0.4-20250808
+Tagged selenium/standalone-firefox:139.0.4-20250808
+Tagged selenium/node-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:139.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:139.0-20250808
+Tagged selenium/standalone-firefox:139.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_140.md
+++ b/CHANGELOG/4.35.0/firefox_140.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 140.0.4
+Short Firefox version -> 140.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:140.0.4-20250808
+Tagged selenium/standalone-firefox:140.0.4-20250808
+Tagged selenium/node-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:140.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:140.0-20250808
+Tagged selenium/standalone-firefox:140.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_98.md
+++ b/CHANGELOG/4.35.0/firefox_98.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 98.0.2
+Short Firefox version -> 98.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:98.0.2-20250808
+Tagged selenium/standalone-firefox:98.0.2-20250808
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:98.0-20250808
+Tagged selenium/standalone-firefox:98.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_99.md
+++ b/CHANGELOG/4.35.0/firefox_99.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 99.0.1
+Short Firefox version -> 99.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:99.0.1-20250808
+Tagged selenium/standalone-firefox:99.0.1-20250808
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:99.0-20250808
+Tagged selenium/standalone-firefox:99.0-20250808
+```

--- a/tests/build-backward-compatible/browser-matrix.yml
+++ b/tests/build-backward-compatible/browser-matrix.yml
@@ -12,7 +12,7 @@ matrix:
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '139':
       EDGE_VERSION: microsoft-edge-stable=139.0.3405.86-1
-      CHROME_VERSION: google-chrome-stable=139.0.7258.66-1
+      CHROME_VERSION: google-chrome-stable=139.0.7258.127-1
       FIREFOX_VERSION: 139.0.4
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '138':


### PR DESCRIPTION
This PR contains the CHANGELOG for Node/Standalone chrome with specific browser versions: [95, 96, 97, 98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138]