### PR TITLE
[ci] CHANGELOG for Node/Standalone firefox browser versions with Grid 4.35.0

### DIFF
--- a/CHANGELOG/4.35.0/firefox_100.md
+++ b/CHANGELOG/4.35.0/firefox_100.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 100.0.2
 Short Firefox version -> 100.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:100.0.2-20250828
-Tagged selenium/standalone-firefox:100.0.2-20250828
-Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:100.0-20250828
-Tagged selenium/standalone-firefox:100.0-20250828
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:100.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:100.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:100.0.2-20250909
+Tagged selenium/standalone-firefox:100.0.2-20250909
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:100.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:100.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:100.0-20250909
+Tagged selenium/standalone-firefox:100.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_101.md
+++ b/CHANGELOG/4.35.0/firefox_101.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 101.0.1
 Short Firefox version -> 101.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:101.0.1-20250828
-Tagged selenium/standalone-firefox:101.0.1-20250828
-Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:101.0-20250828
-Tagged selenium/standalone-firefox:101.0-20250828
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:101.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:101.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:101.0.1-20250909
+Tagged selenium/standalone-firefox:101.0.1-20250909
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:101.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:101.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:101.0-20250909
+Tagged selenium/standalone-firefox:101.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_102.md
+++ b/CHANGELOG/4.35.0/firefox_102.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 102.0.1
 Short Firefox version -> 102.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:102.0.1-20250828
-Tagged selenium/standalone-firefox:102.0.1-20250828
-Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:102.0-20250828
-Tagged selenium/standalone-firefox:102.0-20250828
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:102.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:102.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:102.0.1-20250909
+Tagged selenium/standalone-firefox:102.0.1-20250909
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:102.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:102.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:102.0-20250909
+Tagged selenium/standalone-firefox:102.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_103.md
+++ b/CHANGELOG/4.35.0/firefox_103.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 103.0.2
 Short Firefox version -> 103.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:103.0.2-20250828
-Tagged selenium/standalone-firefox:103.0.2-20250828
-Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:103.0-20250828
-Tagged selenium/standalone-firefox:103.0-20250828
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:103.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:103.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:103.0.2-20250909
+Tagged selenium/standalone-firefox:103.0.2-20250909
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:103.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:103.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:103.0-20250909
+Tagged selenium/standalone-firefox:103.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_104.md
+++ b/CHANGELOG/4.35.0/firefox_104.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 104.0.2
 Short Firefox version -> 104.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:104.0.2-20250828
-Tagged selenium/standalone-firefox:104.0.2-20250828
-Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:104.0-20250828
-Tagged selenium/standalone-firefox:104.0-20250828
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:104.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:104.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:104.0.2-20250909
+Tagged selenium/standalone-firefox:104.0.2-20250909
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:104.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:104.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:104.0-20250909
+Tagged selenium/standalone-firefox:104.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_105.md
+++ b/CHANGELOG/4.35.0/firefox_105.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 105.0.3
 Short Firefox version -> 105.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:105.0.3-20250828
-Tagged selenium/standalone-firefox:105.0.3-20250828
-Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:105.0-20250828
-Tagged selenium/standalone-firefox:105.0-20250828
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:105.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:105.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:105.0.3-20250909
+Tagged selenium/standalone-firefox:105.0.3-20250909
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:105.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:105.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:105.0-20250909
+Tagged selenium/standalone-firefox:105.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_106.md
+++ b/CHANGELOG/4.35.0/firefox_106.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 106.0.5
 Short Firefox version -> 106.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:106.0.5-20250828
-Tagged selenium/standalone-firefox:106.0.5-20250828
-Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:106.0-20250828
-Tagged selenium/standalone-firefox:106.0-20250828
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:106.0.5-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:106.0.5-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:106.0.5-20250909
+Tagged selenium/standalone-firefox:106.0.5-20250909
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:106.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:106.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:106.0-20250909
+Tagged selenium/standalone-firefox:106.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_107.md
+++ b/CHANGELOG/4.35.0/firefox_107.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 107.0.1
 Short Firefox version -> 107.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:107.0.1-20250828
-Tagged selenium/standalone-firefox:107.0.1-20250828
-Tagged selenium/node-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:107.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:107.0-20250828
-Tagged selenium/standalone-firefox:107.0-20250828
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:107.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:107.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:107.0.1-20250909
+Tagged selenium/standalone-firefox:107.0.1-20250909
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:107.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:107.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:107.0-20250909
+Tagged selenium/standalone-firefox:107.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_108.md
+++ b/CHANGELOG/4.35.0/firefox_108.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 108.0.2
 Short Firefox version -> 108.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:108.0.2-20250828
