### PR TITLE
K8s: Expose config session request timeout in Helm chart values

### DIFF
--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -49,6 +49,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | global.seleniumGrid.updateStrategy.rollingUpdate | object | `{"maxSurge":1,"maxUnavailable":0}` | Specify for strategy RollingUpdate |
 | global.seleniumGrid.affinity | object | `{}` | Specify affinity for all components, can be overridden individually |
 | global.seleniumGrid.topologySpreadConstraints | list | `[]` | Specify topologySpreadConstraints for all components, can be overridden individually |
+| global.seleniumGrid.sessionRequestTimeout | int | `300` | Timeout in seconds. A new incoming session request is added to the queue. Requests sitting in the queue for longer than the configured time will timeout. |
 | global.seleniumGrid.nodeMaxSessions | int | `1` | Specify number of max sessions per node. Can be overridden by individual component (this is also set to scaler trigger parameter `nodeMaxSessions` if `autoscaling` is enabled) |
 | global.seleniumGrid.nodeDrainAfterSessionCount | int | `0` | Set number of sessions will be executed in a Node before detaching it from Hub and shutting it down |
 | global.seleniumGrid.nodeEnableManagedDownloads | bool | `true` | This causes the Node to auto manage files downloaded for a given session on the Node (https://www.selenium.dev/documentation/webdriver/drivers/remote_webdriver/#enable-downloads-in-the-grid) |
@@ -300,6 +301,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | components.sessionQueue.imageTag | string | `nil` | Session Queue image tag (this overwrites global.seleniumGrid.imageTag parameter) |
 | components.sessionQueue.imagePullPolicy | string | `"IfNotPresent"` | Image pull policy (see https://kubernetes.io/docs/concepts/containers/images/#updating-images) |
 | components.sessionQueue.imagePullSecret | string | `""` | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
+| components.sessionQueue.sessionRequestTimeout | string | `""` | Override global sessionRequestTimeout |
 | components.sessionQueue.extraEnvironmentVariables | list | `[]` | Specify extra environment variables for Session Queue |
 | components.sessionQueue.extraEnvFrom | list | `[]` | Specify extra environment variables from ConfigMap and Secret for Session Queue |
 | components.sessionQueue.affinity | object | `{}` | Specify affinity for Session Queue pods, this overwrites global.seleniumGrid.affinity parameter |
@@ -331,6 +333,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | hub.annotations | object | `{}` | Custom annotations for Selenium Hub pods |
 | hub.labels | object | `{}` | Custom labels for Selenium Hub pods |
 | hub.disableUI | bool | `false` | Disable the Grid UI |
+| hub.sessionRequestTimeout | string | `""` | Override global sessionRequestTimeout |
 | hub.newSessionThreadPoolSize | string | `nil` | Configure fixed-sized thread pool for the Distributor to create new sessions as it consumes new session requests from the queue |
 | hub.publishPort | int | `4442` | Port where events are published |
 | hub.publishNodePort | int | `31442` | NodePort exposed where events are published |

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -134,6 +134,9 @@ spec:
             - name: SE_DISTRIBUTOR_SLOT_SELECTOR
               value: {{ include "seleniumGrid.autoscaling.distributor.slotSelector" $ | quote }}
             {{- end }}
+            {{- $sessionRequestTimeout := default $.Values.global.seleniumGrid.sessionRequestTimeout $.Values.hub.sessionRequestTimeout | int64 }}
+            - name: SE_SESSION_REQUEST_TIMEOUT
+              value: {{ $sessionRequestTimeout | quote }}
           {{- with .Values.hub.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/selenium-grid/templates/session-queue-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queue-deployment.yaml
@@ -51,6 +51,9 @@ spec:
                   fieldPath: status.podIP
             - name: SE_SESSION_QUEUE_PORT
               value: {{ .Values.components.sessionQueue.port | quote }}
+            {{- $sessionRequestTimeout := default $.Values.global.seleniumGrid.sessionRequestTimeout $.Values.components.sessionQueue.sessionRequestTimeout | int64 }}
+            - name: SE_SESSION_REQUEST_TIMEOUT
+              value: {{ $sessionRequestTimeout | quote }}
           {{- with .Values.components.extraEnvironmentVariables }}
             {{- tpl (toYaml .) $ | nindent 12 }}
           {{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -50,6 +50,8 @@ global:
     #    topologyKey: kubernetes.io/hostname
     #    whenUnsatisfiable: DoNotSchedule
     #    Note: If not define labelSelector, it will be added automatically based on "app" label in each component
+    # -- Timeout in seconds. A new incoming session request is added to the queue. Requests sitting in the queue for longer than the configured time will timeout.
+    sessionRequestTimeout: 300
     # -- Specify number of max sessions per node. Can be overridden by individual component (this is also set to scaler trigger parameter `nodeMaxSessions` if `autoscaling` is enabled)
     nodeMaxSessions: 1
     # Noted: In case of autoscaling enabled, with scaling type `job`, Node will be drained following `nodeMaxSessions` by default
@@ -756,6 +758,8 @@ components:
     imagePullPolicy: IfNotPresent
     # -- Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/)
     imagePullSecret: ""
+    # -- Override global sessionRequestTimeout
+    sessionRequestTimeout: ""
 
     # -- Specify extra environment variables for Session Queue
     extraEnvironmentVariables: []
@@ -849,6 +853,8 @@ hub:
   labels: {}
   # -- Disable the Grid UI
   disableUI: false
+  # -- Override global sessionRequestTimeout
+  sessionRequestTimeout: ""
   # -- Configure fixed-sized thread pool for the Distributor to create new sessions as it consumes new session requests from the queue
   newSessionThreadPoolSize:
   # -- Port where events are published

--- a/tests/charts/ci/base-auth-ingress-values.yaml
+++ b/tests/charts/ci/base-auth-ingress-values.yaml
@@ -2,6 +2,7 @@ global:
   seleniumGrid:
     logLevel: INFO
     stdoutProbeLog: true
+    sessionRequestTimeout: 800
 
 serverConfigMap:
   env:
@@ -19,8 +20,6 @@ isolateComponents: true
 
 hub:
   extraEnvironmentVariables: &extraEnvironmentVariables
-    - name: SE_SESSION_REQUEST_TIMEOUT
-      value: "800"
     - name: SE_SESSION_RETRY_INTERVAL
       value: "5"
     - name: SE_HEALTHCHECK_INTERVAL


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Expose `sessionRequestTimeout` configuration in Helm chart values

- Allow global and component-level override of session request timeout

- Add `SE_SESSION_REQUEST_TIMEOUT` environment variable to Hub and Session Queue

- Update test configuration to use new values parameter


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["global.seleniumGrid.sessionRequestTimeout<br/>300 seconds"] --> B["Hub Deployment"]
  A --> C["Session Queue Deployment"]
  D["hub.sessionRequestTimeout<br/>override"] --> B
  E["components.sessionQueue.sessionRequestTimeout<br/>override"] --> C
  B --> F["SE_SESSION_REQUEST_TIMEOUT<br/>environment variable"]
  C --> F
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>CONFIGURATION.md</strong><dd><code>Document session request timeout parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/CONFIGURATION.md

<ul><li>Add documentation for <code>global.seleniumGrid.sessionRequestTimeout</code> <br>parameter with 300 second default<br> <li> Add documentation for <code>components.sessionQueue.sessionRequestTimeout</code> <br>override parameter<br> <li> Add documentation for <code>hub.sessionRequestTimeout</code> override parameter</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3006/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>hub-deployment.yaml</strong><dd><code>Add session timeout to Hub deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/hub-deployment.yaml

<ul><li>Add <code>SE_SESSION_REQUEST_TIMEOUT</code> environment variable to Hub deployment<br> <li> Use component-level override if provided, otherwise fall back to <br>global value<br> <li> Convert timeout value to int64 for proper formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3006/files#diff-f51202c2bd7c5496905266ca9cb34b863557dfe7226c72c241f67a2aee33c379">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td>
    <details>
      <summary><strong>session-queue-deployment.yaml</strong><dd><code>Add session timeout to Session Queue deployment</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/session-queue-deployment.yaml

<ul><li>Add <code>SE_SESSION_REQUEST_TIMEOUT</code> environment variable to Session Queue <br>deployment<br> <li> Use component-level override if provided, otherwise fall back to <br>global value<br> <li> Convert timeout value to int64 for proper formatting</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3006/files#diff-265c9d150255ef5a016ee51d6dd6396ecc4c26bfe2f1ef19e1c87593a14eccc5">+3/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add session timeout configuration parameters</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<ul><li>Add <code>global.seleniumGrid.sessionRequestTimeout</code> with default value of <br>300 seconds<br> <li> Add <code>components.sessionQueue.sessionRequestTimeout</code> override parameter<br> <li> Add <code>hub.sessionRequestTimeout</code> override parameter<br> <li> Include documentation comments explaining timeout behavior</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3006/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Tests</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>base-auth-ingress-values.yaml</strong><dd><code>Update test configuration to use new parameter</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

tests/charts/ci/base-auth-ingress-values.yaml

<ul><li>Add <code>sessionRequestTimeout: 800</code> to global seleniumGrid configuration<br> <li> Remove hardcoded <code>SE_SESSION_REQUEST_TIMEOUT</code> environment variable from <br>hub extraEnvironmentVariables<br> <li> Migrate to using new Helm chart values parameter instead of direct <br>environment variable</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3006/files#diff-cf188803e7b811b300b841d8b60cc74f33220d1ceea5809a277bdd1bb0e5c92b">+1/-2</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

