### PR TITLE
Docker: Fix video.sh busy-loop when se:recordVideo=false (#3164)

### DIFF
--- a/Video/video.sh
+++ b/Video/video.sh
@@ -255,6 +255,7 @@ else
   video_file_name=""
   video_file=""
   prev_session_id=""
+  skipped_session_id=""
   attempts=0
   max_recorded_count=${SE_DRAIN_AFTER_SESSION_COUNT:-0}
   recorded_count=0
@@ -262,7 +263,7 @@ else
   wait_for_api_respond
   while curl --noproxy "*" "${auth_header[@]}" -sk --request GET ${NODE_STATUS_ENDPOINT} >"/tmp/status.json"; do
     session_id="$(jq -r "${JQ_SESSION_ID_QUERY}" "/tmp/status.json")"
-    if [[ "$session_id" != "null" && "$session_id" != "" && "$session_id" != "reserved" && "$recording_started" = "false" ]]; then
+    if [[ "$session_id" != "null" && "$session_id" != "" && "$session_id" != "reserved" && "$recording_started" = "false" && "$session_id" != "$skipped_session_id" ]]; then
       echo "$(date -u +"${ts_format}") [${process_name}] - Session: $session_id is created"
       session_capabilities="$(jq -r "${JQ_SESSION_CAPABILITIES_QUERY}" "/tmp/status.json")"
       return_list=($(python3 "${VIDEO_CONFIG_DIRECTORY}/video_nodeQuery.py" "${session_id}" "${session_capabilities}"))
@@ -291,8 +292,11 @@ else
           prev_session_id=$session_id
         fi
         echo "$(date -u +"${ts_format}") [${process_name}] - Video recording started"
-        sleep ${poll_interval}
+      else
+        echo "$(date -u +"${ts_format}") [${process_name}] - Recording skipped for session: $session_id (se:recordVideo=false)"
+        skipped_session_id="$session_id"
       fi
+      sleep ${poll_interval}
     elif [[ "$session_id" != "$prev_session_id" && "$recording_started" = "true" ]]; then
       stop_recording
       if [[ $max_recorded_count -gt 0 ]] && [[ $recorded_count -ge $max_recorded_count ]]; then


### PR DESCRIPTION
When a session capability sets se:recordVideo=false, the recorder's polling loop skipped the sleep before looping back to re-check the node status, since the sleep only ran inside the
`caps_se_video_record = "true"` branch. With recording_started staying false and the same session id still active, this caused a tight loop (curl + jq + python3 video_nodeQuery.py subprocess) with no delay for the entire remaining duration of that session, consuming CPU shared with the browser process (most noticeable with
videoRecorder.sidecarContainer=false).

Add the missing sleep after the if/else, and track the last skipped session id so the script does not keep re-invoking video_nodeQuery.py for a session that was already decided not to be recorded.

Fixes #3164

<!-- Thanks for sending us a PR to improve this project! If you are adding a 
feature or fixing a bug, and this needs more documentation, please add it to your PR. -->

**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

Before submitting your PR, please check our [contributing](https://selenium.dev/documentation/en/contributing/) guidelines, applied for this repository.
Avoid large PRs, help reviewers by making them as simple and short as possible.


<!--- Provide a general summary of your changes in the Title above -->

### Description
<!--- Describe your changes in detail -->

### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [ ] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
<!--- Provide a general summary of your changes in the Title above -->
Closes #3164