### PR TITLE
Docker: Support switch binary Chrome/Chromium in Node/Standalone all browsers image

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -7,10 +7,10 @@ LABEL org.opencontainers.image.source="https://github.com/${AUTHORS}/docker-sele
 ARG VERSION
 ARG RELEASE=selenium-${VERSION}
 # Default value should be aligned with upstream Selenium (https://github.com/SeleniumHQ/selenium/blob/trunk/MODULE.bazel)
-ARG OPENTELEMETRY_VERSION=1.51.0
-ARG GRPC_VERSION=1.73.0
-ARG NETTY_VERSION=4.1.123.Final
-ARG CS_VERSION=2.1.24
+ARG OPENTELEMETRY_VERSION=1.53.0
+ARG GRPC_VERSION=1.74.0
+ARG NETTY_VERSION=4.1.126.Final
+ARG CS_VERSION=2.1.25-M18
 ARG ENVSUBST_VERSION=1.4.5
 ARG CURL_VERSION=8.15.0
 
@@ -144,8 +144,8 @@ RUN --mount=type=secret,id=SEL_PASSWD \
         io.opentelemetry:opentelemetry-exporter-otlp:${OPENTELEMETRY_VERSION} \
         io.grpc:grpc-netty:${GRPC_VERSION} \
         io.netty:netty-codec-http:${NETTY_VERSION} \
-        io.netty:netty-handler:${NETTY_VERSION} \
-        io.netty:netty-common:${NETTY_VERSION} \
+        io.netty:netty-codec-http2:${NETTY_VERSION} \
+        io.netty:netty-codec:${NETTY_VERSION} \
         > /external_jars/.classpath.txt \
         && chmod 664 /external_jars/.classpath.txt ; \
      fi \

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -110,8 +110,8 @@
 | SE_NODE_MAX_SESSIONS | 1 |  |  |
 | SE_NODE_OVERRIDE_MAX_SESSIONS | false |  |  |
 | SE_OFFLINE | true | Selenium Manager offline mode, use the browser and driver pre-configured in the image |  |
-| SE_NODE_BROWSER_VERSION | stable | Overwrite the default browserVersion in Node stereotype |  |
-| SE_NODE_PLATFORM_NAME | Linux | Overwrite the default platformName in Node stereotype |  |
+| SE_NODE_BROWSER_VERSION | stable | Overwrite the default browserVersion in Node stereotype. By default, it is short version of current browser installed in Node. For example `139.0` |  |
+| SE_NODE_PLATFORM_NAME | Linux | Overwrite the default platformName in Node stereotype. By default, it is `Linux` |  |
 | SE_SUPERVISORD_LOG_LEVEL | info |  |  |
 | SE_SUPERVISORD_CHILD_LOG_DIR | /tmp |  |  |
 | SE_SUPERVISORD_LOG_FILE | /tmp/supervisord.log |  |  |
@@ -119,9 +119,9 @@
 | SE_SUPERVISORD_START_RETRIES | 5 |  |  |
 | SE_RECORD_AUDIO | false | Flag to enable recording the audio source (default is Pulse Audio input) |  |
 | SE_AUDIO_SOURCE | -f pulse -ac 2 -i default | FFmpeg arguments to record the audio source |  |
-| SE_BROWSER_BINARY_LOCATION |  |  |  |
+| SE_BROWSER_BINARY_LOCATION |  | Browser binary location set to Node driver configuration. This helpful in case you customize on top of official Docker image to install another browser in other path and still using GENERATE_CONFIG=true (where enforce detect-drivers = false and controlled by our config logic). By default in corresponding browser, default path would be `/usr/bin/google-chrome`, `/usr/bin/chromium`, `/usr/bin/firefox`, `/usr/bin/microsoft-edge`. Example usage: `SE_BROWSER_BINARY_LOCATION=/opt/google-chrome` |  |
 | SE_NODE_BROWSER_NAME |  |  |  |