-Tagged selenium/standalone-firefox:108.0.2-20250828
-Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:108.0-20250828
-Tagged selenium/standalone-firefox:108.0-20250828
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:108.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:108.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:108.0.2-20250909
+Tagged selenium/standalone-firefox:108.0.2-20250909
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:108.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:108.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:108.0-20250909
+Tagged selenium/standalone-firefox:108.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_109.md
+++ b/CHANGELOG/4.35.0/firefox_109.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 109.0.1
 Short Firefox version -> 109.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:109.0.1-20250828
-Tagged selenium/standalone-firefox:109.0.1-20250828
-Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:109.0-20250828
-Tagged selenium/standalone-firefox:109.0-20250828
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:109.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:109.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:109.0.1-20250909
+Tagged selenium/standalone-firefox:109.0.1-20250909
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:109.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:109.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:109.0-20250909
+Tagged selenium/standalone-firefox:109.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_110.md
+++ b/CHANGELOG/4.35.0/firefox_110.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 110.0.1
 Short Firefox version -> 110.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:110.0.1-20250828
-Tagged selenium/standalone-firefox:110.0.1-20250828
-Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:110.0-20250828
-Tagged selenium/standalone-firefox:110.0-20250828
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:110.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:110.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:110.0.1-20250909
+Tagged selenium/standalone-firefox:110.0.1-20250909
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:110.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:110.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:110.0-20250909
+Tagged selenium/standalone-firefox:110.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_111.md
+++ b/CHANGELOG/4.35.0/firefox_111.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 111.0.1
 Short Firefox version -> 111.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:111.0.1-20250828
-Tagged selenium/standalone-firefox:111.0.1-20250828
-Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:111.0-20250828
-Tagged selenium/standalone-firefox:111.0-20250828
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:111.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:111.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:111.0.1-20250909
+Tagged selenium/standalone-firefox:111.0.1-20250909
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:111.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:111.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:111.0-20250909
+Tagged selenium/standalone-firefox:111.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_112.md
+++ b/CHANGELOG/4.35.0/firefox_112.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 112.0.2
 Short Firefox version -> 112.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:112.0.2-20250828
-Tagged selenium/standalone-firefox:112.0.2-20250828
-Tagged selenium/node-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:112.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:112.0-20250828
-Tagged selenium/standalone-firefox:112.0-20250828
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:112.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:112.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:112.0.2-20250909
+Tagged selenium/standalone-firefox:112.0.2-20250909
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:112.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:112.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:112.0-20250909
+Tagged selenium/standalone-firefox:112.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_113.md
+++ b/CHANGELOG/4.35.0/firefox_113.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 113.0.2
 Short Firefox version -> 113.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:113.0.2-20250828
-Tagged selenium/standalone-firefox:113.0.2-20250828
-Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:113.0-20250828
-Tagged selenium/standalone-firefox:113.0-20250828
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:113.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:113.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:113.0.2-20250909
+Tagged selenium/standalone-firefox:113.0.2-20250909
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:113.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:113.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:113.0-20250909
+Tagged selenium/standalone-firefox:113.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_114.md
+++ b/CHANGELOG/4.35.0/firefox_114.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 114.0.2
 Short Firefox version -> 114.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:114.0.2-20250828
-Tagged selenium/standalone-firefox:114.0.2-20250828
-Tagged selenium/node-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:114.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:114.0-20250828
-Tagged selenium/standalone-firefox:114.0-20250828
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:114.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:114.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:114.0.2-20250909
+Tagged selenium/standalone-firefox:114.0.2-20250909
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:114.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:114.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:114.0-20250909
+Tagged selenium/standalone-firefox:114.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_115.md
+++ b/CHANGELOG/4.35.0/firefox_115.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 115.0.3
 Short Firefox version -> 115.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:115.0.3-20250828
-Tagged selenium/standalone-firefox:115.0.3-20250828
-Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:115.0-20250828
-Tagged selenium/standalone-firefox:115.0-20250828
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:115.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:115.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:115.0.3-20250909
+Tagged selenium/standalone-firefox:115.0.3-20250909
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:115.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:115.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:115.0-20250909
+Tagged selenium/standalone-firefox:115.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_116.md
+++ b/CHANGELOG/4.35.0/firefox_116.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 116.0.3
 Short Firefox version -> 116.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:116.0.3-20250828
