### PR TITLE
Docker: Roll back default value of `SE_DISTRIBUTOR_SLOT_SELECTOR` as empty

### DIFF
--- a/Base/Dockerfile
+++ b/Base/Dockerfile
@@ -206,7 +206,7 @@ ENV SE_BIND_HOST="false" \
     SE_SERVER_PROTOCOL="http" \
     # Boolean value, maps "--reject-unsupported-caps"
     SE_REJECT_UNSUPPORTED_CAPS="false" \
-    SE_DISTRIBUTOR_SLOT_SELECTOR="org.openqa.selenium.grid.distributor.selector.GreedySlotSelector" \
+    SE_DISTRIBUTOR_SLOT_SELECTOR="" \
     SE_OTEL_JAVA_GLOBAL_AUTOCONFIGURE_ENABLED="true" \
     SE_OTEL_TRACES_EXPORTER="otlp" \
     SE_SUPERVISORD_LOG_LEVEL="info" \

--- a/ENV_VARIABLES.md
+++ b/ENV_VARIABLES.md
@@ -154,4 +154,4 @@
 | SE_VIDEO_MAXRATE |  |  |  |
 | SE_NODE_DELETE_SESSION_ON_UI | true | Enable capability to support deleting session on Grid UI | --delete-session-on-ui |
 | SE_UPDATE_CHROME_COMPONENTS |  | Applicable for node-chrome, standalone-chrome (arch linux/amd64). Update the latest version of Chrome and ChromeDriver at the beginning of the container startup. Read more: [#2872](https://github.com/SeleniumHQ/docker-selenium/pull/2872) |  |
-| SE_DISTRIBUTOR_SLOT_SELECTOR | org.openqa.selenium.grid.distributor.selector.GreedySlotSelector | Full class name of non-default slot selector. This is used to select a slot in a Node once the Node has been matched. Switch to default, use class name `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector` | --slot-selector |
+| SE_DISTRIBUTOR_SLOT_SELECTOR |  | Full class name of non-default slot selector. This is used to select a slot in a Node once the Node has been matched. Switch to built-in Greedy strategy, use class name `org.openqa.selenium.grid.distributor.selector.GreedySlotSelector` | --slot-selector |

--- a/README.md
+++ b/README.md
@@ -630,10 +630,16 @@ instructions on top of it.
 
 #### Distributor configuration
 
-| Environment variable         | Option                      | Type    | Default value | Description                                                                                                  |
-|------------------------------|-----------------------------|---------|---------------|--------------------------------------------------------------------------------------------------------------|
-| `SE_REJECT_UNSUPPORTED_CAPS` | `--reject-unsupported-caps` | boolean | `false`       | Allow the Distributor to reject a request immediately if the Grid does not support the requested capability. |
-| `SE_HEALTHCHECK_INTERVAL`    | `--healthcheck-interval`    | int     | `120`         | This ensures the server can ping all the Nodes successfully after an interval.                               |
+| Environment variable           | Option                      | Type    | Default value | Description                                                                                                           |
+|--------------------------------|-----------------------------|---------|---------------|-----------------------------------------------------------------------------------------------------------------------|
+| `SE_REJECT_UNSUPPORTED_CAPS`   | `--reject-unsupported-caps` | boolean | `false`       | Allow the Distributor to reject a request immediately if the Grid does not support the requested capability.          |
+| `SE_HEALTHCHECK_INTERVAL`      | `--healthcheck-interval`    | int     | `120`         | This ensures the server can ping all the Nodes successfully after an interval.                                        |
+| `SE_DISTRIBUTOR_SLOT_SELECTOR` | `--slot-selector`           | string  | ``            | Full class name of non-default slot selector. This is used to select a slot in a Node once the Node has been matched. |
+
+Distributor component comes with two main built-in Slot Selector implementations
+* `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector`: Grid’s default strategy (used if you don’t configure anything else). It follows the balanced, least-recently-used approach described above. The `DefaultSlotSelector` will choose the Node that has been free for the longest time, ensuring no single node is overused when others are idle. This simple strategy has minimal overhead and works well for most general testing scenarios where an even distribution of sessions is desired.
+
+* `org.openqa.selenium.grid.distributor.selector.GreedySlotSelector`: An alternative built-in provided. The `GreedySlotSelector` aims to maximize node utilization by concentrating sessions on one node before using another. As noted, it will tend to fill up a node’s slots one by one, reducing the number of nodes that are partially utilized at any given time. This strategy is beneficial for resource-intensive or high-concurrency scenarios (for example, load testing or running in an environment where you scale nodes on demand). More insight, let's refer to [#2990](https://github.com/SeleniumHQ/docker-selenium/issues/2990).
 
 ___
 

--- a/scripts/generate_list_env_vars/description.yaml
+++ b/scripts/generate_list_env_vars/description.yaml
@@ -491,6 +491,6 @@
   cli: ''
 - name: SE_DISTRIBUTOR_SLOT_SELECTOR
   description: Full class name of non-default slot selector. This is used to select
-    a slot in a Node once the Node has been matched. Switch to default, use class
-    name `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector`
+    a slot in a Node once the Node has been matched. Switch to built-in Greedy strategy,
+    use class name `org.openqa.selenium.grid.distributor.selector.GreedySlotSelector`
   cli: --slot-selector

--- a/scripts/generate_list_env_vars/value.yaml
+++ b/scripts/generate_list_env_vars/value.yaml
@@ -19,7 +19,7 @@
 - name: SE_DISTRIBUTOR_PORT
   default: '5553'
 - name: SE_DISTRIBUTOR_SLOT_SELECTOR
-  default: org.openqa.selenium.grid.distributor.selector.GreedySlotSelector
+  default: ''
 - name: SE_DRAIN_AFTER_SESSION_COUNT
   default: '0'
 - name: SE_ENABLE_BROWSER_LEFTOVERS_CLEANUP


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fixes https://github.com/SeleniumHQ/docker-selenium/issues/2990
An empty value means the default slot selector will be used, `org.openqa.selenium.grid.distributor.selector.DefaultSlotSelector`.
For `GreedySlotSelector`, the user has to explicitly set it.
Update details of these 2 built-in slot selectors in README.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Roll back `SE_DISTRIBUTOR_SLOT_SELECTOR` default from GreedySlotSelector to empty

- Update documentation to clarify slot selector behavior and built-in implementations

- Explain DefaultSlotSelector as Grid's default strategy when not configured

- Document GreedySlotSelector as alternative for resource-intensive scenarios


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["SE_DISTRIBUTOR_SLOT_SELECTOR<br/>GreedySlotSelector"] -->|"Revert to"| B["SE_DISTRIBUTOR_SLOT_SELECTOR<br/>Empty String"]
  B -->|"Uses Grid default"| C["DefaultSlotSelector"]
  B -->|"Can be configured to"| D["GreedySlotSelector"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Reset slot selector default to empty</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

Base/Dockerfile

<ul><li>Changed <code>SE_DISTRIBUTOR_SLOT_SELECTOR</code> environment variable default <br>value from <br><code>org.openqa.selenium.grid.distributor.selector.GreedySlotSelector</code> to <br>empty string</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2993/files#diff-c7235ebbda8248c044e6b13da481ae97f4a21846ed2341a056b6b873abaa482b">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>ENV_VARIABLES.md</strong><dd><code>Update slot selector documentation and defaults</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

ENV_VARIABLES.md

<ul><li>Updated default value for <code>SE_DISTRIBUTOR_SLOT_SELECTOR</code> from <br>GreedySlotSelector class name to empty<br> <li> Clarified documentation to reference DefaultSlotSelector as the <br>default strategy and GreedySlotSelector as an alternative</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2993/files#diff-575787a64e27e14d8c3ef34ad655dde25f38457d2c82335a3cb9f2dd44024035">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Add comprehensive slot selector documentation</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added <code>SE_DISTRIBUTOR_SLOT_SELECTOR</code> to Distributor configuration table <br>with empty default value<br> <li> Added detailed explanation of two built-in slot selector <br>implementations<br> <li> Documented DefaultSlotSelector as Grid's default balanced, <br>least-recently-used strategy<br> <li> Documented GreedySlotSelector as alternative for resource-intensive <br>and high-concurrency scenarios</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2993/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+10/-4</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>description.yaml</strong><dd><code>Update slot selector description reference</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_list_env_vars/description.yaml

<ul><li>Updated description to reference GreedySlotSelector as built-in <br>alternative instead of DefaultSlotSelector as default</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2993/files#diff-b3cb49ac37600014419abf1369cf4b5a461d55671b0c6b815b18d7d5030c2352">+2/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>value.yaml</strong><dd><code>Reset slot selector default value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

scripts/generate_list_env_vars/value.yaml

<ul><li>Changed default value of <code>SE_DISTRIBUTOR_SLOT_SELECTOR</code> from <br><code>org.openqa.selenium.grid.distributor.selector.GreedySlotSelector</code> to <br>empty string</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/2993/files#diff-40c21ad1afd76f2f3afbc05f7c916aebf35417a74feabeaec3d84600944e9e9e">+1/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