-| SE_NODE_CONTAINER_NAME |  |  |  |
+| SE_NODE_CONTAINER_NAME |  | Set a unique name to identify the Node is running in which container (via session capabilities `se:containerName`). This is helpful when deploying Node in Kubernetes cluster, where is able to use metadata pod name set to this env variable. By default, it is the `$(hostname)` (a.k.a container id could be seen via `docker ps`) |  |
 | SE_NODE_HOST |  |  |  |
 | SE_NODE_RELAY_BROWSER_NAME |  |  |  |
 | SE_NODE_RELAY_MAX_SESSIONS |  |  |  |
@@ -131,7 +131,7 @@
 | SE_NODE_RELAY_STATUS_ENDPOINT |  |  |  |
 | SE_NODE_RELAY_URL |  |  |  |
 | SE_NODE_STEREOTYPE |  | Capabilities in JSON string to overwrite the default Node stereotype |  |
-| SE_NODE_STEREOTYPE_EXTRA |  | Extra capabilities in JSON string that wants to merge to the default Node stereotype |  |
+| SE_NODE_STEREOTYPE_EXTRA |  | Extra capabilities in JSON string that wants to merge to the default Node stereotype. This is helpful when you want to retain the default Node stereotype and append additional capabilities. Example usage `SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}` |  |
 | SE_SESSIONS_MAP_EXTERNAL_HOSTNAME |  |  |  |
 | SE_SESSIONS_MAP_EXTERNAL_IMPLEMENTATION |  |  |  |
 | SE_SESSIONS_MAP_EXTERNAL_JDBC_PASSWORD |  |  |  |

--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -144,16 +144,17 @@ if [ -d "/opt/selenium/browsers" ]; then
 			if [ -f "${browser_dir}version" ] && [ "${SE_NODE_BROWSER_VERSION,,}" = "stable" ]; then
 				SE_NODE_BROWSER_VERSION=$(short_version "$(cat "${browser_dir}version")")
 			fi
-			if [ -f "${browser_dir}binary_location" ] && [ -z "${SE_BROWSER_BINARY_LOCATION}" ]; then
-				SE_BROWSER_BINARY_LOCATION=$(cat "${browser_dir}binary_location")
+			if [ -f "${browser_dir}binary_location" ]; then
+				BINARY_LOCATION=$(cat "${browser_dir}binary_location")
+				BINARY_LOCATION=$(echo "$BINARY_LOCATION" | SE_BROWSER_BINARY_LOCATION=${SE_BROWSER_BINARY_LOCATION} envsubst)
 			fi
 			SE_NODE_CONTAINER_NAME="${SE_NODE_CONTAINER_NAME:-$(hostname)}"
 
 			# 'browserName' is mandatory for default stereotype
 			if [[ -z "${SE_NODE_STEREOTYPE}" ]] && [[ -n "${SE_NODE_BROWSER_NAME}" ]] && ([[ -z "${SE_NODE_RELAY_URL}" ]] || [[ "${SE_NODE_RELAY_ONLY}" = "false" ]]); then
 				SE_NODE_STEREOTYPE="{\"browserName\": \"${SE_NODE_BROWSER_NAME}\", \"browserVersion\": \"${SE_NODE_BROWSER_VERSION}\", \"platformName\": \"${SE_NODE_PLATFORM_NAME}\", \"se:containerName\": \"${SE_NODE_CONTAINER_NAME}\", \"container:hostname\": \"$(hostname)\"}"
-				if [[ -n "${SE_BROWSER_BINARY_LOCATION}" ]]; then
-					SE_NODE_STEREOTYPE="$(python3 /opt/bin/json_merge.py "${SE_NODE_STEREOTYPE}" "${SE_BROWSER_BINARY_LOCATION}")"
+				if [[ -n "${BINARY_LOCATION}" ]]; then
+					SE_NODE_STEREOTYPE="$(python3 /opt/bin/json_merge.py "${SE_NODE_STEREOTYPE}" "${BINARY_LOCATION}")"
 				fi
 			else
 				SE_NODE_STEREOTYPE="${SE_NODE_STEREOTYPE}"

--- a/NodeChrome/Dockerfile
+++ b/NodeChrome/Dockerfile
@@ -52,7 +52,7 @@ USER ${SEL_UID}
 RUN mkdir -p /opt/selenium/browsers/chrome \
     && echo "chrome" > /opt/selenium/browsers/chrome/name \
     && google-chrome --version | awk '{print $3}' > /opt/selenium/browsers/chrome/version \
