### PR TITLE
K8s: Migrate subchart Redis to cloudpirates/redis from bitnami/redis

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,10 +31,10 @@ CHROMIUM_VERSION := $(or $(CHROMIUM_VERSION),$(CHROMIUM_VERSION),latest)
 FIREFOX_DOWNLOAD_URL := $(or $(FIREFOX_DOWNLOAD_URL),$(FIREFOX_DOWNLOAD_URL),)
 SBOM_OUTPUT := $(or $(SBOM_OUTPUT),$(SBOM_OUTPUT),package_versions.txt)
 KEDA_TAG_PREV_VERSION := $(or $(KEDA_TAG_PREV_VERSION),$(KEDA_TAG_PREV_VERSION),2.19.0)
-KEDA_CORE_VERSION := $(or $(KEDA_CORE_VERSION),$(KEDA_CORE_VERSION),2.19.0)
-KEDA_TAG_VERSION := $(or $(KEDA_TAG_VERSION),$(KEDA_TAG_VERSION),2.19.0)
+KEDA_CORE_VERSION := $(or $(KEDA_CORE_VERSION),$(KEDA_CORE_VERSION),2.20.1)
+KEDA_TAG_VERSION := $(or $(KEDA_TAG_VERSION),$(KEDA_TAG_VERSION),2.20.1)
 KEDA_BASED_NAME := $(or $(KEDA_BASED_NAME),$(KEDA_BASED_NAME),kedacore)
-KEDA_BASED_TAG := $(or $(KEDA_BASED_TAG),$(KEDA_BASED_TAG),2.19.0)
+KEDA_BASED_TAG := $(or $(KEDA_BASED_TAG),$(KEDA_BASED_TAG),2.20.1)
 TEST_PATCHED_KEDA := $(or $(TEST_PATCHED_KEDA),$(TEST_PATCHED_KEDA),false)
 TRACING_EXPORTER_ENDPOINT := $(or $(TRACING_EXPORTER_ENDPOINT),$(TRACING_EXPORTER_ENDPOINT),http://\$$KUBERNETES_NODE_HOST_IP:4317)
 GHCR_NAMESPACE := $(or $(GHCR_NAMESPACE),$(GHCR_NAMESPACE),ghcr.io/seleniumhq)
@@ -487,8 +487,7 @@ tag_and_push_browser_images_ghcr:
 		node-firefox standalone-firefox; do \
 		docker images --format "{{.Tag}}" "$(NAME)/$$image" | grep -v "^<none>$$" | while IFS= read -r tag; do \
 		docker buildx imagetools create \
-		--tag $(GHCR_NAMESPACE)/$$image:$$tag \
-		docker.io/$(NAME)/$$image:$$tag ; \
+		--tag $(GHCR_NAMESPACE)/$$image:$$tag docker.io/$(NAME)/$$image:$$tag ; \
 	done ; \
 	done
 
@@ -496,16 +495,14 @@ mirror_browser_images_ghcr:
 	for image in node-$(BROWSER_NAME) standalone-$(BROWSER_NAME); do \
 		docker images --format "{{.Tag}}" "$(NAME)/$$image" | grep -v "^<none>$$" | while IFS= read -r tag; do \
 		docker buildx imagetools create \
-		--tag $(GHCR_NAMESPACE)/$$image:$$tag \
-		docker.io/$(NAME)/$$image:$$tag ; \
+		--tag $(GHCR_NAMESPACE)/$$image:$$tag docker.io/$(NAME)/$$image:$$tag ; \
 	done ; \
 	done
 
 mirror_browser_channel_image_ghcr:
 	for image in node-$(BROWSER_NAME) standalone-$(BROWSER_NAME); do \
 		docker buildx imagetools create \
-		--tag $(GHCR_NAMESPACE)/$$image:$(BROWSER_TAG) \
-		docker.io/$(NAME)/$$image:$(BROWSER_TAG) ; \
+		--tag $(GHCR_NAMESPACE)/$$image:$(BROWSER_TAG) docker.io/$(NAME)/$$image:$(BROWSER_TAG) ; \
 	done
 
 tag_ffmpeg_latest:
@@ -553,8 +550,7 @@ release_ffmpeg_latest:
 release_ffmpeg_ghcr_latest:
 	for tag in latest $(FFMPEG_VERSION) $(FFMPEG_VERSION)-$(BUILD_DATE); do \
 		docker buildx imagetools create \
-		--tag $(GHCR_NAMESPACE)/ffmpeg:$$tag \
-		docker.io/$(NAME)/ffmpeg:$$tag ; \
+		--tag $(GHCR_NAMESPACE)/ffmpeg:$$tag docker.io/$(NAME)/ffmpeg:$$tag ; \
 	done
 
 release_latest:
@@ -592,8 +588,7 @@ release_ghcr_latest:
 		standalone-edge standalone-firefox standalone-docker \
 		standalone-kubernetes standalone-all-browsers video; do \
 		docker buildx imagetools create \
-		--tag $(GHCR_NAMESPACE)/$$image:latest \
-		docker.io/$(NAME)/$$image:latest ; \
+		--tag $(GHCR_NAMESPACE)/$$image:latest docker.io/$(NAME)/$$image:latest ; \
 	done
 
 generate_latest_sbom:
@@ -667,8 +662,7 @@ release_ghcr_nightly:
 		standalone-edge standalone-firefox standalone-docker \
 		standalone-kubernetes standalone-all-browsers video; do \
 		docker buildx imagetools create \
-		--tag $(GHCR_NAMESPACE)/$$image:nightly \
-		docker.io/$(NAME)/$$image:nightly ; \
+		--tag $(GHCR_NAMESPACE)/$$image:nightly docker.io/$(NAME)/$$image:nightly ; \
 	done
 
 generate_nightly_sbom:
@@ -880,13 +874,11 @@ release_ghcr:
 		standalone-kubernetes standalone-all-browsers; do \
 		for tag in $(TAG_VERSION) $(MAJOR) $(MAJOR).$(MINOR) $(MAJOR_MINOR_PATCH); do \
 			docker buildx imagetools create \
-			--tag $(GHCR_NAMESPACE)/$$image:$$tag \
-			docker.io/$(NAME)/$$image:$$tag ; \
+			--tag $(GHCR_NAMESPACE)/$$image:$$tag docker.io/$(NAME)/$$image:$$tag ; \
 		done ; \
 	done
 	docker buildx imagetools create \
-	  --tag $(GHCR_NAMESPACE)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) \
-	  docker.io/$(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE)
+	  --tag $(GHCR_NAMESPACE)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) docker.io/$(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE)
 
 start_test_site:
 	@docker rm -f the-internet 2>/dev/null || true

