### PR TITLE
Docker: Fix regression `SE_NODE_STEREOTYPE_EXTRA` could not merge stereotypes

### DIFF
--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -28,7 +28,8 @@ function backup_original_env_vars() {
 
 		# Backup original value if not already backed up
 		if [[ -z "${!backup_var}" ]] && [[ -n "${!common_var}" ]]; then
-			eval "${backup_var}=\"${!common_var}\""
+			# Use printf -v to avoid eval and preserve quotes verbatim
+			printf -v "$backup_var" '%s' "${!common_var}"
 			echo "Backed up original ${common_var}=${!common_var} to ${backup_var}"
 		fi
 	done
@@ -43,11 +44,11 @@ function restore_original_env_vars() {
 
 		# Restore original value if backup exists
 		if [[ -n "${!backup_var}" ]]; then
-			eval "${common_var}=\"${!backup_var}\""
+			printf -v "$common_var" '%s' "${!backup_var}"
 			echo "Restored original ${backup_var}=${!backup_var} to ${common_var}"
 		else
 			# Clear the variable if no backup exists
-			eval "${common_var}=\"\""
+			printf -v "$common_var" '%s' ""
 			echo "Cleared ${common_var} (no original backup)"
 		fi
 	done
@@ -64,12 +65,12 @@ function assign_browser_specific_env_vars() {
 
 		# Check if the browser-specific environment variable exists
 		if [[ -n "${!browser_specific_var}" ]]; then
-			# Assign the browser-specific value to the common variable
-			eval "${common_var}=\"${!browser_specific_var}\""
+			# Assign the browser-specific value to the common variable, preserving quotes
+			printf -v "$common_var" '%s' "${!browser_specific_var}"
 			echo "Assigned ${browser_specific_var}=${!browser_specific_var} to ${common_var}"
 		elif [[ -n "${!backup_var}" ]]; then
 			# Inherit original value if browser-specific value is not set
-			eval "${common_var}=\"${!backup_var}\""
+			printf -v "$common_var" '%s' "${!backup_var}"
 			echo "Inherited original ${backup_var}=${!backup_var} to ${common_var}"
 		fi
 	done
@@ -178,6 +179,10 @@ if [ -d "/opt/selenium/browsers" ]; then
 				echo "[[node.driver-configuration]]" >>"$FILENAME"
 				echo "display-name = \"${SE_NODE_BROWSER_NAME}\"" >>"$FILENAME"
 				echo "stereotype = '${SE_NODE_STEREOTYPE}'" >>"$FILENAME"
+				# Validate SE_NODE_MAX_SESSIONS is a positive integer
+				if [[ "${SE_NODE_MAX_SESSIONS}" =~ ^[0-9]+$ ]] && [[ "${SE_NODE_MAX_SESSIONS}" -gt 0 ]]; then
+					echo "max-sessions = ${SE_NODE_MAX_SESSIONS}" >>"$FILENAME"
+				fi
 				echo "" >>"$FILENAME"
 			fi
 


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes #2968
Single/Double quote " is not retained when assigning value to variable in shell script, so it breaks the JSON format.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Replace `eval` with `printf -v` for safer variable assignment

- Add validation for `SE_NODE_MAX_SESSIONS` parameter

- Fix stereotype merging regression in Docker configuration


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["eval usage"] -- "replace with" --> B["printf -v"]
  C["SE_NODE_MAX_SESSIONS"] -- "add validation" --> D["positive integer check"]
  B --> E["safer variable assignment"]
  D --> F["prevent invalid config"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Improve variable handling safety and add session validation</code></dd></summary>
<hr>

NodeBase/generate_config

<ul><li>Replace <code>eval</code> statements with <code>printf -v</code> for safer variable assignment<br> <li> Add validation for <code>SE_NODE_MAX_SESSIONS</code> to ensure positive integer <br>values<br> <li> Preserve quotes verbatim in environment variable handling<br> <li> Fix stereotype merging functionality in Docker configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2971/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+11/-6</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