-    && echo '{"goog:chromeOptions": {"binary": "/usr/bin/google-chrome"}}' > /opt/selenium/browsers/chrome/binary_location
+    && echo '{"goog:chromeOptions": {"binary": "${SE_BROWSER_BINARY_LOCATION:-/usr/bin/google-chrome}"}}' > /opt/selenium/browsers/chrome/binary_location
 
 ENV SE_OTEL_SERVICE_NAME="selenium-node-chrome" \
     SE_NODE_ENABLE_MANAGED_DOWNLOADS="true"

--- a/NodeChromium/Dockerfile
+++ b/NodeChromium/Dockerfile
@@ -46,7 +46,7 @@ USER ${SEL_UID}
 RUN mkdir -p /opt/selenium/browsers/chrome \
     && echo "chrome" > /opt/selenium/browsers/chrome/name \
     && chromium --version | awk '{print $2}' > /opt/selenium/browsers/chrome/version \
-    && echo '{"goog:chromeOptions": {"binary": "/usr/bin/chromium"}}' > /opt/selenium/browsers/chrome/binary_location
+    && echo '{"goog:chromeOptions": {"binary": "${SE_BROWSER_BINARY_LOCATION:-/usr/bin/chromium}"}}' > /opt/selenium/browsers/chrome/binary_location
 
 ENV SE_OTEL_SERVICE_NAME="selenium-node-chrome" \
     SE_NODE_ENABLE_MANAGED_DOWNLOADS="true"

--- a/NodeEdge/Dockerfile
+++ b/NodeEdge/Dockerfile
@@ -69,7 +69,7 @@ USER ${SEL_UID}
 RUN mkdir -p /opt/selenium/browsers/edge \
     && echo "MicrosoftEdge" > /opt/selenium/browsers/edge/name \
     && microsoft-edge --version | awk '{print $3}' > /opt/selenium/browsers/edge/version \
-    && echo '{"ms:edgeOptions": {"binary": "/usr/bin/microsoft-edge"}}' > /opt/selenium/browsers/edge/binary_location
+    && echo '{"ms:edgeOptions": {"binary": "${SE_BROWSER_BINARY_LOCATION:-/usr/bin/microsoft-edge}"}}' > /opt/selenium/browsers/edge/binary_location
 
 ENV SE_OTEL_SERVICE_NAME="selenium-node-edge" \
     SE_NODE_ENABLE_MANAGED_DOWNLOADS="true"

--- a/NodeFirefox/Dockerfile
+++ b/NodeFirefox/Dockerfile
@@ -88,7 +88,7 @@ USER ${SEL_UID}
 RUN mkdir -p /opt/selenium/browsers/firefox \
     && echo "firefox" > /opt/selenium/browsers/firefox/name \
     && firefox --version | awk '{print $3}' > /opt/selenium/browsers/firefox/version \
-    && echo '{"moz:firefoxOptions": {"binary": "/usr/bin/firefox"}}' > /opt/selenium/browsers/firefox/binary_location
+    && echo '{"moz:firefoxOptions": {"binary": "${SE_BROWSER_BINARY_LOCATION:-/usr/bin/firefox}"}}' > /opt/selenium/browsers/firefox/binary_location
 
 ENV SE_OTEL_SERVICE_NAME="selenium-node-firefox" \
     SE_NODE_ENABLE_MANAGED_DOWNLOADS="true"

