### PR TITLE
#2957 Fixed tolerations indent for keda patched jobs

### DIFF
--- a/charts/selenium-grid/templates/patch-keda/delete-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/delete-keda-objects-job.yaml
@@ -37,7 +37,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.autoscaling.patchObjectFinalizers.tolerations  }}
-          tolerations : {{ toYaml . | nindent 8 }}
+          tolerations : {{ toYaml . | nindent 12 }}
         {{- end }}
       volumes:
         - name: cleanup-script

--- a/charts/selenium-grid/templates/patch-keda/delete-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/delete-keda-objects-job.yaml
@@ -37,7 +37,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.autoscaling.patchObjectFinalizers.tolerations  }}
-          tolerations : {{ toYaml . | nindent 12 }}
+          tolerations: {{ toYaml . | nindent 12 }}
         {{- end }}
       volumes:
         - name: cleanup-script

--- a/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
@@ -37,7 +37,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.autoscaling.patchObjectFinalizers.tolerations  }}
-          tolerations : {{ toYaml . | nindent 8 }}
+          tolerations : {{ toYaml . | nindent 12 }}
         {{- end }}
       volumes:
         - name: cleanup-script

--- a/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
+++ b/charts/selenium-grid/templates/patch-keda/patch-keda-objects-job.yaml
@@ -37,7 +37,7 @@ spec:
           resources: {{ toYaml . | nindent 12 }}
         {{- end }}
         {{- with $.Values.autoscaling.patchObjectFinalizers.tolerations  }}
-          tolerations : {{ toYaml . | nindent 12 }}
+          tolerations: {{ toYaml . | nindent 12 }}
         {{- end }}
       volumes:
         - name: cleanup-script


### PR DESCRIPTION
### Description
Upgrade "selenium-grid" failed: post-upgrade hooks failed: warning: Hook post-upgrade selenium-grid/templates/patch-keda/delete-keda-objects-job.yaml

Tolerations indent is wrong and causing invalid job spec and upgrade failure


### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [x] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
