### PR TITLE
Docker: Env variable to disable specific browser in generate_config of Node/Standalone all-browsers

### DIFF
--- a/NodeBase/generate_config
+++ b/NodeBase/generate_config
@@ -10,6 +10,7 @@ function short_version() {
 
 # A global array of environment variable prefixes supports different browser suffixes
 ENV_PREFIXES=(
+	"SE_NODE_ENABLE_BROWSER"
 	"SE_NODE_STEREOTYPE"
 	"SE_NODE_BROWSER_NAME"
 	"SE_NODE_BROWSER_VERSION"
@@ -142,6 +143,11 @@ if [ -d "/opt/selenium/browsers" ]; then
 			echo "===Start generating stereotype for browser: ${browser_name}==="
 			# Assign environment variables with browser suffix to common variables
 			assign_browser_specific_env_vars "$browser_name"
+			if [ "${SE_NODE_ENABLE_BROWSER}" = "false" ]; then
+				echo "===Skip generating stereotype for browser: ${browser_name}, SE_NODE_ENABLE_BROWSER_${browser_name} is set false==="
+				restore_original_env_vars
+				continue
+			fi
 
 			if [ -f "${browser_dir}name" ]; then
 				SE_NODE_BROWSER_NAME=$(cat "${browser_dir}name")

--- a/README.md
+++ b/README.md
@@ -427,6 +427,24 @@ According to multi-arch support, browsers are available in images `selenium/node
 
 Both Chrome and Chromium browser binary are available in image arch `linux/amd64`. However, Chrome browser binary is activated by default. In case you want to switch to Chromium browser binary, you can set environment variable `SE_BROWSER_BINARY_LOCATION_CHROME=/usr/bin/chromium`.
 
+Via environment variable `SE_NODE_ENABLE_BROWSER_<BROWSER>`, with `<BROWSER>` is the name of browser in uppercase (e.g. `CHROME`, `FIREFOX`, `EDGE`). You can disable a browser to be installed in the Node/Standalone image all browsers.
+
+For example with image linux/amd64 and linux/arm64, you can disable Firefox browser by setting environment variable `SE_NODE_ENABLE_BROWSER_FIREFOX=false`.
+
+For example with image linux/amd64, you can disable Chrome browser by setting environment variable `SE_NODE_ENABLE_BROWSER_CHROME=false`. Similar for Edge browser, set `SE_NODE_ENABLE_BROWSER_EDGE=false`.
+
+Here is list of environment variables which support suffix `_<BROWSER>` in Node/Standalone image all browsers:
+
+```
+SE_NODE_STEREOTYPE
+SE_NODE_BROWSER_NAME
+SE_NODE_BROWSER_VERSION
+SE_NODE_PLATFORM_NAME
+SE_BROWSER_BINARY_LOCATION
+SE_NODE_STEREOTYPE_EXTRA
+SE_NODE_MAX_SESSIONS
+```
+
 ## Environment Variables
 
 **Checkout full list of environment variables [here](ENV_VARIABLES.md).**


### PR DESCRIPTION
### **User description**
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->


___

### **PR Type**
Enhancement


___

### **Description**
- Add environment variable `SE_NODE_ENABLE_BROWSER_<BROWSER>` to disable specific browsers

- Allow selective browser installation in Node/Standalone all-browsers images

- Document supported environment variable suffixes for browser configuration

- Enable skipping browser stereotype generation when disabled


___

### Diagram Walkthrough


```mermaid
flowchart LR
  A["Browser Directory Loop"] --> B["Assign Browser-Specific Env Vars"]
  B --> C{"SE_NODE_ENABLE_BROWSER<br/>== false?"}
  C -->|Yes| D["Skip Browser Setup"]
  C -->|No| E["Generate Stereotype"]
  D --> F["Continue to Next Browser"]
  E --> F
```



<details><summary><h3>File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>generate_config</strong><dd><code>Add browser disable logic to generate_config script</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

NodeBase/generate_config

<ul><li>Added <code>SE_NODE_ENABLE_BROWSER</code> to the <code>ENV_PREFIXES</code> array for environment <br>variable processing<br> <li> Implemented conditional check to skip browser stereotype generation <br>when <code>SE_NODE_ENABLE_BROWSER</code> is set to <code>false</code><br> <li> Restores original environment variables and continues to next browser <br>when disabled</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3039/files#diff-7588f975550d93b98a8db2d5aa40b89c714b125a6bc81ea550556b1bca556f52">+6/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></td></tr><tr><td><strong>Documentation</strong></td><td><table>
<tr>
  <td>
    <details>
      <summary><strong>README.md</strong><dd><code>Document browser disable environment variable feature</code>&nbsp; &nbsp; &nbsp; &nbsp; </dd></summary>
<hr>

README.md

<ul><li>Added documentation for <code>SE_NODE_ENABLE_BROWSER_<BROWSER></code> environment variable <br>functionality<br> <li> Provided examples for disabling Firefox, Chrome, and Edge browsers<br> <li> Listed all environment variable suffixes supported in Node/Standalone <br>all-browsers images<br> <li> Clarified usage across different architectures (linux/amd64, <br>linux/arm64)</ul>


</details>


  </td>
  <td><a href="https://github.com/SeleniumHQ/docker-selenium/pull/3039/files#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5">+18/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></td></tr></tbody></table>

</details>

___

