### PR TITLE
[build] Keep Chrome dev/beta images on linux/amd64 only, resolve the latest rclone tag

### DIFF
--- a/.ffmpeg/Dockerfile
+++ b/.ffmpeg/Dockerfile
@@ -1,6 +1,6 @@
 FROM ubuntu:noble AS builder
 ARG FFMPEG_VERSION="8.1"
-ARG RCLONE_VER="v1.75-stable"
+ARG RCLONE_VER="latest"
 ARG GO_VERSION="latest"
 #ARG GO_CRYPTO_VERSION="v0.36.0"
 #ARG GO_OAUTH2_VERSION="v0.27.0"
@@ -33,6 +33,11 @@ RUN if [ "${GO_VERSION}" = "latest" ]; then \
     && go version
 
 RUN cd /usr/local/src \
+    && if [ "${RCLONE_VER}" = "latest" ]; then \
+        RCLONE_VER=$(git ls-remote --tags --refs https://github.com/rclone/rclone.git \
+        | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1); \
+    fi \
+    && echo "Building rclone ${RCLONE_VER}" \
     && git clone -b ${RCLONE_VER} --single-branch --depth 1 https://github.com/rclone/rclone.git \
     && cd rclone \
     # Patch deps version in go.mod to fix CVEs

--- a/.ffmpeg/Dockerfile
+++ b/.ffmpeg/Dockerfile
@@ -34,8 +34,11 @@ RUN if [ "${GO_VERSION}" = "latest" ]; then \
 
 RUN cd /usr/local/src \
     && if [ "${RCLONE_VER}" = "latest" ]; then \
-        RCLONE_VER=$(git ls-remote --tags --refs https://github.com/rclone/rclone.git \
-        | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1); \
+        RCLONE_VER=$(curl -sk https://api.github.com/repos/rclone/rclone/releases/latest | jq -r '.tag_name // empty'); \
+        if [ -z "${RCLONE_VER}" ]; then \
+            RCLONE_VER=$(git ls-remote --tags --refs https://github.com/rclone/rclone.git \
+            | sed 's#.*refs/tags/##' | grep -E '^v[0-9]+\.[0-9]+\.[0-9]+$' | sort -V | tail -n 1); \
+        fi; \
     fi \
     && echo "Building rclone ${RCLONE_VER}" \
     && git clone -b ${RCLONE_VER} --single-branch --depth 1 https://github.com/rclone/rclone.git \

--- a/.github/workflows/update-dev-beta-browser-images.yml
+++ b/.github/workflows/update-dev-beta-browser-images.yml
@@ -30,12 +30,14 @@ jobs:
       fail-fast: false
       matrix:
         include:
+          # Chrome dev/beta are ahead of the Chromium driver packages, which follow the
+          # stable channel, so there is no matching driver for those majors on arm64
           - browser: chrome
             channel: dev
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - browser: chrome
             channel: beta
-            platforms: linux/amd64,linux/arm64
+            platforms: linux/amd64
           - browser: firefox
             channel: dev
             platforms: linux/amd64,linux/arm64

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ Note:
 - Google Chrome (`google-chrome`) now is available for Linux/ARM64 via APT stable channel from v150+. The Chrome (node and standalone) images are available in multi-arch. Older Chrome versions remain AMD64 only; the supported platforms per version are tracked in the [browser matrix](tests/build-backward-compatible/browser-matrix.yml) via the `CHROME_PLATFORMS` key.
 Microsoft does not build Edge (`microsoft-edge`) for Linux/ARM platforms, hence the Edge (node and standalone) images are only available for AMD64.
 
-- Google does not publish a ChromeDriver build for Linux/ARM64 (Chrome for Testing only ships `linux64`). On ARM64 the Chrome images use the Chromium driver of the same major version instead, taken from the Debian `chromium-driver` package archived at [NDViet/chromium-stable](https://github.com/NDViet/chromium-stable).
+- Google does not publish a ChromeDriver build for Linux/ARM64 (Chrome for Testing only ships `linux64`). On ARM64 the Chrome images use the Chromium driver of the same major version instead, taken from the Debian `chromium-driver` package archived at [NDViet/chromium-stable](https://github.com/NDViet/chromium-stable). Those packages follow the stable channel, hence the Chrome `dev` and `beta` images are only available for AMD64.
 
 - We also supply Chrome for Testing (CfT), but it is only available for Linux/AMD64.
 


### PR DESCRIPTION
**Thanks for contributing to the Docker-Selenium project!**
**A PR well described will help maintainers to quickly review and merge it**

### Description

Two build fixes after #3187.

**Chrome dev/beta images back to `linux/amd64` only**

- `.github/workflows/update-dev-beta-browser-images.yml`: Chrome dev/beta build for `linux/amd64` again, with a comment explaining why. Firefox dev/beta stay multi-arch and the stable Chrome images stay multi-arch.
- `README.md`: note that the Chrome dev/beta images are AMD64 only.

**Video image resolves the rclone version itself**

- `.ffmpeg/Dockerfile`: `RCLONE_VER` defaults to `latest` and is resolved from the rclone GitHub releases, which are sorted by publish date, so the most recently tagged release is used. `git ls-remote --sort=-creatordate` can not do this, sorting remote refs by date needs object data that is not available without a repository, so a version sorted tag list is kept as a fallback for when the API returns nothing, for instance when it is rate limited. An explicit `RCLONE_VER` is still used as is.

### Motivation and Context

**Chrome dev/beta**

Google publishes no ChromeDriver for Linux/ARM64, so the ARM64 Chrome images use the Debian `chromium-driver` package of the same major version instead. Those packages follow the stable channel and currently top out at 151, while Chrome beta is 152 and dev is 153, so no matching driver major exists for those channels and the build fails:

```
Detected architecture: arm64
Detected Chrome major version: 152
Google does not build ChromeDriver for linux/arm64, getting the Chromium driver version from https://raw.githubusercontent.com/NDViet/chromium-stable/refs/heads/main/browser-matrix.yml
Chromium driver package for major version 152 is not available yet, it can not be installed on linux/arm64
ERROR: process "/bin/sh -c chmod +x /opt/bin/install-chromedriver.sh && /opt/bin/install-chromedriver.sh" did not complete successfully: exit code: 1
```

This is structural rather than a temporary lag: a Chromium driver for a given major only lands once that major reaches stable, which is exactly when the version stops being dev/beta.

**rclone**

`RCLONE_VER` pointed at `v1.75-stable`, a maintenance branch rclone has not cut yet, so the clone failed and the video image could not build:

```
warning: Could not find remote branch v1.75-stable to clone.
fatal: Remote branch v1.75-stable not found in upstream origin
```

Resolving the version at build time also keeps the video image on the current rclone release without a manual bump. Verified in a container: the latest release resolves to `v1.75.0`, the shallow clone succeeds and `make` builds `rclone v1.75.0`.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [x] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