-Tagged selenium/standalone-firefox:116.0.3-20250828
-Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:116.0-20250828
-Tagged selenium/standalone-firefox:116.0-20250828
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:116.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:116.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:116.0.3-20250909
+Tagged selenium/standalone-firefox:116.0.3-20250909
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:116.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:116.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:116.0-20250909
+Tagged selenium/standalone-firefox:116.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_117.md
+++ b/CHANGELOG/4.35.0/firefox_117.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 117.0.1
 Short Firefox version -> 117.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:117.0.1-20250828
-Tagged selenium/standalone-firefox:117.0.1-20250828
-Tagged selenium/node-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:117.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:117.0-20250828
-Tagged selenium/standalone-firefox:117.0-20250828
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:117.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:117.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:117.0.1-20250909
+Tagged selenium/standalone-firefox:117.0.1-20250909
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:117.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:117.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:117.0-20250909
+Tagged selenium/standalone-firefox:117.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_118.md
+++ b/CHANGELOG/4.35.0/firefox_118.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 118.0.2
 Short Firefox version -> 118.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:118.0.2-20250828
-Tagged selenium/standalone-firefox:118.0.2-20250828
-Tagged selenium/node-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:118.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:118.0-20250828
-Tagged selenium/standalone-firefox:118.0-20250828
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:118.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:118.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:118.0.2-20250909
+Tagged selenium/standalone-firefox:118.0.2-20250909
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:118.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:118.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:118.0-20250909
+Tagged selenium/standalone-firefox:118.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_119.md
+++ b/CHANGELOG/4.35.0/firefox_119.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 119.0.1
 Short Firefox version -> 119.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:119.0.1-20250828
-Tagged selenium/standalone-firefox:119.0.1-20250828
-Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:119.0-20250828
-Tagged selenium/standalone-firefox:119.0-20250828
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:119.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:119.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:119.0.1-20250909
+Tagged selenium/standalone-firefox:119.0.1-20250909
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:119.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:119.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:119.0-20250909
+Tagged selenium/standalone-firefox:119.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_120.md
+++ b/CHANGELOG/4.35.0/firefox_120.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 120.0.1
 Short Firefox version -> 120.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:120.0.1-20250828
-Tagged selenium/standalone-firefox:120.0.1-20250828
-Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:120.0-20250828
-Tagged selenium/standalone-firefox:120.0-20250828
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:120.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:120.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:120.0.1-20250909
+Tagged selenium/standalone-firefox:120.0.1-20250909
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:120.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:120.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:120.0-20250909
+Tagged selenium/standalone-firefox:120.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_121.md
+++ b/CHANGELOG/4.35.0/firefox_121.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 121.0.1
 Short Firefox version -> 121.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:121.0.1-20250828
-Tagged selenium/standalone-firefox:121.0.1-20250828
-Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:121.0-20250828
-Tagged selenium/standalone-firefox:121.0-20250828
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:121.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:121.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:121.0.1-20250909
+Tagged selenium/standalone-firefox:121.0.1-20250909
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:121.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:121.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:121.0-20250909
+Tagged selenium/standalone-firefox:121.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_122.md
+++ b/CHANGELOG/4.35.0/firefox_122.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 122.0.1
 Short Firefox version -> 122.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:122.0.1-20250828
-Tagged selenium/standalone-firefox:122.0.1-20250828
-Tagged selenium/node-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:122.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:122.0-20250828
-Tagged selenium/standalone-firefox:122.0-20250828
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:122.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:122.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:122.0.1-20250909
+Tagged selenium/standalone-firefox:122.0.1-20250909
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:122.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:122.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:122.0-20250909
+Tagged selenium/standalone-firefox:122.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_123.md
+++ b/CHANGELOG/4.35.0/firefox_123.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 123.0.1
 Short Firefox version -> 123.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:123.0.1-20250828
-Tagged selenium/standalone-firefox:123.0.1-20250828
-Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:123.0-20250828
-Tagged selenium/standalone-firefox:123.0-20250828
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:123.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:123.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:123.0.1-20250909
+Tagged selenium/standalone-firefox:123.0.1-20250909
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:123.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:123.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:123.0-20250909
+Tagged selenium/standalone-firefox:123.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_124.md
+++ b/CHANGELOG/4.35.0/firefox_124.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 124.0.2
 Short Firefox version -> 124.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:124.0.2-20250828
