### PR TITLE
Test: Control recording over session capability only

### DIFF
--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -119,7 +119,7 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: playwright_connect_grid
-          - k8s-version: 'v1.33.6'
+          - k8s-version: 'v1.32.10'
             cluster: 'minikube'
             helm-version: 'v3.18.6'
             docker-version: '28.5.2'

--- a/tests/SeleniumTests/__init__.py
+++ b/tests/SeleniumTests/__init__.py
@@ -159,8 +159,7 @@ class ChromeTests(SeleniumGenericTests):
             options.enable_downloads = SELENIUM_ENABLE_MANAGED_DOWNLOADS
             if not SELENIUM_ENABLE_MANAGED_DOWNLOADS:
                 options.add_argument('disable-features=DownloadBubble,DownloadBubbleV2')
-            if TEST_ADD_CAPS_RECORD_VIDEO:
-                options.set_capability('se:recordVideo', True)
+            options.set_capability('se:recordVideo', True)
             if TEST_RETAIN_ON_FAILURE:
                 options.set_capability('se:retainOnFailure', True)
             if TEST_CUSTOM_SPECIFIC_NAME:
@@ -221,8 +220,7 @@ class EdgeTests(SeleniumGenericTests):
             options.enable_downloads = SELENIUM_ENABLE_MANAGED_DOWNLOADS
             if not SELENIUM_ENABLE_MANAGED_DOWNLOADS:
                 options.add_argument('disable-features=DownloadBubble,DownloadBubbleV2')
-            if TEST_ADD_CAPS_RECORD_VIDEO:
-                options.set_capability('se:recordVideo', True)
+            options.set_capability('se:recordVideo', True)
             if TEST_RETAIN_ON_FAILURE:
                 options.set_capability('se:retainOnFailure', True)
             if TEST_CUSTOM_SPECIFIC_NAME:
@@ -277,8 +275,7 @@ class FirefoxTests(SeleniumGenericTests):
             profile.set_preference('intl.accept_languages', 'vi-VN,vi')
             profile.set_preference('intl.locale.requested', 'vi-VN,vi')
             options.profile = profile
-            if TEST_ADD_CAPS_RECORD_VIDEO:
-                options.set_capability('se:recordVideo', True)
+            options.set_capability('se:recordVideo', True)
             if TEST_RETAIN_ON_FAILURE:
                 options.set_capability('se:retainOnFailure', True)
             if TEST_CUSTOM_SPECIFIC_NAME:

--- a/tests/docker-compose-v3-dev-arm64.yml
+++ b/tests/docker-compose-v3-dev-arm64.yml
@@ -17,7 +17,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_VNC_NO_PASSWORD=true
       - SE_NODE_ENABLE_MANAGED_DOWNLOADS=true
-      - SE_RECORD_VIDEO=true
 
   firefox:
     deploy:
@@ -33,7 +32,6 @@ services:
       - SE_EVENT_BUS_HOST=selenium-hub
       - SE_VNC_NO_PASSWORD=true
       - SE_NODE_ENABLE_MANAGED_DOWNLOADS=true
-      - SE_RECORD_VIDEO=true
 
   selenium-hub:
     image: selenium/hub:4.43.0-20260404

--- a/tests/docker-compose-v3-event-driven-arm64.yml
+++ b/tests/docker-compose-v3-event-driven-arm64.yml
@@ -36,7 +36,6 @@ services:
       - /tmp/videos:/videos
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_RECORD_VIDEO=true
       - SE_RETAIN_ON_FAILURE=true
       # Remote name and destination path to upload
       - SE_UPLOAD_DESTINATION_PREFIX=myftp://ftp/seluser
@@ -62,7 +61,6 @@ services:
       - /tmp/videos:/videos
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_RECORD_VIDEO=true
       - SE_RETAIN_ON_FAILURE=true
       # Remote name and destination path to upload
       - SE_UPLOAD_DESTINATION_PREFIX=myftp://ftp/seluser

--- a/tests/docker-compose-v3-event-driven-standalone-arm64.yml
+++ b/tests/docker-compose-v3-event-driven-standalone-arm64.yml
@@ -36,7 +36,6 @@ services:
       - /tmp/videos:/videos
     environment:
       - SE_VIDEO_RECORD_STANDALONE=true
-      - SE_RECORD_VIDEO=true
       - SE_VIDEO_UPLOAD_ENABLED=true
       - SE_DYNAMIC_OVERRIDE_MAX_SESSIONS=true
       - SE_DYNAMIC_MAX_SESSIONS=4

--- a/tests/docker-compose-v3-get-started-arm64.yml
+++ b/tests/docker-compose-v3-get-started-arm64.yml
@@ -14,8 +14,6 @@ services:
       - /tmp/videos:/videos
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
 
   firefox:
@@ -30,8 +28,6 @@ services:
       - /tmp/videos:/videos
     environment:
       - SE_EVENT_BUS_HOST=selenium-hub
-      - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_NODE_GRID_URL=http://selenium-hub:4444
 
   selenium-hub:

--- a/tests/docker-compose-v3-test-parallel.yml
+++ b/tests/docker-compose-v3-test-parallel.yml
@@ -31,8 +31,6 @@ services:
       - SE_DRAIN_AFTER_SESSION_COUNT=4
       - SE_ENABLE_TLS=true
       - SE_JAVA_OPTS=-Dwebdriver.httpclient.readTimeout=${REQUEST_TIMEOUT}
-      - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_SERVER_PROTOCOL=https
       - SE_NODE_GRID_URL=https://selenium-hub:4444
       - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}
@@ -65,8 +63,6 @@ services:
       - SE_DRAIN_AFTER_SESSION_COUNT=2
       - SE_ENABLE_TLS=true
       - SE_JAVA_OPTS=-Dwebdriver.httpclient.readTimeout=${REQUEST_TIMEOUT}
-      - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_SERVER_PROTOCOL=https
       - SE_NODE_GRID_URL=https://selenium-hub:4444
       - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}
@@ -97,8 +93,6 @@ services:
       - SE_DRAIN_AFTER_SESSION_COUNT=3
       - SE_ENABLE_TLS=true
       - SE_JAVA_OPTS=-Dwebdriver.httpclient.readTimeout=${REQUEST_TIMEOUT}
-      - SE_RECORD_VIDEO=true
-      - SE_VIDEO_FILE_NAME=auto
       - SE_SERVER_PROTOCOL=https
       - SE_NODE_GRID_URL=https://selenium-hub:4444
       - SE_NODE_STEREOTYPE_EXTRA={"myApp:version":"beta","myApp:publish":"public"}


### PR DESCRIPTION
<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
Container env var no need to set `SE_RECORD_VIDEO=true`
Whenever the session capability is set (`options.set_capability('se:recordVideo', True)` - example in Python), video service will start recording

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
