### PR TITLE
chart(selenium-grid): add ServiceMonitor and PodMonitor support for Prometheus Operator

### DIFF
--- a/charts/selenium-grid/templates/monitoring-exporter-deployment.yaml
+++ b/charts/selenium-grid/templates/monitoring-exporter-deployment.yaml
@@ -31,7 +31,8 @@ spec:
           {{- $imageRegistry := default .Values.global.seleniumGrid.imageRegistry .Values.monitoring.exporter.imageRegistry }}
           image: {{ printf "%s/%s:%s" $imageRegistry .Values.monitoring.exporter.imageName .Values.monitoring.exporter.imageTag | quote }}
           ports:
-            - containerPort: {{ .Values.monitoring.exporter.port }}
+            - name: metrics
+              containerPort: {{ .Values.monitoring.exporter.port }}
     {{- with .Values.monitoring.exporter.tolerations }}
       tolerations: {{ toYaml . | nindent 6 }}
     {{- end }}

--- a/charts/selenium-grid/templates/monitoring-exporter-service.yaml
+++ b/charts/selenium-grid/templates/monitoring-exporter-service.yaml
@@ -26,7 +26,7 @@ spec:
     - name: http-port
       protocol: TCP
       port: {{ .Values.monitoring.exporter.port }}
-      targetPort: {{ .Values.monitoring.exporter.port }}
+      targetPort: metrics
     {{- if and (eq .Values.monitoring.exporter.service.type "NodePort") .Values.monitoring.exporter.service.nodePort }}
       nodePort: {{ .Values.monitoring.exporter.service.nodePort }}
     {{- end }}

