### PR TITLE
K8s: Gate distributed component replicas on external datastore

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -341,6 +341,22 @@ Component update strategy template
 {{- end -}}
 
 {{/*
+Replica count for a distributed component (Distributor, SessionQueue, SessionMap).
+The value from `.replicas` is honored only when the component's external datastore is
+enabled, since replicas share state through it. Without an external datastore, running
+multiple replicas would break the grid (no shared state), so the count is forced to 1.
+Pass the component config, e.g. `.Values.components.distributor`.
+*/}}
+{{- define "seleniumGrid.component.replicaCount" -}}
+{{- $component := . -}}
+{{- if (dig "externalDatastore" "enabled" false $component) -}}
+{{- max 1 ($component.replicas | int) -}}
+{{- else -}}
+1
+{{- end -}}
+{{- end -}}
+
+{{/*
 Common pod template
 */}}
 {{- define "seleniumGrid.podTemplate" -}}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   strategy:
     {{- template "seleniumGrid.updateStrategy" (list $.Values.components.distributor $.Values.global.seleniumGrid) }}
-  replicas: {{ max 1 (.Values.components.distributor.replicas | int) }}
+  replicas: {{ include "seleniumGrid.component.replicaCount" .Values.components.distributor }}
   revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   strategy:
     {{- template "seleniumGrid.updateStrategy" (list $.Values.components.sessionMap $.Values.global.seleniumGrid) }}
-  replicas: {{ max 1 (.Values.components.sessionMap.replicas | int) }}
+  replicas: {{ include "seleniumGrid.component.replicaCount" .Values.components.sessionMap }}
   revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:

--- a/charts/selenium-grid/templates/session-queue-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queue-deployment.yaml
@@ -11,7 +11,7 @@ metadata:
 spec:
   strategy:
     {{- template "seleniumGrid.updateStrategy" (list $.Values.components.sessionQueue $.Values.global.seleniumGrid) }}
-  replicas: {{ max 1 (.Values.components.sessionQueue.replicas | int) }}
+  replicas: {{ include "seleniumGrid.component.replicaCount" .Values.components.sessionQueue }}
   revisionHistoryLimit: {{ .Values.global.seleniumGrid.revisionHistoryLimit }}
   selector:
     matchLabels:


### PR DESCRIPTION
## What

In distributed mode (`isolateComponents: true`), the Distributor, SessionQueue, and SessionMap components can be scaled to multiple replicas only when they share state through an external datastore (Redis/Postgres). This gates the replica count on that datastore so multi-replica setups without shared state can't be created by accident.

- Adds a `seleniumGrid.component.replicaCount` helper: it honors `components.<x>.replicas` when that component's `externalDatastore.enabled` is true, and otherwise forces `1` (nil-safe via `dig`).
- Uses it in the three distributed-mode deployments: `distributor`, `session-queue`, `session-map`.

Replica counts remain fully settable from chart values once a datastore is configured — this only prevents the silently-broken case of >1 replica with no shared state.

## Why

Running multiple Distributor/SessionQueue/SessionMap replicas without a shared datastore breaks the grid (each replica has independent state). Previously `replicas: {{ max 1 (...) }}` allowed >1 regardless of datastore.

## Verify

`helm template` with `isolateComponents=true`:

| Scenario | distributor | session-queue | session-map |
|---|---|---|---|
| datastore ON, replicas 3/2/4 | 3 | 2 | 4 |
| datastore OFF, replicas 3/2/4 | 1 | 1 | 1 |
| mixed (only sessionMap datastore ON), all replicas=5 | 1 | 1 | 5 |

`helm lint` passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)