-Tagged selenium/standalone-firefox:124.0.2-20250828
-Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:124.0-20250828
-Tagged selenium/standalone-firefox:124.0-20250828
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:124.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:124.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:124.0.2-20250909
+Tagged selenium/standalone-firefox:124.0.2-20250909
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:124.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:124.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:124.0-20250909
+Tagged selenium/standalone-firefox:124.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_125.md
+++ b/CHANGELOG/4.35.0/firefox_125.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 125.0.3
 Short Firefox version -> 125.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:125.0.3-20250828
-Tagged selenium/standalone-firefox:125.0.3-20250828
-Tagged selenium/node-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:125.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:125.0-20250828
-Tagged selenium/standalone-firefox:125.0-20250828
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:125.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:125.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:125.0.3-20250909
+Tagged selenium/standalone-firefox:125.0.3-20250909
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:125.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:125.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:125.0-20250909
+Tagged selenium/standalone-firefox:125.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_126.md
+++ b/CHANGELOG/4.35.0/firefox_126.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 126.0.1
 Short Firefox version -> 126.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:126.0.1-20250828
-Tagged selenium/standalone-firefox:126.0.1-20250828
-Tagged selenium/node-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:126.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:126.0-20250828
-Tagged selenium/standalone-firefox:126.0-20250828
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:126.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:126.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:126.0.1-20250909
+Tagged selenium/standalone-firefox:126.0.1-20250909
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:126.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:126.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:126.0-20250909
+Tagged selenium/standalone-firefox:126.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_127.md
+++ b/CHANGELOG/4.35.0/firefox_127.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 127.0.2
 Short Firefox version -> 127.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:127.0.2-20250828
-Tagged selenium/standalone-firefox:127.0.2-20250828
-Tagged selenium/node-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:127.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:127.0-20250828
-Tagged selenium/standalone-firefox:127.0-20250828
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:127.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:127.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:127.0.2-20250909
+Tagged selenium/standalone-firefox:127.0.2-20250909
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:127.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:127.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:127.0-20250909
+Tagged selenium/standalone-firefox:127.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_128.md
+++ b/CHANGELOG/4.35.0/firefox_128.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 128.0.3
 Short Firefox version -> 128.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:128.0.3-20250828
-Tagged selenium/standalone-firefox:128.0.3-20250828
-Tagged selenium/node-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:128.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:128.0-20250828
-Tagged selenium/standalone-firefox:128.0-20250828
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:128.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:128.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:128.0.3-20250909
+Tagged selenium/standalone-firefox:128.0.3-20250909
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:128.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:128.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:128.0-20250909
+Tagged selenium/standalone-firefox:128.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_129.md
+++ b/CHANGELOG/4.35.0/firefox_129.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 129.0.2
 Short Firefox version -> 129.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:129.0.2-20250828
-Tagged selenium/standalone-firefox:129.0.2-20250828
-Tagged selenium/node-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:129.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:129.0-20250828
-Tagged selenium/standalone-firefox:129.0-20250828
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:129.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:129.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:129.0.2-20250909
+Tagged selenium/standalone-firefox:129.0.2-20250909
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:129.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:129.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:129.0-20250909
+Tagged selenium/standalone-firefox:129.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_130.md
+++ b/CHANGELOG/4.35.0/firefox_130.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 130.0.1
 Short Firefox version -> 130.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:130.0.1-20250828
-Tagged selenium/standalone-firefox:130.0.1-20250828
-Tagged selenium/node-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:130.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:130.0-20250828
-Tagged selenium/standalone-firefox:130.0-20250828
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:130.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:130.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:130.0.1-20250909
+Tagged selenium/standalone-firefox:130.0.1-20250909
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:130.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:130.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:130.0-20250909
+Tagged selenium/standalone-firefox:130.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_131.md
+++ b/CHANGELOG/4.35.0/firefox_131.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 131.0.3
 Short Firefox version -> 131.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:131.0.3-20250828
-Tagged selenium/standalone-firefox:131.0.3-20250828
-Tagged selenium/node-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:131.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:131.0-20250828
-Tagged selenium/standalone-firefox:131.0-20250828
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:131.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:131.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:131.0.3-20250909
+Tagged selenium/standalone-firefox:131.0.3-20250909
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:131.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:131.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:131.0-20250909
+Tagged selenium/standalone-firefox:131.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_132.md
+++ b/CHANGELOG/4.35.0/firefox_132.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 132.0.2
 Short Firefox version -> 132.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:132.0.2-20250828
