### PR TITLE
Fix build deps in node-chromium

### DIFF
--- a/NodeChromium/Dockerfile
+++ b/NodeChromium/Dockerfile
@@ -13,6 +13,7 @@ ARG CHROMIUM_DEB_SITE="http://deb.debian.org/debian"
 RUN echo "deb ${CHROMIUM_DEB_SITE}/ sid main" >/etc/apt/sources.list.d/debian.list \
   && wget -qO- https://ftp-master.debian.org/keys/archive-key-12.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-keyring.gpg \
   && wget -qO- https://ftp-master.debian.org/keys/archive-key-12-security.asc | gpg --dearmor > /etc/apt/trusted.gpg.d/debian-archive-security-keyring.gpg \
+  && for d in bin lib lib32 lib64 libo32 libx32 sbin; do dpkg-divert --package base-files --no-rename --remove /$d; done \
   && apt-get update -qqy \
   && if [ "${CHROMIUM_VERSION}" = "latest" ]; \
       then apt-get -qqy --no-install-recommends install chromium-common chromium chromium-l10n chromium-driver; \
@@ -30,7 +31,8 @@ RUN echo "deb ${CHROMIUM_DEB_SITE}/ sid main" >/etc/apt/sources.list.d/debian.li
 # Chromium Launch Script Wrapper
 #=================================
 COPY wrap_chromium_binary /opt/bin/wrap_chromium_binary
-RUN /opt/bin/wrap_chromium_binary
+RUN /opt/bin/wrap_chromium_binary \
+    && chromium --version
 
 #============================================
 # Chromium cleanup script and supervisord file


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Fix the error during build the image
```
  (Reading database ... 16190 files and directories currently installed.)
  7.430 Preparing to unpack .../base-files_14_amd64.deb ...
  7.446 dpkg-divert: error: 'diversion of /lib32 to /.lib32.usr-is-merged by base-files' clashes with 'diversion of /lib32 to /lib32.usr-is-merged by base-files'
  7.447 dpkg: error processing archive /var/cache/apt/archives/base-files_14_amd64.deb (--unpack):
  7.447  new base-files package pre-installation script subprocess returned error exit status 2
  7.567 Errors were encountered while processing:
  7.567  /var/cache/apt/archives/base-files_14_amd64.deb
  7.601 E: Sub-process /usr/bin/dpkg returned an error code (1)
  ------
  Dockerfile:13
```

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Bug fix


___

### **Description**
- Removes dpkg-divert conflicts for Debian sid packages

- Adds chromium version verification after installation


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Debian sid setup"] --> B["Remove dpkg-divert conflicts"]
  B --> C["Install chromium packages"]
  C --> D["Wrap chromium binary"]
  D --> E["Verify chromium version"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Bug fix</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>Dockerfile</strong><dd><code>Resolve dpkg conflicts and verify chromium installation</code>&nbsp; &nbsp; </dd></summary>
<hr>

NodeChromium/Dockerfile

<ul><li>Adds dpkg-divert removal loop to resolve conflicts with Debian sid <br>base-files package<br> <li> Appends chromium version check after binary wrapper execution for <br>build verification<br> <li> Ensures proper package installation in sid environment with <br>conflicting file diversions</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3035/files#diff-ddc70cdbe415111d77d5eadd39b842ca541bd0f0a9ecb04fceb7597f2f09d598">+3/-1</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr></tr></tbody></table>

</details>

___

