### PR TITLE
[ci] CHANGELOG for Node/Standalone firefox browser versions with Grid 4.35.0

### DIFF
--- a/CHANGELOG/4.35.0/firefox_100.md
+++ b/CHANGELOG/4.35.0/firefox_100.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 100.0.2
+Short Firefox version -> 100.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:100.0.2-20250808
+Tagged selenium/standalone-firefox:100.0.2-20250808
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:100.0-20250808
+Tagged selenium/standalone-firefox:100.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_101.md
+++ b/CHANGELOG/4.35.0/firefox_101.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 101.0.1
+Short Firefox version -> 101.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:101.0.1-20250808
+Tagged selenium/standalone-firefox:101.0.1-20250808
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:101.0-20250808
+Tagged selenium/standalone-firefox:101.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_102.md
+++ b/CHANGELOG/4.35.0/firefox_102.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 102.0.1
+Short Firefox version -> 102.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:102.0.1-20250808
+Tagged selenium/standalone-firefox:102.0.1-20250808
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:102.0-20250808
+Tagged selenium/standalone-firefox:102.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_103.md
+++ b/CHANGELOG/4.35.0/firefox_103.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 103.0.2
+Short Firefox version -> 103.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:103.0.2-20250808
+Tagged selenium/standalone-firefox:103.0.2-20250808
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:103.0-20250808
+Tagged selenium/standalone-firefox:103.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_104.md
+++ b/CHANGELOG/4.35.0/firefox_104.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 104.0.2
+Short Firefox version -> 104.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:104.0.2-20250808
+Tagged selenium/standalone-firefox:104.0.2-20250808
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:104.0-20250808
+Tagged selenium/standalone-firefox:104.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_105.md
+++ b/CHANGELOG/4.35.0/firefox_105.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 105.0.3
+Short Firefox version -> 105.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:105.0.3-20250808
+Tagged selenium/standalone-firefox:105.0.3-20250808
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:105.0-20250808
+Tagged selenium/standalone-firefox:105.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_106.md
+++ b/CHANGELOG/4.35.0/firefox_106.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 106.0.5
+Short Firefox version -> 106.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:106.0.5-20250808
+Tagged selenium/standalone-firefox:106.0.5-20250808
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:106.0-20250808
+Tagged selenium/standalone-firefox:106.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_107.md
+++ b/CHANGELOG/4.35.0/firefox_107.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 107.0.1
+Short Firefox version -> 107.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:107.0.1-20250808
+Tagged selenium/standalone-firefox:107.0.1-20250808
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:107.0-20250808
+Tagged selenium/standalone-firefox:107.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_108.md
+++ b/CHANGELOG/4.35.0/firefox_108.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 108.0.2
+Short Firefox version -> 108.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:108.0.2-20250808
+Tagged selenium/standalone-firefox:108.0.2-20250808
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:108.0-20250808
+Tagged selenium/standalone-firefox:108.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_109.md
+++ b/CHANGELOG/4.35.0/firefox_109.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 109.0.1
+Short Firefox version -> 109.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:109.0.1-20250808
+Tagged selenium/standalone-firefox:109.0.1-20250808
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:109.0-20250808
+Tagged selenium/standalone-firefox:109.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_110.md
+++ b/CHANGELOG/4.35.0/firefox_110.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 110.0.1
+Short Firefox version -> 110.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:110.0.1-20250808
+Tagged selenium/standalone-firefox:110.0.1-20250808
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:110.0-20250808
+Tagged selenium/standalone-firefox:110.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_111.md
+++ b/CHANGELOG/4.35.0/firefox_111.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 111.0.1
+Short Firefox version -> 111.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:111.0.1-20250808
+Tagged selenium/standalone-firefox:111.0.1-20250808
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:111.0-20250808
+Tagged selenium/standalone-firefox:111.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_112.md
+++ b/CHANGELOG/4.35.0/firefox_112.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 112.0.2
+Short Firefox version -> 112.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:112.0.2-20250808
+Tagged selenium/standalone-firefox:112.0.2-20250808
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:112.0-20250808
+Tagged selenium/standalone-firefox:112.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_113.md
+++ b/CHANGELOG/4.35.0/firefox_113.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 113.0.2
+Short Firefox version -> 113.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:113.0.2-20250808
+Tagged selenium/standalone-firefox:113.0.2-20250808
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:113.0-20250808
+Tagged selenium/standalone-firefox:113.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_114.md
+++ b/CHANGELOG/4.35.0/firefox_114.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 114.0.2
+Short Firefox version -> 114.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:114.0.2-20250808
+Tagged selenium/standalone-firefox:114.0.2-20250808
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:114.0-20250808
+Tagged selenium/standalone-firefox:114.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_115.md
+++ b/CHANGELOG/4.35.0/firefox_115.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 115.0.3
+Short Firefox version -> 115.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:115.0.3-20250808
+Tagged selenium/standalone-firefox:115.0.3-20250808
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:115.0-20250808
+Tagged selenium/standalone-firefox:115.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_116.md
+++ b/CHANGELOG/4.35.0/firefox_116.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 116.0.3
+Short Firefox version -> 116.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:116.0.3-20250808
+Tagged selenium/standalone-firefox:116.0.3-20250808
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:116.0-20250808
+Tagged selenium/standalone-firefox:116.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_117.md
+++ b/CHANGELOG/4.35.0/firefox_117.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 117.0.1
+Short Firefox version -> 117.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:117.0.1-20250808
+Tagged selenium/standalone-firefox:117.0.1-20250808
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:117.0-20250808
+Tagged selenium/standalone-firefox:117.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_118.md
+++ b/CHANGELOG/4.35.0/firefox_118.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 118.0.2
+Short Firefox version -> 118.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:118.0.2-20250808
+Tagged selenium/standalone-firefox:118.0.2-20250808
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:118.0-20250808
+Tagged selenium/standalone-firefox:118.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_119.md
+++ b/CHANGELOG/4.35.0/firefox_119.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 119.0.1
+Short Firefox version -> 119.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:119.0.1-20250808
+Tagged selenium/standalone-firefox:119.0.1-20250808
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:119.0-20250808
+Tagged selenium/standalone-firefox:119.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_120.md
+++ b/CHANGELOG/4.35.0/firefox_120.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 120.0.1
+Short Firefox version -> 120.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:120.0.1-20250808
+Tagged selenium/standalone-firefox:120.0.1-20250808
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:120.0-20250808
+Tagged selenium/standalone-firefox:120.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_121.md
+++ b/CHANGELOG/4.35.0/firefox_121.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 121.0.1
+Short Firefox version -> 121.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:121.0.1-20250808
+Tagged selenium/standalone-firefox:121.0.1-20250808
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:121.0-20250808
+Tagged selenium/standalone-firefox:121.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_122.md
+++ b/CHANGELOG/4.35.0/firefox_122.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 122.0.1
+Short Firefox version -> 122.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:122.0.1-20250808
+Tagged selenium/standalone-firefox:122.0.1-20250808
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:122.0-20250808
+Tagged selenium/standalone-firefox:122.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_123.md
+++ b/CHANGELOG/4.35.0/firefox_123.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 123.0.1
+Short Firefox version -> 123.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:123.0.1-20250808
+Tagged selenium/standalone-firefox:123.0.1-20250808
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:123.0-20250808
+Tagged selenium/standalone-firefox:123.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_124.md
+++ b/CHANGELOG/4.35.0/firefox_124.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 124.0.2
+Short Firefox version -> 124.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:124.0.2-20250808
+Tagged selenium/standalone-firefox:124.0.2-20250808
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:124.0-20250808
+Tagged selenium/standalone-firefox:124.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_125.md
+++ b/CHANGELOG/4.35.0/firefox_125.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 125.0.3
+Short Firefox version -> 125.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:125.0.3-20250808
+Tagged selenium/standalone-firefox:125.0.3-20250808
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:125.0-20250808
+Tagged selenium/standalone-firefox:125.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_126.md
+++ b/CHANGELOG/4.35.0/firefox_126.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 126.0.1
+Short Firefox version -> 126.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:126.0.1-20250808
+Tagged selenium/standalone-firefox:126.0.1-20250808
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:126.0-20250808
+Tagged selenium/standalone-firefox:126.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_127.md
+++ b/CHANGELOG/4.35.0/firefox_127.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 127.0.2
+Short Firefox version -> 127.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:127.0.2-20250808
+Tagged selenium/standalone-firefox:127.0.2-20250808
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:127.0-20250808
+Tagged selenium/standalone-firefox:127.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_128.md
+++ b/CHANGELOG/4.35.0/firefox_128.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 128.0.3
+Short Firefox version -> 128.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:128.0.3-20250808
+Tagged selenium/standalone-firefox:128.0.3-20250808
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:128.0-20250808
+Tagged selenium/standalone-firefox:128.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_129.md
+++ b/CHANGELOG/4.35.0/firefox_129.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 129.0.2
+Short Firefox version -> 129.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:129.0.2-20250808
+Tagged selenium/standalone-firefox:129.0.2-20250808
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:129.0-20250808
+Tagged selenium/standalone-firefox:129.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_130.md
+++ b/CHANGELOG/4.35.0/firefox_130.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 130.0.1
+Short Firefox version -> 130.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:130.0.1-20250808
+Tagged selenium/standalone-firefox:130.0.1-20250808
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:130.0-20250808
+Tagged selenium/standalone-firefox:130.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_131.md
+++ b/CHANGELOG/4.35.0/firefox_131.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 131.0.3
+Short Firefox version -> 131.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:131.0.3-20250808
+Tagged selenium/standalone-firefox:131.0.3-20250808
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:131.0-20250808
+Tagged selenium/standalone-firefox:131.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_132.md
+++ b/CHANGELOG/4.35.0/firefox_132.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 132.0.2
+Short Firefox version -> 132.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:132.0.2-20250808
+Tagged selenium/standalone-firefox:132.0.2-20250808
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:132.0-20250808
+Tagged selenium/standalone-firefox:132.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_133.md
+++ b/CHANGELOG/4.35.0/firefox_133.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 133.0.3
+Short Firefox version -> 133.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:133.0.3-20250808
+Tagged selenium/standalone-firefox:133.0.3-20250808
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:133.0-20250808
+Tagged selenium/standalone-firefox:133.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_134.md
+++ b/CHANGELOG/4.35.0/firefox_134.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 134.0.2
+Short Firefox version -> 134.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:134.0.2-20250808
+Tagged selenium/standalone-firefox:134.0.2-20250808
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:134.0-20250808
+Tagged selenium/standalone-firefox:134.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_135.md
+++ b/CHANGELOG/4.35.0/firefox_135.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 135.0.1
+Short Firefox version -> 135.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:135.0.1-20250808
+Tagged selenium/standalone-firefox:135.0.1-20250808
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:135.0-20250808
+Tagged selenium/standalone-firefox:135.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_136.md
+++ b/CHANGELOG/4.35.0/firefox_136.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 136.0.4
+Short Firefox version -> 136.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:136.0.4-20250808
+Tagged selenium/standalone-firefox:136.0.4-20250808
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:136.0-20250808
+Tagged selenium/standalone-firefox:136.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_137.md
+++ b/CHANGELOG/4.35.0/firefox_137.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 137.0.2
+Short Firefox version -> 137.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:137.0.2-20250808
+Tagged selenium/standalone-firefox:137.0.2-20250808
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:137.0-20250808
+Tagged selenium/standalone-firefox:137.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_138.md
+++ b/CHANGELOG/4.35.0/firefox_138.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 138.0.4
+Short Firefox version -> 138.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:138.0.4-20250808
+Tagged selenium/standalone-firefox:138.0.4-20250808
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:138.0-20250808
+Tagged selenium/standalone-firefox:138.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_139.md
+++ b/CHANGELOG/4.35.0/firefox_139.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 139.0.4
+Short Firefox version -> 139.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:139.0.4-20250808
+Tagged selenium/standalone-firefox:139.0.4-20250808
+Tagged selenium/node-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:139.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:139.0-20250808
+Tagged selenium/standalone-firefox:139.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_140.md
+++ b/CHANGELOG/4.35.0/firefox_140.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 140.0.4
+Short Firefox version -> 140.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:140.0.4-20250808
+Tagged selenium/standalone-firefox:140.0.4-20250808
+Tagged selenium/node-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:140.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:140.0-20250808
+Tagged selenium/standalone-firefox:140.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_98.md
+++ b/CHANGELOG/4.35.0/firefox_98.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 98.0.2
+Short Firefox version -> 98.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:98.0.2-20250808
+Tagged selenium/standalone-firefox:98.0.2-20250808
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:98.0-20250808
+Tagged selenium/standalone-firefox:98.0-20250808
+```

--- a/CHANGELOG/4.35.0/firefox_99.md
+++ b/CHANGELOG/4.35.0/firefox_99.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250808 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250808, namespace selenium
+Selenium Grid version -> 4.35.0-20250808
+Firefox version -> 99.0.1
+Short Firefox version -> 99.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250808
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-20250808
+Tagged selenium/node-firefox:99.0.1-20250808
+Tagged selenium/standalone-firefox:99.0.1-20250808
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250808
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-20250808
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-20250808
+Tagged selenium/node-firefox:99.0-20250808
+Tagged selenium/standalone-firefox:99.0-20250808
+```

--- a/tests/build-backward-compatible/browser-matrix.yml
+++ b/tests/build-backward-compatible/browser-matrix.yml
@@ -12,7 +12,7 @@ matrix:
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '139':
       EDGE_VERSION: microsoft-edge-stable=139.0.3405.86-1
-      CHROME_VERSION: google-chrome-stable=139.0.7258.66-1
+      CHROME_VERSION: google-chrome-stable=139.0.7258.127-1
       FIREFOX_VERSION: 139.0.4
       FIREFOX_PLATFORMS: linux/amd64,linux/arm64
     '138':


### PR DESCRIPTION
This PR contains the CHANGELOG for Node/Standalone firefox with specific browser versions: [98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140]