### PR TITLE
Add option to inject network policies into chart

### DIFF
--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -409,6 +409,14 @@ helm upgrade selenium-grid docker-selenium/selenium-grid --set 'firefoxNode.enab
 
 Note: the parameter used for --set-json is just an example, please refer to [Container Spec](https://www.devspace.sh/component-chart/docs/configuration/containers) for an overview of usable parameters.
 
+If needed, you can add network policies for your selenium-grid by running:
+
+```bash
+helm upgrade selenium-grid docker-selenium/selenium-grid --set 'firefoxNode.enabled=true' --set-json 'networkPolicies={"allow-selenium":{"podSelector":{"matchLabels":{"app.kubernetes.io/name":"selenium-node-firefox"}},"policyTypes":["Egress"],"egress":[{}]}}'
+```
+
+Note: the parameter used for --set-json is just an example, please refer to [Network Policy Spec](https://kubernetes.io/docs/concepts/services-networking/network-policies/) for an overview of usable parameters.
+
 ## Uninstalling Selenium Grid release
 
 To uninstall:

--- a/charts/selenium-grid/templates/networkpolicy.yaml
+++ b/charts/selenium-grid/templates/networkpolicy.yaml
@@ -1,0 +1,10 @@
+{{- range $name, $spec := .Values.networkPolicies }}
+apiVersion: networking.k8s.io/v1
+kind: NetworkPolicy
+metadata:
+  name: {{ $name }}
+  namespace: {{ $.Release.Namespace }}
+spec:
+{{ toYaml $spec | indent 2 }}
+---
+{{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -2185,6 +2185,18 @@ videoManager:
   #   persistentVolumeClaim:
   #     claimName: video-pv-claim
 
+# -- Add network policies to this chart
+# It can be set using the --set-json option
+networkPolicies: {}
+# allow-selenium:
+#   podSelector:
+#     matchLabels:
+#       app.kubernetes.io/name: selenium-node-firefox
+#   policyTypes:
+#     - Egress
+#   egress:
+#     - {}
+
 # Configuration for dependency chart keda
 keda:
   # enabled: false


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR.

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.
-->

<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->
This PR adds an option to inject network policies into the Helm chart.

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
We plan to deploy selenium-grid into namespaces where a "DENY by default" network-policy applies. This PR enables us to inject a network policy with ALLOW rules for selenium nodes.

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add network policy injection capability to Helm chart

- Create NetworkPolicy template for Kubernetes deployments

- Add networkPolicies configuration value with examples

- Document network policy usage in README


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["values.yaml<br/>networkPolicies config"] --> B["networkpolicy.yaml<br/>template"]
  B --> C["Kubernetes<br/>NetworkPolicy resources"]
  D["README.md<br/>documentation"] --> E["User guidance<br/>for network policies"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>networkpolicy.yaml</strong><dd><code>New NetworkPolicy template for Kubernetes</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/templates/networkpolicy.yaml

<ul><li>New template file for rendering Kubernetes NetworkPolicy resources<br> <li> Iterates over networkPolicies values using range loop<br> <li> Generates NetworkPolicy manifests with metadata and spec<br> <li> Supports multiple network policies via dictionary configuration</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3033/files#diff-e9de5a1da20f1c70371698abf826d9d83d8d097420aad83079c2a5bdc5b76d3f">+10/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Configuration changes</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>values.yaml</strong><dd><code>Add networkPolicies configuration value</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/values.yaml

<ul><li>Add networkPolicies configuration parameter (empty by default)<br> <li> Include commented example showing Egress policy for selenium nodes<br> <li> Document usage with podSelector and matchLabels<br> <li> Enable flexible network policy injection via --set-json</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3033/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e">+12/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document network policy injection usage</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

charts/selenium-grid/README.md

<ul><li>Add section documenting network policy injection capability<br> <li> Provide helm upgrade command example with --set-json syntax<br> <li> Include reference to Kubernetes Network Policy Spec documentation<br> <li> Show practical example for firefox node network policy</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3033/files#diff-fc10bcbda83e36362ecb788d804050f34349dd654dfedca83d53ad34b0f19e08">+8/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