--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ Talk to us at https://www.selenium.dev/support/
 * [Dev and Beta Channel Browser Images](#dev-and-beta-channel-browser-images)
   * [Dev and Beta Standalone Mode](#dev-and-beta-standalone-mode)
   * [Dev and Beta on the Grid](#dev-and-beta-on-the-grid)
+* [Single Node/Standalone Image With All Browsers](#single-nodestandalone-image-with-all-browsers)
 * [Environment Variables](#environment-variables)
 * [Execution modes](#execution-modes)
   * [Standalone](#standalone)
@@ -159,16 +160,6 @@ The following browsers are available in multi-arch images:
 |    x86_64 (aka amd64)     |   ✅    |    ✅     |    ✅    |  ✅   |
 | aarch64 (aka arm64/armv8) |   ❌    |    ✅     |    ✅    |  ❌   |
 | armhf (aka arm32/armv7l)  |   ❌    |    ❌     |    ❌    |  ❌   |
-
-
-Accordingly, browsers are available in images `selenium/node-all-browsers` and `selenium/standalone-all-browsers` would be different per architecture.
-
-| Browser / Arch | x86_64 (aka amd64) | aarch64 (aka arm64/armv8) |
-|----------------|--------------------|---------------------------|
-| Chrome         | ✅                  | ❌                         |
-| Edge           | ✅                  | ❌                         |
-| Firefox        | ✅                  | ✅                         |
-| Chromium       | ❌                  | ✅                         |
 
 Note:
 
@@ -373,6 +364,26 @@ services:
 ```
 
 For more information on the Dev and Beta channel container images, see the blog post on [Dev and Beta Channel Browsers via Docker Selenium](https://www.selenium.dev/blog/2022/dev-and-beta-channel-browsers-via-docker-selenium/).
+
+## Single Node/Standalone Image With All Browsers
+
+From image tag `4.35.0` onwards, a single Node/Standalone image is available with all browsers are pre-installed. Those images are `selenium/standalone-all-browsers` (standalone all in one), `selenium/node-all-browsers` (for Hub-Node mode).
+
+These two images are suitable for users:
+- Prefer a single container with "all-in-one" includes Selenium Grid and popular browsers.
+- Don't care about the image size, prefer the convenience.
+- Lightweight workload, able to figure out for yourself the resource consumption.
+
+According to multi-arch support, browsers are available in images `selenium/node-all-browsers` and `selenium/standalone-all-browsers` would be different per architecture.
+
+| Browser / Arch | x86_64 (aka amd64) | aarch64 (aka arm64/armv8) |
+|----------------|--------------------|---------------------------|
+| Chrome         | ✅                  | ❌                         |
+| Edge           | ✅                  | ❌                         |
+| Firefox        | ✅                  | ✅                         |
+| Chromium       | ✅                  | ✅                         |
+
+Both Chrome and Chromium browser binary are available in image arch `linux/amd64`. However, Chrome browser binary is activated by default. In case you want to switch to Chromium browser binary, you can set environment variable `SE_BROWSER_BINARY_LOCATION_CHROME=/usr/bin/chromium`.
 
 ## Environment Variables
 

--- a/scripts/generate_list_env_vars/description.yaml
+++ b/scripts/generate_list_env_vars/description.yaml
@@ -339,10 +339,12 @@
     in the image
   cli: ''
 - name: SE_NODE_BROWSER_VERSION
-  description: Overwrite the default browserVersion in Node stereotype
+  description: Overwrite the default browserVersion in Node stereotype. By default,
+    it is short version of current browser installed in Node. For example `139.0`
   cli: ''
 - name: SE_NODE_PLATFORM_NAME
-  description: Overwrite the default platformName in Node stereotype
+  description: Overwrite the default platformName in Node stereotype. By default,
+    it is `Linux`
   cli: ''
 - name: SE_SUPERVISORD_LOG_LEVEL
   description: ''
@@ -366,13 +368,22 @@
   description: FFmpeg arguments to record the audio source
   cli: ''
 - name: SE_BROWSER_BINARY_LOCATION
-  description: ''
+  description: 'Browser binary location set to Node driver configuration. This helpful
+    in case you customize on top of official Docker image to install another browser
+    in other path and still using GENERATE_CONFIG=true (where enforce detect-drivers
+    = false and controlled by our config logic). By default in corresponding browser,
+    default path would be `/usr/bin/google-chrome`, `/usr/bin/chromium`, `/usr/bin/firefox`,
+    `/usr/bin/microsoft-edge`. Example usage: `SE_BROWSER_BINARY_LOCATION=/opt/google-chrome`'
   cli: ''
 - name: SE_NODE_BROWSER_NAME
   description: ''
   cli: ''
 - name: SE_NODE_CONTAINER_NAME
-  description: ''
+  description: Set a unique name to identify the Node is running in which container
+    (via session capabilities `se:containerName`). This is helpful when deploying
+    Node in Kubernetes cluster, where is able to use metadata pod name set to this
+    env variable. By default, it is the `$(hostname)` (a.k.a container id could be
+    seen via `docker ps`)
   cli: ''
 - name: SE_NODE_HOST
   description: ''
@@ -403,7 +414,8 @@
   cli: ''
 - name: SE_NODE_STEREOTYPE_EXTRA
   description: Extra capabilities in JSON string that wants to merge to the default
-    Node stereotype
+    Node stereotype. This is helpful when you want to retain the default Node stereotype
+    and append additional capabilities. Example usage `SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}`
   cli: ''
 - name: SE_SESSIONS_MAP_EXTERNAL_HOSTNAME
   description: ''


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add support for switching browser binaries via environment variable

- Improve documentation for environment variables with examples

- Enhance all-browsers image configuration flexibility

- Update README with single image architecture details


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Environment Variable"] --> B["SE_BROWSER_BINARY_LOCATION"]
  B --> C["Browser Binary Path"]
  C --> D["Chrome/Chromium Switch"]
  D --> E["Node Configuration"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ENV_VARIABLES.md</strong><dd><code>Enhanced environment variable documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ENV_VARIABLES.md

<ul><li>Enhanced descriptions for <code>SE_BROWSER_BINARY_LOCATION</code> with usage <br>examples<br> <li> Added detailed explanations for <code>SE_NODE_CONTAINER_NAME</code> and stereotype <br>variables<br> <li> Improved documentation clarity with default values and use cases</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-575787a64e27e14d8c3ef34ad655dde25f38457d2c82335a3cb9f2dd44024035">+5/-5</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>All-browsers image documentation and architecture details</code></dd></summary>
<hr>

README.md

<ul><li>Added new section for single Node/Standalone image with all browsers<br> <li> Moved browser architecture compatibility table to appropriate section<br> <li> Added Chrome/Chromium switching instructions for amd64 architecture</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+21/-10</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>description.yaml</strong><dd><code>Environment variable descriptions enhancement</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_list_env_vars/description.yaml

<ul><li>Enhanced descriptions for browser binary location and container name <br>variables<br> <li> Added detailed usage examples and default value explanations<br> <li> Improved stereotype extra capabilities documentation</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-b3cb49ac37600014419abf1369cf4b5a461d55671b0c6b815b18d7d5030c2352">+17/-5</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Dynamic browser binary path configuration</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/generate_config

<ul><li>Modified binary location handling to support environment variable <br>substitution<br> <li> Changed from direct assignment to using <code>envsubst</code> for dynamic path <br>resolution<br> <li> Updated variable naming from <code>SE_BROWSER_BINARY_LOCATION</code> to <br><code>BINARY_LOCATION</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+5/-4</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Chrome binary path environment variable support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeChrome/Dockerfile

<ul><li>Updated binary location template to use <code>SE_BROWSER_BINARY_LOCATION</code> <br>environment variable<br> <li> Added fallback to default Chrome path <code>/usr/bin/google-chrome</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-472dbd85c9d65177f8d5dfbfdd9c8ee2ec7f54201808b8cd118c5ef399246cd2">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Chromium binary path environment variable support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeChromium/Dockerfile

<ul><li>Updated binary location template to use <code>SE_BROWSER_BINARY_LOCATION</code> <br>environment variable<br> <li> Added fallback to default Chromium path <code>/usr/bin/chromium</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-ddc70cdbe415111d77d5eadd39b842ca541bd0f0a9ecb04fceb7597f2f09d598">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Edge binary path environment variable support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeEdge/Dockerfile

<ul><li>Updated binary location template to use <code>SE_BROWSER_BINARY_LOCATION</code> <br>environment variable<br> <li> Added fallback to default Edge path <code>/usr/bin/microsoft-edge</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-893377e247a3d9c8b0af528510d3c1b84c3e6818bbefa61438f8938b55043547">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Firefox binary path environment variable support</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeFirefox/Dockerfile

<ul><li>Updated binary location template to use <code>SE_BROWSER_BINARY_LOCATION</code> <br>environment variable<br> <li> Added fallback to default Firefox path <code>/usr/bin/firefox</code></ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2946/files#diff-c2bc9e0f9895cda9d9c529e4247b2cb8fd1e3dbc64feb8f685a37ffed83f15ac">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