--- a/charts/selenium-grid/templates/monitoring-pod-monitor.yaml
+++ b/charts/selenium-grid/templates/monitoring-pod-monitor.yaml
@@ -1,0 +1,33 @@
+{{- if and (eq (include "seleniumGrid.monitoring.enabled" $) "true") .Values.monitoring.podMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: PodMonitor
+metadata:
+  name: {{ template "seleniumGrid.monitoring.exporter.fullname" $ }}
+  namespace: {{ .Values.monitoring.podMonitor.namespace | default .Release.Namespace }}
+  {{- with .Values.monitoring.podMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with .Values.monitoring.podMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seleniumGrid.monitoring.exporter.fullname" $ }}
+  podMetricsEndpoints:
+    - port: metrics
+      path: {{ .Values.monitoring.podMonitor.path }}
+      interval: {{ .Values.monitoring.podMonitor.interval }}
+      scrapeTimeout: {{ .Values.monitoring.podMonitor.scrapeTimeout }}
+      {{- with .Values.monitoring.podMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitoring.podMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/selenium-grid/templates/monitoring-service-monitor.yaml
+++ b/charts/selenium-grid/templates/monitoring-service-monitor.yaml
@@ -1,0 +1,33 @@
+{{- if and (eq (include "seleniumGrid.monitoring.enabled" $) "true") .Values.monitoring.serviceMonitor.enabled }}
+apiVersion: monitoring.coreos.com/v1
+kind: ServiceMonitor
+metadata:
+  name: {{ template "seleniumGrid.monitoring.exporter.fullname" $ }}
+  namespace: {{ .Values.monitoring.serviceMonitor.namespace | default .Release.Namespace }}
+  {{- with .Values.monitoring.serviceMonitor.annotations }}
+  annotations:
+    {{- toYaml . | nindent 4 }}
+  {{- end }}
+  labels:
+    {{- include "seleniumGrid.commonLabels" $ | nindent 4 }}
+    {{- with .Values.monitoring.serviceMonitor.labels }}
+    {{- toYaml . | nindent 4 }}
+    {{- end }}
+spec:
+  selector:
+    matchLabels:
+      app.kubernetes.io/name: {{ template "seleniumGrid.monitoring.exporter.fullname" $ }}
+  endpoints:
+    - port: http-port
+      path: {{ .Values.monitoring.serviceMonitor.path }}
+      interval: {{ .Values.monitoring.serviceMonitor.interval }}
+      scrapeTimeout: {{ .Values.monitoring.serviceMonitor.scrapeTimeout }}
+      {{- with .Values.monitoring.serviceMonitor.relabelings }}
+      relabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+      {{- with .Values.monitoring.serviceMonitor.metricRelabelings }}
+      metricRelabelings:
+        {{- toYaml . | nindent 8 }}
+      {{- end }}
+{{- end }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -1041,6 +1041,46 @@ monitoring:
     key: ""
     value: ""
   annotations: {}
+  # -- ServiceMonitor configuration for Prometheus Operator
+  serviceMonitor:
+    # -- Enable ServiceMonitor resource
+    enabled: false
+    # -- Namespace to deploy the ServiceMonitor into (defaults to release namespace)
+    namespace: ""
+    # -- Additional labels for the ServiceMonitor
+    labels: {}
+    # -- Additional annotations for the ServiceMonitor
+    annotations: {}
+    # -- Metrics scrape path
+    path: /metrics
+    # -- Scrape interval
+    interval: 30s
+    # -- Scrape timeout
+    scrapeTimeout: 10s
+    # -- RelabelConfigs to apply to samples before scraping
+    relabelings: []
+    # -- MetricRelabelConfigs to apply to samples before ingestion
+    metricRelabelings: []
+  # -- PodMonitor configuration for Prometheus Operator (alternative to ServiceMonitor)
+  podMonitor:
+    # -- Enable PodMonitor resource
+    enabled: false
+    # -- Namespace to deploy the PodMonitor into (defaults to release namespace)
+    namespace: ""
+    # -- Additional labels for the PodMonitor
+    labels: {}
+    # -- Additional annotations for the PodMonitor
+    annotations: {}
+    # -- Metrics scrape path
+    path: /metrics
+    # -- Scrape interval
+    interval: 30s
+    # -- Scrape timeout
+    scrapeTimeout: 10s
+    # -- RelabelConfigs to apply to samples before scraping
+    relabelings: []
+    # -- MetricRelabelConfigs to apply to samples before ingestion
+    metricRelabelings: []
 
 # Keda scaled object configuration
 autoscaling:


### PR DESCRIPTION
## Motivation

Users running kube-prometheus-stack currently have no native way to scrape the Selenium Grid metrics exporter via Prometheus Operator. The only option is to configure `additionalScrapeConfigs` manually. This PR adds first-class `ServiceMonitor` and `PodMonitor` support.

## Changes

- **Named container port** (`metrics`) on the exporter Deployment — explicit port referencing instead of a magic number
- **Service port `targetPort`** updated to reference the named port `metrics` (port name `http-port` preserved — no breaking change)
- **`monitoring-service-monitor.yaml`** — new `ServiceMonitor` resource scraping the exporter Service on port `http-port`
- **`monitoring-pod-monitor.yaml`** — new `PodMonitor` resource scraping exporter Pods directly on port `metrics` (alternative for users without a Service)
- **`values.yaml`** — new `monitoring.serviceMonitor.*` and `monitoring.podMonitor.*` blocks; both disabled by default

## Usage

```yaml
# ServiceMonitor (scrapes via Service)
monitoring:
  enabled: true
  serviceMonitor:
    enabled: true
    interval: 30s
    scrapeTimeout: 10s
    labels:
      release: kube-prometheus-stack  # match your Prometheus operator selector

# PodMonitor (scrapes pods directly — alternative)
monitoring:
  enabled: true
  podMonitor:
    enabled: true
```

## Testing

```bash
# ServiceMonitor
helm template test charts/selenium-grid/ --set monitoring.enabled=true --set monitoring.serviceMonitor.enabled=true

# PodMonitor
helm template test charts/selenium-grid/ --set monitoring.enabled=true --set monitoring.podMonitor.enabled=true
```

Both render valid `monitoring.coreos.com/v1` resources with correct port references.