### PR TITLE
[ci] CHANGELOG for Node/Standalone edge browser versions with Grid 4.35.0

### DIFF
--- a/CHANGELOG/4.35.0/edge_114.md
+++ b/CHANGELOG/4.35.0/edge_114.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 114.0.1823.82
+Short Edge version -> 114.0
+EdgeDriver version -> 114.0.1823.82
+Short EdgeDriver version -> 114.0
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-grid-4.35.0-20250808
+Tagged selenium/node-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250808
+Tagged selenium/standalone-edge:114.0.1823.82-edgedriver-114.0.1823.82-20250808
+Tagged selenium/node-edge:114.0.1823.82-20250808
+Tagged selenium/standalone-edge:114.0.1823.82-20250808
+Tagged selenium/node-edge:114.0-edgedriver-114.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:114.0-edgedriver-114.0-20250808
+Tagged selenium/standalone-edge:114.0-edgedriver-114.0-20250808
+Tagged selenium/node-edge:114.0-20250808
+Tagged selenium/standalone-edge:114.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_115.md
+++ b/CHANGELOG/4.35.0/edge_115.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 115.0.1901.203
+Short Edge version -> 115.0
+EdgeDriver version -> 115.0.1901.203
+Short EdgeDriver version -> 115.0
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-grid-4.35.0-20250808
+Tagged selenium/node-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250808
+Tagged selenium/standalone-edge:115.0.1901.203-edgedriver-115.0.1901.203-20250808
+Tagged selenium/node-edge:115.0.1901.203-20250808
+Tagged selenium/standalone-edge:115.0.1901.203-20250808
+Tagged selenium/node-edge:115.0-edgedriver-115.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:115.0-edgedriver-115.0-20250808
+Tagged selenium/standalone-edge:115.0-edgedriver-115.0-20250808
+Tagged selenium/node-edge:115.0-20250808
+Tagged selenium/standalone-edge:115.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_116.md
+++ b/CHANGELOG/4.35.0/edge_116.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 116.0.1938.81
+Short Edge version -> 116.0
+EdgeDriver version -> 116.0.1938.81
+Short EdgeDriver version -> 116.0
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-grid-4.35.0-20250808
+Tagged selenium/node-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250808
+Tagged selenium/standalone-edge:116.0.1938.81-edgedriver-116.0.1938.81-20250808
+Tagged selenium/node-edge:116.0.1938.81-20250808
+Tagged selenium/standalone-edge:116.0.1938.81-20250808
+Tagged selenium/node-edge:116.0-edgedriver-116.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:116.0-edgedriver-116.0-20250808
+Tagged selenium/standalone-edge:116.0-edgedriver-116.0-20250808
+Tagged selenium/node-edge:116.0-20250808
+Tagged selenium/standalone-edge:116.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_117.md
+++ b/CHANGELOG/4.35.0/edge_117.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 117.0.2045.55
+Short Edge version -> 117.0
+EdgeDriver version -> 117.0.2045.55
+Short EdgeDriver version -> 117.0
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-grid-4.35.0-20250808
+Tagged selenium/node-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250808
+Tagged selenium/standalone-edge:117.0.2045.55-edgedriver-117.0.2045.55-20250808
+Tagged selenium/node-edge:117.0.2045.55-20250808
+Tagged selenium/standalone-edge:117.0.2045.55-20250808
+Tagged selenium/node-edge:117.0-edgedriver-117.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:117.0-edgedriver-117.0-20250808
+Tagged selenium/standalone-edge:117.0-edgedriver-117.0-20250808
+Tagged selenium/node-edge:117.0-20250808
+Tagged selenium/standalone-edge:117.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_118.md
+++ b/CHANGELOG/4.35.0/edge_118.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 118.0.2088.76
+Short Edge version -> 118.0
+EdgeDriver version -> 118.0.2088.76
+Short EdgeDriver version -> 118.0
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-grid-4.35.0-20250808
+Tagged selenium/node-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250808
+Tagged selenium/standalone-edge:118.0.2088.76-edgedriver-118.0.2088.76-20250808
+Tagged selenium/node-edge:118.0.2088.76-20250808
+Tagged selenium/standalone-edge:118.0.2088.76-20250808
+Tagged selenium/node-edge:118.0-edgedriver-118.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:118.0-edgedriver-118.0-20250808
+Tagged selenium/standalone-edge:118.0-edgedriver-118.0-20250808
+Tagged selenium/node-edge:118.0-20250808
+Tagged selenium/standalone-edge:118.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_119.md
+++ b/CHANGELOG/4.35.0/edge_119.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 119.0.2151.97
+Short Edge version -> 119.0
+EdgeDriver version -> 119.0.2151.97
+Short EdgeDriver version -> 119.0
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-grid-4.35.0-20250808
+Tagged selenium/node-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250808
+Tagged selenium/standalone-edge:119.0.2151.97-edgedriver-119.0.2151.97-20250808
+Tagged selenium/node-edge:119.0.2151.97-20250808
+Tagged selenium/standalone-edge:119.0.2151.97-20250808
+Tagged selenium/node-edge:119.0-edgedriver-119.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:119.0-edgedriver-119.0-20250808
+Tagged selenium/standalone-edge:119.0-edgedriver-119.0-20250808
+Tagged selenium/node-edge:119.0-20250808
+Tagged selenium/standalone-edge:119.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_120.md
+++ b/CHANGELOG/4.35.0/edge_120.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 120.0.2210.144
+Short Edge version -> 120.0
+EdgeDriver version -> 120.0.2210.144
+Short EdgeDriver version -> 120.0
+Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-grid-4.35.0-20250808
+Tagged selenium/node-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250808
+Tagged selenium/standalone-edge:120.0.2210.144-edgedriver-120.0.2210.144-20250808
+Tagged selenium/node-edge:120.0.2210.144-20250808
+Tagged selenium/standalone-edge:120.0.2210.144-20250808
+Tagged selenium/node-edge:120.0-edgedriver-120.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:120.0-edgedriver-120.0-20250808
+Tagged selenium/standalone-edge:120.0-edgedriver-120.0-20250808
+Tagged selenium/node-edge:120.0-20250808
+Tagged selenium/standalone-edge:120.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_121.md
+++ b/CHANGELOG/4.35.0/edge_121.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 121.0.2277.128
+Short Edge version -> 121.0
+EdgeDriver version -> 121.0.2277.128
+Short EdgeDriver version -> 121.0
+Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-grid-4.35.0-20250808
+Tagged selenium/node-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250808
+Tagged selenium/standalone-edge:121.0.2277.128-edgedriver-121.0.2277.128-20250808
+Tagged selenium/node-edge:121.0.2277.128-20250808
+Tagged selenium/standalone-edge:121.0.2277.128-20250808
+Tagged selenium/node-edge:121.0-edgedriver-121.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:121.0-edgedriver-121.0-20250808
+Tagged selenium/standalone-edge:121.0-edgedriver-121.0-20250808
+Tagged selenium/node-edge:121.0-20250808
+Tagged selenium/standalone-edge:121.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_122.md
+++ b/CHANGELOG/4.35.0/edge_122.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 122.0.2365.92
+Short Edge version -> 122.0
+EdgeDriver version -> 122.0.2365.92
+Short EdgeDriver version -> 122.0
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250808
+Tagged selenium/standalone-edge:122.0.2365.92-edgedriver-122.0.2365.92-20250808
+Tagged selenium/node-edge:122.0.2365.92-20250808
+Tagged selenium/standalone-edge:122.0.2365.92-20250808
+Tagged selenium/node-edge:122.0-edgedriver-122.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:122.0-edgedriver-122.0-20250808
+Tagged selenium/standalone-edge:122.0-edgedriver-122.0-20250808
+Tagged selenium/node-edge:122.0-20250808
+Tagged selenium/standalone-edge:122.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_123.md
+++ b/CHANGELOG/4.35.0/edge_123.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 123.0.2420.97
+Short Edge version -> 123.0
+EdgeDriver version -> 123.0.2420.97
+Short EdgeDriver version -> 123.0
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-grid-4.35.0-20250808
+Tagged selenium/node-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250808
+Tagged selenium/standalone-edge:123.0.2420.97-edgedriver-123.0.2420.97-20250808
+Tagged selenium/node-edge:123.0.2420.97-20250808
+Tagged selenium/standalone-edge:123.0.2420.97-20250808
+Tagged selenium/node-edge:123.0-edgedriver-123.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:123.0-edgedriver-123.0-20250808
+Tagged selenium/standalone-edge:123.0-edgedriver-123.0-20250808
+Tagged selenium/node-edge:123.0-20250808
+Tagged selenium/standalone-edge:123.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_124.md
+++ b/CHANGELOG/4.35.0/edge_124.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 124.0.2478.109
+Short Edge version -> 124.0
+EdgeDriver version -> 124.0.2478.109
+Short EdgeDriver version -> 124.0
+Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-grid-4.35.0-20250808
+Tagged selenium/node-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250808
+Tagged selenium/standalone-edge:124.0.2478.109-edgedriver-124.0.2478.109-20250808
+Tagged selenium/node-edge:124.0.2478.109-20250808
+Tagged selenium/standalone-edge:124.0.2478.109-20250808
+Tagged selenium/node-edge:124.0-edgedriver-124.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:124.0-edgedriver-124.0-20250808
+Tagged selenium/standalone-edge:124.0-edgedriver-124.0-20250808
+Tagged selenium/node-edge:124.0-20250808
+Tagged selenium/standalone-edge:124.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_125.md
+++ b/CHANGELOG/4.35.0/edge_125.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 125.0.2535.92
+Short Edge version -> 125.0
+EdgeDriver version -> 125.0.2535.92
+Short EdgeDriver version -> 125.0
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250808
+Tagged selenium/standalone-edge:125.0.2535.92-edgedriver-125.0.2535.92-20250808
+Tagged selenium/node-edge:125.0.2535.92-20250808
+Tagged selenium/standalone-edge:125.0.2535.92-20250808
+Tagged selenium/node-edge:125.0-edgedriver-125.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:125.0-edgedriver-125.0-20250808
+Tagged selenium/standalone-edge:125.0-edgedriver-125.0-20250808
+Tagged selenium/node-edge:125.0-20250808
+Tagged selenium/standalone-edge:125.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_126.md
+++ b/CHANGELOG/4.35.0/edge_126.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 126.0.2592.113
+Short Edge version -> 126.0
+EdgeDriver version -> 126.0.2592.123
+Short EdgeDriver version -> 126.0
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-grid-4.35.0-20250808
+Tagged selenium/node-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250808
+Tagged selenium/standalone-edge:126.0.2592.113-edgedriver-126.0.2592.123-20250808
+Tagged selenium/node-edge:126.0.2592.113-20250808
+Tagged selenium/standalone-edge:126.0.2592.113-20250808
+Tagged selenium/node-edge:126.0-edgedriver-126.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:126.0-edgedriver-126.0-20250808
+Tagged selenium/standalone-edge:126.0-edgedriver-126.0-20250808
+Tagged selenium/node-edge:126.0-20250808
+Tagged selenium/standalone-edge:126.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_127.md
+++ b/CHANGELOG/4.35.0/edge_127.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 127.0.2651.105
+Short Edge version -> 127.0
+EdgeDriver version -> 127.0.2651.107
+Short EdgeDriver version -> 127.0
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-grid-4.35.0-20250808
+Tagged selenium/node-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250808
+Tagged selenium/standalone-edge:127.0.2651.105-edgedriver-127.0.2651.107-20250808
+Tagged selenium/node-edge:127.0.2651.105-20250808
+Tagged selenium/standalone-edge:127.0.2651.105-20250808
+Tagged selenium/node-edge:127.0-edgedriver-127.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:127.0-edgedriver-127.0-20250808
+Tagged selenium/standalone-edge:127.0-edgedriver-127.0-20250808
+Tagged selenium/node-edge:127.0-20250808
+Tagged selenium/standalone-edge:127.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_128.md
+++ b/CHANGELOG/4.35.0/edge_128.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 128.0.2739.79
+Short Edge version -> 128.0
+EdgeDriver version -> 128.0.2739.81
+Short EdgeDriver version -> 128.0
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-grid-4.35.0-20250808
+Tagged selenium/node-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250808
+Tagged selenium/standalone-edge:128.0.2739.79-edgedriver-128.0.2739.81-20250808
+Tagged selenium/node-edge:128.0.2739.79-20250808
+Tagged selenium/standalone-edge:128.0.2739.79-20250808
+Tagged selenium/node-edge:128.0-edgedriver-128.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:128.0-edgedriver-128.0-20250808
+Tagged selenium/standalone-edge:128.0-edgedriver-128.0-20250808
+Tagged selenium/node-edge:128.0-20250808
+Tagged selenium/standalone-edge:128.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_129.md
+++ b/CHANGELOG/4.35.0/edge_129.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 129.0.2792.89
+Short Edge version -> 129.0
+EdgeDriver version -> 129.0.2792.98
+Short EdgeDriver version -> 129.0
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-grid-4.35.0-20250808
+Tagged selenium/node-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250808
+Tagged selenium/standalone-edge:129.0.2792.89-edgedriver-129.0.2792.98-20250808
+Tagged selenium/node-edge:129.0.2792.89-20250808
+Tagged selenium/standalone-edge:129.0.2792.89-20250808
+Tagged selenium/node-edge:129.0-edgedriver-129.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:129.0-edgedriver-129.0-20250808
+Tagged selenium/standalone-edge:129.0-edgedriver-129.0-20250808
+Tagged selenium/node-edge:129.0-20250808
+Tagged selenium/standalone-edge:129.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_130.md
+++ b/CHANGELOG/4.35.0/edge_130.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 130.0.2849.80
+Short Edge version -> 130.0
+EdgeDriver version -> 130.0.2849.78
+Short EdgeDriver version -> 130.0
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-grid-4.35.0-20250808
+Tagged selenium/node-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250808
+Tagged selenium/standalone-edge:130.0.2849.80-edgedriver-130.0.2849.78-20250808
+Tagged selenium/node-edge:130.0.2849.80-20250808
+Tagged selenium/standalone-edge:130.0.2849.80-20250808
+Tagged selenium/node-edge:130.0-edgedriver-130.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:130.0-edgedriver-130.0-20250808
+Tagged selenium/standalone-edge:130.0-edgedriver-130.0-20250808
+Tagged selenium/node-edge:130.0-20250808
+Tagged selenium/standalone-edge:130.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_131.md
+++ b/CHANGELOG/4.35.0/edge_131.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 131.0.2903.147
+Short Edge version -> 131.0
+EdgeDriver version -> 131.0.2903.147
+Short EdgeDriver version -> 131.0
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-grid-4.35.0-20250808
+Tagged selenium/node-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250808
+Tagged selenium/standalone-edge:131.0.2903.147-edgedriver-131.0.2903.147-20250808
+Tagged selenium/node-edge:131.0.2903.147-20250808
+Tagged selenium/standalone-edge:131.0.2903.147-20250808
+Tagged selenium/node-edge:131.0-edgedriver-131.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:131.0-edgedriver-131.0-20250808
+Tagged selenium/standalone-edge:131.0-edgedriver-131.0-20250808
+Tagged selenium/node-edge:131.0-20250808
+Tagged selenium/standalone-edge:131.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_132.md
+++ b/CHANGELOG/4.35.0/edge_132.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 132.0.2957.140
+Short Edge version -> 132.0
+EdgeDriver version -> 132.0.2957.140
+Short EdgeDriver version -> 132.0
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-grid-4.35.0-20250808
+Tagged selenium/node-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250808
+Tagged selenium/standalone-edge:132.0.2957.140-edgedriver-132.0.2957.140-20250808
+Tagged selenium/node-edge:132.0.2957.140-20250808
+Tagged selenium/standalone-edge:132.0.2957.140-20250808
+Tagged selenium/node-edge:132.0-edgedriver-132.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:132.0-edgedriver-132.0-20250808
+Tagged selenium/standalone-edge:132.0-edgedriver-132.0-20250808
+Tagged selenium/node-edge:132.0-20250808
+Tagged selenium/standalone-edge:132.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_133.md
+++ b/CHANGELOG/4.35.0/edge_133.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 133.0.3065.92
+Short Edge version -> 133.0
+EdgeDriver version -> 133.0.3065.92
+Short EdgeDriver version -> 133.0
+Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250808
+Tagged selenium/standalone-edge:133.0.3065.92-edgedriver-133.0.3065.92-20250808
+Tagged selenium/node-edge:133.0.3065.92-20250808
+Tagged selenium/standalone-edge:133.0.3065.92-20250808
+Tagged selenium/node-edge:133.0-edgedriver-133.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:133.0-edgedriver-133.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:133.0-edgedriver-133.0-20250808
+Tagged selenium/standalone-edge:133.0-edgedriver-133.0-20250808
+Tagged selenium/node-edge:133.0-20250808
+Tagged selenium/standalone-edge:133.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_134.md
+++ b/CHANGELOG/4.35.0/edge_134.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 134.0.3124.95
+Short Edge version -> 134.0
+EdgeDriver version -> 134.0.3124.95
+Short EdgeDriver version -> 134.0
+Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-grid-4.35.0-20250808
+Tagged selenium/node-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250808
+Tagged selenium/standalone-edge:134.0.3124.95-edgedriver-134.0.3124.95-20250808
+Tagged selenium/node-edge:134.0.3124.95-20250808
+Tagged selenium/standalone-edge:134.0.3124.95-20250808
+Tagged selenium/node-edge:134.0-edgedriver-134.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:134.0-edgedriver-134.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:134.0-edgedriver-134.0-20250808
+Tagged selenium/standalone-edge:134.0-edgedriver-134.0-20250808
+Tagged selenium/node-edge:134.0-20250808
+Tagged selenium/standalone-edge:134.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_135.md
+++ b/CHANGELOG/4.35.0/edge_135.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 135.0.3179.98
+Short Edge version -> 135.0
+EdgeDriver version -> 135.0.3179.98
+Short EdgeDriver version -> 135.0
+Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-grid-4.35.0-20250808
+Tagged selenium/node-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250808
+Tagged selenium/standalone-edge:135.0.3179.98-edgedriver-135.0.3179.98-20250808
+Tagged selenium/node-edge:135.0.3179.98-20250808
+Tagged selenium/standalone-edge:135.0.3179.98-20250808
+Tagged selenium/node-edge:135.0-edgedriver-135.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:135.0-edgedriver-135.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:135.0-edgedriver-135.0-20250808
+Tagged selenium/standalone-edge:135.0-edgedriver-135.0-20250808
+Tagged selenium/node-edge:135.0-20250808
+Tagged selenium/standalone-edge:135.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_136.md
+++ b/CHANGELOG/4.35.0/edge_136.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 136.0.3240.92
+Short Edge version -> 136.0
+EdgeDriver version -> 136.0.3240.92
+Short EdgeDriver version -> 136.0
+Tagged selenium/node-edge:136.0.3240.92-edgedriver-136.0.3240.92-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:136.0.3240.92-edgedriver-136.0.3240.92-grid-4.35.0-20250808
+Tagged selenium/node-edge:136.0.3240.92-edgedriver-136.0.3240.92-20250808
+Tagged selenium/standalone-edge:136.0.3240.92-edgedriver-136.0.3240.92-20250808
+Tagged selenium/node-edge:136.0.3240.92-20250808
+Tagged selenium/standalone-edge:136.0.3240.92-20250808
+Tagged selenium/node-edge:136.0-edgedriver-136.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:136.0-edgedriver-136.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:136.0-edgedriver-136.0-20250808
+Tagged selenium/standalone-edge:136.0-edgedriver-136.0-20250808
+Tagged selenium/node-edge:136.0-20250808
+Tagged selenium/standalone-edge:136.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_137.md
+++ b/CHANGELOG/4.35.0/edge_137.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 137.0.3296.93
+Short Edge version -> 137.0
+EdgeDriver version -> 137.0.3296.93
+Short EdgeDriver version -> 137.0
+Tagged selenium/node-edge:137.0.3296.93-edgedriver-137.0.3296.93-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:137.0.3296.93-edgedriver-137.0.3296.93-grid-4.35.0-20250808
+Tagged selenium/node-edge:137.0.3296.93-edgedriver-137.0.3296.93-20250808
+Tagged selenium/standalone-edge:137.0.3296.93-edgedriver-137.0.3296.93-20250808
+Tagged selenium/node-edge:137.0.3296.93-20250808
+Tagged selenium/standalone-edge:137.0.3296.93-20250808
+Tagged selenium/node-edge:137.0-edgedriver-137.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:137.0-edgedriver-137.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:137.0-edgedriver-137.0-20250808
+Tagged selenium/standalone-edge:137.0-edgedriver-137.0-20250808
+Tagged selenium/node-edge:137.0-20250808
+Tagged selenium/standalone-edge:137.0-20250808
+```

--- a/CHANGELOG/4.35.0/edge_138.md
+++ b/CHANGELOG/4.35.0/edge_138.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false edge true
+Tagging images for browser edge, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Edge version -> 138.0.3351.121
+Short Edge version -> 138.0
+EdgeDriver version -> 138.0.3351.121
+Short EdgeDriver version -> 138.0
+Tagged selenium/node-edge:138.0.3351.121-edgedriver-138.0.3351.121-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:138.0.3351.121-edgedriver-138.0.3351.121-grid-4.35.0-20250808
+Tagged selenium/node-edge:138.0.3351.121-edgedriver-138.0.3351.121-20250808
+Tagged selenium/standalone-edge:138.0.3351.121-edgedriver-138.0.3351.121-20250808
+Tagged selenium/node-edge:138.0.3351.121-20250808
+Tagged selenium/standalone-edge:138.0.3351.121-20250808
+Tagged selenium/node-edge:138.0-edgedriver-138.0-grid-4.35.0-20250808
+Tagged selenium/standalone-edge:138.0-edgedriver-138.0-grid-4.35.0-20250808
+Tagged selenium/node-edge:138.0-edgedriver-138.0-20250808
+Tagged selenium/standalone-edge:138.0-edgedriver-138.0-20250808
+Tagged selenium/node-edge:138.0-20250808
+Tagged selenium/standalone-edge:138.0-20250808
+```

--- a/tests/build-backward-compatible/browser-matrix.yml
+++ b/tests/build-backward-compatible/browser-matrix.yml
@@ -12,7 +12,7 @@ matrix:
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '139':
       EDGE_VERSION: microsoft-edge-stable=139.0.3405.86-1
-      CHROME_VERSION: google-chrome-stable=139.0.7258.66-1
+      CHROME_VERSION: google-chrome-stable=139.0.7258.127-1
       FIREFOX_VERSION: 139.0.4
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '138':


### PR DESCRIPTION
This PR contains the CHANGELOG for Node/Standalone edge with specific browser versions: [95, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138]