-Tagged selenium/standalone-firefox:132.0.2-20250828
-Tagged selenium/node-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:132.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:132.0-20250828
-Tagged selenium/standalone-firefox:132.0-20250828
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:132.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:132.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:132.0.2-20250909
+Tagged selenium/standalone-firefox:132.0.2-20250909
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:132.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:132.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:132.0-20250909
+Tagged selenium/standalone-firefox:132.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_133.md
+++ b/CHANGELOG/4.35.0/firefox_133.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 133.0.3
 Short Firefox version -> 133.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:133.0.3-20250828
-Tagged selenium/standalone-firefox:133.0.3-20250828
-Tagged selenium/node-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:133.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:133.0-20250828
-Tagged selenium/standalone-firefox:133.0-20250828
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:133.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:133.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:133.0.3-20250909
+Tagged selenium/standalone-firefox:133.0.3-20250909
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:133.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:133.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:133.0-20250909
+Tagged selenium/standalone-firefox:133.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_134.md
+++ b/CHANGELOG/4.35.0/firefox_134.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 134.0.2
 Short Firefox version -> 134.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:134.0.2-20250828
-Tagged selenium/standalone-firefox:134.0.2-20250828
-Tagged selenium/node-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:134.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:134.0-20250828
-Tagged selenium/standalone-firefox:134.0-20250828
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:134.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:134.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:134.0.2-20250909
+Tagged selenium/standalone-firefox:134.0.2-20250909
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:134.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:134.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:134.0-20250909
+Tagged selenium/standalone-firefox:134.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_135.md
+++ b/CHANGELOG/4.35.0/firefox_135.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 135.0.1
 Short Firefox version -> 135.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:135.0.1-20250828
-Tagged selenium/standalone-firefox:135.0.1-20250828
-Tagged selenium/node-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:135.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:135.0-20250828
-Tagged selenium/standalone-firefox:135.0-20250828
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:135.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:135.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:135.0.1-20250909
+Tagged selenium/standalone-firefox:135.0.1-20250909
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:135.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:135.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:135.0-20250909
+Tagged selenium/standalone-firefox:135.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_136.md
+++ b/CHANGELOG/4.35.0/firefox_136.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 136.0.4
 Short Firefox version -> 136.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:136.0.4-20250828
-Tagged selenium/standalone-firefox:136.0.4-20250828
-Tagged selenium/node-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:136.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:136.0-20250828
-Tagged selenium/standalone-firefox:136.0-20250828
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:136.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:136.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:136.0.4-20250909
+Tagged selenium/standalone-firefox:136.0.4-20250909
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:136.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:136.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:136.0-20250909
+Tagged selenium/standalone-firefox:136.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_137.md
+++ b/CHANGELOG/4.35.0/firefox_137.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 137.0.2
 Short Firefox version -> 137.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:137.0.2-20250828
-Tagged selenium/standalone-firefox:137.0.2-20250828
-Tagged selenium/node-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:137.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:137.0-20250828
-Tagged selenium/standalone-firefox:137.0-20250828
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:137.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:137.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:137.0.2-20250909
+Tagged selenium/standalone-firefox:137.0.2-20250909
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:137.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:137.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:137.0-20250909
+Tagged selenium/standalone-firefox:137.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_138.md
+++ b/CHANGELOG/4.35.0/firefox_138.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 138.0.4
 Short Firefox version -> 138.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:138.0.4-20250828
-Tagged selenium/standalone-firefox:138.0.4-20250828
-Tagged selenium/node-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:138.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:138.0-20250828
-Tagged selenium/standalone-firefox:138.0-20250828
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:138.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:138.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:138.0.4-20250909
+Tagged selenium/standalone-firefox:138.0.4-20250909
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:138.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:138.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:138.0-20250909
+Tagged selenium/standalone-firefox:138.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_139.md
+++ b/CHANGELOG/4.35.0/firefox_139.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 139.0.4
 Short Firefox version -> 139.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:139.0.4-20250828
-Tagged selenium/standalone-firefox:139.0.4-20250828
-Tagged selenium/node-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:139.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:139.0-20250828
-Tagged selenium/standalone-firefox:139.0-20250828
+Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:139.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:139.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:139.0.4-20250909
+Tagged selenium/standalone-firefox:139.0.4-20250909
+Tagged selenium/node-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:139.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:139.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:139.0-20250909
+Tagged selenium/standalone-firefox:139.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_140.md
+++ b/CHANGELOG/4.35.0/firefox_140.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 140.0.4
 Short Firefox version -> 140.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:140.0.4-20250828