--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -19,9 +19,9 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | Repository | Name | Version |
 |------------|------|---------|
 | https://charts.bitnami.com/bitnami | postgresql | ^18.0.0 |
-| https://charts.bitnami.com/bitnami | redis | ^25.0.0 |
+| https://cloudpirates-io.github.io/helm-charts | redis | ^0.30.0 |
 | https://jaegertracing.github.io/helm-charts | jaeger | ^4.0.0 |
-| https://kedacore.github.io/charts | keda | 2.19 |
+| https://kedacore.github.io/charts | keda | ^2.20.0 |
 | https://prometheus-community.github.io/helm-charts | kube-prometheus-stack | ^86.0.0 |
 | https://traefik.github.io/charts | traefik | ^40.0.0 |
 
@@ -232,10 +232,10 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | components.distributor.imagePullSecret | string | `""` | Image pull secret (see https://kubernetes.io/docs/tasks/configure-pod-container/pull-image-private-registry/) |
 | components.distributor.newSessionThreadPoolSize | string | `nil` | Configure fixed-sized thread pool for the Distributor to create new sessions as it consumes new session requests from the queue |
 | components.distributor.slotSelectorStrategy | string | `""` | Full class name of non-default slot selector. This is used to select a slot in a Node once the Node has been matched |
-| components.distributor.externalDatastore | object | `{"backend":"redis","enabled":false,"redis":{"implementation":"org.openqa.selenium.grid.distributor.redis.RedisBackedDistributor","url":"redis://{{ $.Release.Name }}-redis-master:6379"}}` | Configure external datastore for Distributor. When enabled, all replicas share state through the backend (node registrations, slot reservations, health-check coordination), allowing zero-downtime rolling restarts. |
+| components.distributor.externalDatastore | object | `{"backend":"redis","enabled":false,"redis":{"implementation":"org.openqa.selenium.grid.distributor.redis.RedisBackedDistributor","url":"redis://{{ $.Release.Name }}-redis:6379"}}` | Configure external datastore for Distributor. When enabled, all replicas share state through the backend (node registrations, slot reservations, health-check coordination), allowing zero-downtime rolling restarts. |
 | components.distributor.externalDatastore.enabled | bool | `false` | Enable external datastore for Distributor |
 | components.distributor.externalDatastore.backend | string | `"redis"` | Backend for external datastore (supported: redis) |
-| components.distributor.externalDatastore.redis | object | `{"implementation":"org.openqa.selenium.grid.distributor.redis.RedisBackedDistributor","url":"redis://{{ $.Release.Name }}-redis-master:6379"}` | Configure Redis backed Distributor |
+| components.distributor.externalDatastore.redis | object | `{"implementation":"org.openqa.selenium.grid.distributor.redis.RedisBackedDistributor","url":"redis://{{ $.Release.Name }}-redis:6379"}` | Configure Redis backed Distributor |
 | components.distributor.extraEnvironmentVariables | list | `[]` | Specify extra environment variables for Distributor |
 | components.distributor.extraEnvFrom | list | `[]` | Specify extra environment variables from ConfigMap and Secret for Distributor |
 | components.distributor.affinity | object | `{}` | Specify affinity for distributor pods, this overwrites global.seleniumGrid.affinity parameter |
@@ -315,7 +315,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | components.sessionMap.externalDatastore.enabled | bool | `false` | Enable external datastore for Session Map |
 | components.sessionMap.externalDatastore.backend | string | `"redis"` | Backend for external datastore (supported: postgresql, redis). Details for each backend are described below config key |
 | components.sessionMap.externalDatastore.postgresql | object | `{"implementation":"org.openqa.selenium.grid.sessionmap.jdbc.JdbcBackedSessionMap","jdbcPassword":"seluser","jdbcUrl":"jdbc:postgresql://{{ $.Release.Name }}-postgresql:5432/selenium_sessions","jdbcUser":"seluser"}` | Configure database backed Session Map (https://www.selenium.dev/documentation/grid/advanced_features/external_datastore/#database-backed-session-map) |
-| components.sessionMap.externalDatastore.redis | object | `{"hostname":"{{ $.Release.Name }}-redis-master","implementation":"org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap","port":"6379","scheme":"redis"}` | Configure Redis backed Session Map (https://www.selenium.dev/documentation/grid/advanced_features/external_datastore/#redis-backed-session-map) |
+| components.sessionMap.externalDatastore.redis | object | `{"hostname":"{{ $.Release.Name }}-redis","implementation":"org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap","port":"6379","scheme":"redis"}` | Configure Redis backed Session Map (https://www.selenium.dev/documentation/grid/advanced_features/external_datastore/#redis-backed-session-map) |
 | components.sessionQueue.imageRegistry | string | `nil` | Registry to pull the image (this overwrites global.seleniumGrid.imageRegistry parameter) |
 | components.sessionQueue.imageName | string | `"session-queue"` | Session Queue image name |
 | components.sessionQueue.imageTag | string | `nil` | Session Queue image tag (this overwrites global.seleniumGrid.imageTag parameter) |
@@ -795,7 +795,6 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | postgresql.auth | object | `{"database":"selenium_sessions","password":"seluser","username":"seluser"}` | Authentication should be aligned with config in session map |
 | postgresql.primary.initdb.scripts | object | `{"init.sql":"CREATE TABLE IF NOT EXISTS sessions_map(\n  session_ids varchar(256),\n  session_caps text,\n  session_uri varchar(256),\n  session_stereotype text,\n  session_start varchar(256)\n);\n"}` | Initdb scripts for PostgreSQL to create sessions_map table |
 | redis.enabled | bool | `false` | Enable to install Redis along with Grid |
-| redis.image.repository | string | `"bitnamilegacy/redis"` |  |
 | redis.architecture | string | `"standalone"` | Setup architecture |
 | redis.auth.enabled | bool | `false` | Disable authentication due to implementation still not supporting it |
 

--- a/charts/selenium-grid/Chart.yaml
+++ b/charts/selenium-grid/Chart.yaml
@@ -7,7 +7,7 @@ appVersion: 4.44.0-20260505
 icon: https://github.com/SeleniumHQ/docker-selenium/raw/trunk/logo.png
 dependencies:
 - repository: https://kedacore.github.io/charts
-  version: 2.19
+  version: ^2.20.0
   name: keda
   condition: autoscaling.enabled, keda.enabled
 - repository: https://traefik.github.io/charts
@@ -26,8 +26,8 @@ dependencies:
   version: ^18.0.0
   name: postgresql
   condition: postgresql.enabled
-- repository: https://charts.bitnami.com/bitnami
-  version: ^25.0.0
+- repository: https://cloudpirates-io.github.io/helm-charts
+  version: ^0.30.0
   name: redis
   condition: redis.enabled
 maintainers:

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -577,7 +577,7 @@ components:
       # -- Configure Redis backed Distributor
       redis:
         implementation: "org.openqa.selenium.grid.distributor.redis.RedisBackedDistributor"
-        url: "redis://{{ $.Release.Name }}-redis-master:6379"
+        url: "redis://{{ $.Release.Name }}-redis:6379"
     # -- Specify extra environment variables for Distributor
     extraEnvironmentVariables: []
     # -- Specify extra environment variables from ConfigMap and Secret for Distributor
@@ -794,7 +794,7 @@ components:
       redis:
         scheme: "redis"
         implementation: "org.openqa.selenium.grid.sessionmap.redis.RedisBackedSessionMap"
-        hostname: "{{ $.Release.Name }}-redis-master"
+        hostname: "{{ $.Release.Name }}-redis"
         port: "6379"
 
   # Configuration for Session Queue component
@@ -2371,12 +2371,10 @@ postgresql:
             session_start varchar(256)
           );
 
-# Configuration for dependency chart Redis (README: https://artifacthub.io/packages/helm/bitnami/redis)
+# Configuration for dependency chart Redis (README: https://artifacthub.io/packages/helm/cloudpirates/redis)
 redis:
   # -- Enable to install Redis along with Grid
   enabled: false
-  image:
-    repository: bitnamilegacy/redis
   # -- Setup architecture
   architecture: standalone
   auth:

--- a/tests/charts/config/ct.yaml
+++ b/tests/charts/config/ct.yaml
@@ -9,6 +9,7 @@ chart-repos:
   - jaegertracing=https://jaegertracing.github.io/helm-charts
   - prometheusCommunity=https://prometheus-community.github.io/helm-charts
   - bitnami=https://charts.bitnami.com/bitnami
+  - cloudpirates=https://cloudpirates-io.github.io/helm-charts
 upgrade: false
 helm-extra-args: --timeout 600s
 check-version-increment: false


### PR DESCRIPTION
<h3>PR Summary by Qodo</h3>

Helm: Switch Redis subchart to cloudpirates and align Redis service endpoints
<code>✨ Enhancement</code> <code>⚙️ Configuration changes</code> <code>📝 Documentation</code> <code>🕐 20-40 Minutes</code>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>Walkthroughs</h3>

<details open>
<summary>User Description</summary>

<br/>

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->

</details>

<details open>
<summary>AI Description</summary>

<br/>

<pre>
• Migrate Helm dependency Redis from Bitnami to cloudpirates and add chart repo for testing.
• Update Redis-backed external datastore defaults to use the new Redis service name.
• Bump KEDA chart/version references and tidy GHCR imagetools tag commands.
</pre>
</details>

<details>
<summary>Diagram</summary>

<br/>

```mermaid
graph TD
  A["selenium-grid Helm chart"] --> B["Chart.yaml deps"] --> R[("Redis subchart")]
  A --> V["values.yaml"] --> E["Redis endpoints"]
  A --> D["CONFIGURATION.md"]
  T["ct.yaml chart repos"] --> R
```

</details>




<details>
<summary>High-Level Assessment</summary>

<br/>

The following are alternative approaches to this PR:

<details>
<summary><b>1. Stay on Bitnami Redis (non-legacy) and adjust values</b></summary>

- ➕ Avoids changing dependency source/repo for consumers
- ➕ May reduce ecosystem divergence if Bitnami remains the standard
- ➖ May not address the reason for leaving Bitnami (maintenance/licensing/packaging constraints)
- ➖ Still requires ongoing compatibility work as Bitnami chart conventions change

</details>

<details>
<summary><b>2. Remove bundled Redis; require external/managed Redis</b></summary>

- ➕ Reduces Helm dependency footprint and install complexity
- ➕ Aligns with typical production setups using managed Redis
- ➖ Degrades out-of-the-box experience for users who rely on bundled Redis
- ➖ Requires more user-provided config and validation logic

</details>

**Recommendation:** Proceed with the cloudpirates/redis migration as implemented: dependency metadata, docs, chart-testing repos, and default Redis endpoints are updated consistently. In review, validate the cloudpirates chart’s Service name/port and that auth-disabled mode still matches Selenium Grid’s Redis client assumptions.

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">

<h3>File Changes</h3>

<details>
<summary><strong>Documentation</strong> (1)</summary>

<blockquote>
<details>
<summary><strong>CONFIGURATION.md</strong> <code>Document cloudpirates Redis dependency and updated Redis service hostnames</code> <code>+5/-6</code></summary>

<br/>

>Document cloudpirates Redis dependency and updated Redis service hostnames
>
><pre>
>• Replaces the Bitnami Redis dependency entry with cloudpirates/redis and bumps the documented KEDA chart version constraint. Updates Redis-backed external datastore examples to use &#x27;{{ $.Release.Name }}-redis&#x27; instead of &#x27;-redis-master&#x27;, and removes the Bitnami legacy Redis image repository note.
></pre>
>
><a href='https://github.com/SeleniumHQ/docker-selenium/pull/3148/files#diff-8f21b9acf6691fc99d88780146e016715fe83ed0b5ef37fe81455f892d347786'>charts/selenium-grid/CONFIGURATION.md</a>
<hr/>

</details>
</blockquote>

</details>

<details>
<summary><strong>Other</strong> (4)</summary>

<blockquote>
<details>
<summary><strong>Makefile</strong> <code>Bump KEDA versions and tighten GHCR imagetools command formatting</code> <code>+11/-19</code></summary>

<br/>

>Bump KEDA versions and tighten GHCR imagetools command formatting
>
><pre>
>• Updates KEDA version variables from 2.19.0 to 2.20.1. Reformats several &#x27;docker buildx imagetools create&#x27; invocations to keep &#x27;--tag&#x27; and the source image on a single line.
></pre>
>
><a href='https://github.com/SeleniumHQ/docker-selenium/pull/3148/files#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52'>Makefile</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>Chart.yaml</strong> <code>Switch Redis dependency to cloudpirates and bump KEDA chart constraint</code> <code>+3/-3</code></summary>

<br/>

>Switch Redis dependency to cloudpirates and bump KEDA chart constraint
>
><pre>
>• Updates the KEDA dependency constraint to &#x27;^2.20.0&#x27;. Migrates the Redis dependency repository to &#x27;https://cloudpirates-io.github.io/helm-charts&#x27; and sets its version constraint to &#x27;^0.30.0&#x27;.
></pre>
>
><a href='https://github.com/SeleniumHQ/docker-selenium/pull/3148/files#diff-2b5986f61311d561a9497008138d7238cc08e721bd34f673c94e03ba0068a731'>charts/selenium-grid/Chart.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>values.yaml</strong> <code>Align Redis external datastore defaults with new subchart service name</code> <code>+3/-5</code></summary>

<br/>

>Align Redis external datastore defaults with new subchart service name
>
><pre>
>• Updates default Redis URLs/hostnames used by Distributor and Session Map external datastore configs to point at &#x27;{{ $.Release.Name }}-redis&#x27; instead of &#x27;-redis-master&#x27;. Updates the Redis dependency README link and removes the pinned Bitnami legacy image override.
></pre>
>
><a href='https://github.com/SeleniumHQ/docker-selenium/pull/3148/files#diff-78eaafaacc320a0b69216c3173a3961d2305653ce2c9f054fb4d42d90f71813e'>charts/selenium-grid/values.yaml</a>
<hr/>

</details>
</blockquote>

<blockquote>
<details>
<summary><strong>ct.yaml</strong> <code>Add cloudpirates Helm repo for chart-testing</code> <code>+1/-0</code></summary>

<br/>

>Add cloudpirates Helm repo for chart-testing
>
><pre>
>• Registers the &#x27;cloudpirates&#x27; Helm repository so chart-testing can resolve the new Redis dependency during CI/test runs.
></pre>
>
><a href='https://github.com/SeleniumHQ/docker-selenium/pull/3148/files#diff-b829ff8918c1eb9396994926b3337e8e00683cf8e0ca57e00021285ea16c51ef'>tests/charts/config/ct.yaml</a>
<hr/>

</details>
</blockquote>

</details>

<img src="https://www.qodo.ai/wp-content/uploads/2025/11/light-grey-line.svg" height="10%" alt="Grey Divider">


<a href="https://www.qodo.ai"><img src="https://www.qodo.ai/wp-content/uploads/2025/03/qodo-logo.svg" width="80" alt="Qodo Logo"></a>