-Tagged selenium/standalone-firefox:140.0.4-20250828
-Tagged selenium/node-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:140.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:140.0-20250828
-Tagged selenium/standalone-firefox:140.0-20250828
+Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:140.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:140.0.4-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:140.0.4-20250909
+Tagged selenium/standalone-firefox:140.0.4-20250909
+Tagged selenium/node-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:140.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:140.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:140.0-20250909
+Tagged selenium/standalone-firefox:140.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_141.md
+++ b/CHANGELOG/4.35.0/firefox_141.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 141.0.3
 Short Firefox version -> 141.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:141.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:141.0.3-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:141.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:141.0.3-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:141.0.3-20250828
-Tagged selenium/standalone-firefox:141.0.3-20250828
-Tagged selenium/node-firefox:141.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:141.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:141.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:141.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:141.0-20250828
-Tagged selenium/standalone-firefox:141.0-20250828
+Tagged selenium/node-firefox:141.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:141.0.3-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:141.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:141.0.3-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:141.0.3-20250909
+Tagged selenium/standalone-firefox:141.0.3-20250909
+Tagged selenium/node-firefox:141.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:141.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:141.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:141.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:141.0-20250909
+Tagged selenium/standalone-firefox:141.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_142.md
+++ b/CHANGELOG/4.35.0/firefox_142.md
@@ -1,0 +1,21 @@
+```
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
+Firefox version -> 142.0.1
+Short Firefox version -> 142.0
+GeckoDriver version -> 0.36.0
+Short GeckoDriver version -> 0.36
+Tagged selenium/node-firefox:142.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:142.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:142.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:142.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:142.0.1-20250909
+Tagged selenium/standalone-firefox:142.0.1-20250909
+Tagged selenium/node-firefox:142.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:142.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:142.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:142.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:142.0-20250909
+Tagged selenium/standalone-firefox:142.0-20250909
+```

--- a/CHANGELOG/4.35.0/firefox_98.md
+++ b/CHANGELOG/4.35.0/firefox_98.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 98.0.2
 Short Firefox version -> 98.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:98.0.2-20250828
-Tagged selenium/standalone-firefox:98.0.2-20250828
-Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:98.0-20250828
-Tagged selenium/standalone-firefox:98.0-20250828
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:98.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:98.0.2-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:98.0.2-20250909
+Tagged selenium/standalone-firefox:98.0.2-20250909
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:98.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:98.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:98.0-20250909
+Tagged selenium/standalone-firefox:98.0-20250909
 ```

--- a/CHANGELOG/4.35.0/firefox_99.md
+++ b/CHANGELOG/4.35.0/firefox_99.md
@@ -1,21 +1,21 @@
 ```
-./tag_and_push_browser_images.sh 4.35.0 20250828 selenium false firefox true
-Tagging images for browser firefox, version 4.35.0, build date 20250828, namespace selenium
-Selenium Grid version -> 4.35.0-20250828
+./tag_and_push_browser_images.sh 4.35.0 20250909 selenium false firefox true
+Tagging images for browser firefox, version 4.35.0, build date 20250909, namespace selenium
+Selenium Grid version -> 4.35.0-20250909
 Firefox version -> 99.0.1
 Short Firefox version -> 99.0
 GeckoDriver version -> 0.36.0
 Short GeckoDriver version -> 0.36
-Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250828
-Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-20250828
-Tagged selenium/node-firefox:99.0.1-20250828
-Tagged selenium/standalone-firefox:99.0.1-20250828
-Tagged selenium/node-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250828
-Tagged selenium/node-firefox:99.0-geckodriver-0.36-20250828
-Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-20250828
-Tagged selenium/node-firefox:99.0-20250828
-Tagged selenium/standalone-firefox:99.0-20250828
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-grid-4.35.0-20250909
+Tagged selenium/node-firefox:99.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/standalone-firefox:99.0.1-geckodriver-0.36.0-20250909
+Tagged selenium/node-firefox:99.0.1-20250909
+Tagged selenium/standalone-firefox:99.0.1-20250909
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-grid-4.35.0-20250909
+Tagged selenium/node-firefox:99.0-geckodriver-0.36-20250909
+Tagged selenium/standalone-firefox:99.0-geckodriver-0.36-20250909
+Tagged selenium/node-firefox:99.0-20250909
+Tagged selenium/standalone-firefox:99.0-20250909
 ```


### PR DESCRIPTION
### **User description**
This PR contains the CHANGELOG for Node/Standalone firefox with specific browser versions: [98, 99, 100, 101, 102, 103, 104, 105, 106, 107, 108, 109, 110, 111, 112, 113, 114, 115, 116, 117, 118, 119, 120, 121, 122, 123, 124, 125, 126, 127, 128, 129, 130, 131, 132, 133, 134, 135, 136, 137, 138, 139, 140, 141, 142]


___

### **PR Type**
Documentation


___

### **Description**
• Updated build date from `20250828` to `20250909` across all Firefox changelog files for Selenium Grid 4.35.0
• Updated Docker image tags to use the new build date `20250909` for all Firefox versions (98-142)
• Maintained existing Firefox and GeckoDriver version specifications for each browser version
• Covers 45 different Firefox browser versions with consistent build date updates


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Old Build Date: 20250828"] -- "Update across all files" --> B["New Build Date: 20250909"]
  B --> C["Firefox Versions 98-142"]
  C --> D["Updated Docker Image Tags"]
  C --> E["Updated Changelog Files"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><details><summary>25 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox_100.md</strong><dd><code>Update Firefox 100 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_100.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-b1e077cf47fb6243dc0047f761464098e8da5ec1dd4cbc057bbdad0d5e49cf12">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_101.md</strong><dd><code>Update Firefox 101 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_101.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-263063991aa7a8e13533843e93c844c5444219de54c8ae4e6995b5b14cf848f2">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_102.md</strong><dd><code>Update Firefox 102 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_102.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-978ac9b8a81f9b093531061293003ca541ebe8dc2fb4c9ff37fb2e5f61355a43">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_103.md</strong><dd><code>Update Firefox 103 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_103.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-1abc98bf7b0c1529518a470fba23ec5f3d43388ed8e590ed13dcf4b3cb1f1247">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_104.md</strong><dd><code>Update Firefox 104 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_104.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-9feb7089a22695d4335cb304da2168daa7e4fc05aebbe06ba1cfad3d6fc034e8">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_105.md</strong><dd><code>Update Firefox 105 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_105.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-01fac18f77608804692a0bf92a1886a2f0196e37c7f0dbcd9a4d47b56663f5f5">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_106.md</strong><dd><code>Update Firefox 106 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_106.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-324e6c77d6d6b952e4107856cd9966dd3cb0f836889da15191dab7121294b685">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_107.md</strong><dd><code>Update Firefox 107 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_107.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-47928899eca706478d35d0bac2c99be471f216a196690714bf7373065d99819b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_108.md</strong><dd><code>Update Firefox 108 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_108.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-7581b3ccce8c8ce8578caa883add9356213af191178ec522a63a3f8e785f95a7">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_109.md</strong><dd><code>Update Firefox 109 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_109.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-8a98b66a2f4b1695e7e14931507a532824b6a9167d7959c2768046d368dcbd1c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_110.md</strong><dd><code>Update Firefox 110 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_110.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-66a11de49ac64c9cc486fd2e2ab7199be9b9d90e27bec17134b01a9f1ed4c411">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_111.md</strong><dd><code>Update Firefox 111 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_111.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-e6ffd30b04b818a55311131440ba4e19333a57fe60ac4b77542ac19c3ce0c787">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_112.md</strong><dd><code>Update Firefox 112 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_112.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-4bb9b9b90ebdaf4de8a989da3ef25d95d9af1aa8d24269d468efd8b93e3a264a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_113.md</strong><dd><code>Update Firefox 113 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_113.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-5b4e66292aaad65f865368e2d6663de02b0e6bd08bd35b57d1cbca22f8032766">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_114.md</strong><dd><code>Update Firefox 114 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_114.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-f2b15753aa67883b0e24dcc99d898bf870b0fbb14f918ea1730f127c628f36d4">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_115.md</strong><dd><code>Update Firefox 115 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_115.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-aba53bd02f61144a88948ec2f746220930cb7159aa5b8373a1b294425612c60c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_116.md</strong><dd><code>Update Firefox 116 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_116.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-dd55c8630e418cf9d866527584a48c7fb6629b5b872a662c58a1313a3855fb7f">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_117.md</strong><dd><code>Update Firefox 117 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_117.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-7b3b6e03a4b5b39d92e4968e6a0935f55e4def78bc7a58d6d3dee70b83f520e7">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_118.md</strong><dd><code>Update Firefox 118 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_118.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-75f473c67590307d272dc06c39b09135200952ddfd39bf1f4de79b3436a719da">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_119.md</strong><dd><code>Update Firefox 119 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_119.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-4965d574e7ca3b2d45132d8c59268e408d04f01752f4f18829a8a457ec271315">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_120.md</strong><dd><code>Update Firefox 120 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_120.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-076505e9d899328b7f016e2c1d0f1e0796c5070455f91ffe0c664c3793ad7faa">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_121.md</strong><dd><code>Update Firefox 121 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_121.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-8306f5cc3686210343c953cac92b0e09d78a3962c59a0f4a075f6759f7a6dcdd">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_122.md</strong><dd><code>Update Firefox 122 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_122.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-01c597c756500fa7ec8f2ffd52537fd5fa62e81b60cb0c33e1ff6cc7b40d13ee">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_123.md</strong><dd><code>Update Firefox 123 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_123.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-9ba40cf5dc51856562ceb9404d7487cd0e69231a1c8fd647ff8146fcf9886d22">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_124.md</strong><dd><code>Update Firefox 124 changelog build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_124.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-616a1d8ae1e3e2382f90e55f5f5a432ed85aa0a4fcc33e0fad9b28c7a8c87db5">+15/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>8 files</summary><table>
<tr>
  <td>
    <details>
      <summary><strong>firefox_136.md</strong><dd><code>Update Firefox 136 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_136.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>136.0.4</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-bfd14f1ef67954d11d67e757df7886d8984c8d3b047e9db1891dd68c9d17125b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_137.md</strong><dd><code>Update Firefox 137 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_137.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>137.0.2</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-a3199a46a481ce2aeb6b252b8768d419051be9b2bfebc12eb68ba118fd836d12">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_138.md</strong><dd><code>Update Firefox 138 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_138.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>138.0.4</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-e3301199cf0030bd9fc5f087c629fc7763355280b723e8d0a496e2e4a684aafa">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_139.md</strong><dd><code>Update Firefox 139 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_139.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>139.0.4</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-77fe8dd88ed37458a148718ac253bbf9aae45778e01a17446f2f9c0b2833c3d5">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_140.md</strong><dd><code>Update Firefox 140 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_140.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>140.0.4</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-7a88465757aaa0e6c2290614b078253af052e41cd10ced0b9ff374c50ee9998a">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_141.md</strong><dd><code>Update Firefox 141 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_141.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>141.0.3</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-268f5f6b8006b9348a29d4502982543a01e74cd6f6e2db8319a7ccfabd25ed7f">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_98.md</strong><dd><code>Update Firefox 98 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_98.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>98.0.2</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-18af83e6847161e66f9f45b4dd222d109d2e434ba3541a14c00a0a6ddf669c4b">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>firefox_99.md</strong><dd><code>Update Firefox 99 changelog with new build date</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

CHANGELOG/4.35.0/firefox_99.md

• Updated build date from <code>20250828</code> to <code>20250909</code> in script command and <br>Selenium Grid version<br> • Updated all Docker image tags to use new build <br>date <code>20250909</code> instead of <code>20250828</code><br> • Maintained Firefox version <code>99.0.1</code> <br>and GeckoDriver version <code>0.36.0</code>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-6a01168b477b8a41c3d3e5240edfd70f375228851fa04f385bb3ecc307d739ab">+15/-15</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>12 files</summary><table>
<tr>
  <td><strong>firefox_125.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-95ff127879647a2a0edab3ae09f5ab3d692ab5d81d150ba882620350b22381ab">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_126.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-9d6ba83cb673e12f111c5b249ff49d06acd85385f9972aba647e186dd588780c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_127.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-8a3a3b4e3fad9bc0023b9dc757e66a4933bf439264d2feb5914b9228081630e5">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_128.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-87801bd9b5d722faf46b6082e7fd9c61320e88773600e6a01825cfd1c8dcd081">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_129.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-4ed36babe15f6bb09a80074cf8c314e5adda2a47b40f6ffdf04a134fcfc75709">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_130.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-183fa1ed386516d73af98256c92021e3ac731fbf3593692bf5f9bb8276671805">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_131.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-5152f53a732c0a83c954c6ff2719424d4897493125ea09dd2068748b0044642c">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_132.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-8d8a89a509c3e0495f64c9b4838668f4e128762410f05c45824e15a8ff02c7bf">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_133.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-1341648d438a57622ef4da9b1200dd5c2f96a4af182931a608363b7f8bff46af">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_134.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-9652156a36d88655dff5ec13dfa18b8b1ac398959f19b7b3dd7b86eac285b484">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_135.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-8d8aa4385e69b6325807398245138532900ce1ef3347075878982fab901eae36">+15/-15</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>firefox_142.md</strong></td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2966/files#diff-247aa4fe829460a1db81960327e340f8bcdbb3fcd67926c54781e4313c716ab9">+21/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___

