### PR TITLE
[video] Fall back to SE_NODE_CONTAINER_NAME for the per-session subfolder

### DIFF
--- a/Video/video.sh
+++ b/Video/video.sh
@@ -273,9 +273,19 @@ else
         echo "$(date -u +"${ts_format}") [${process_name}] - Start recording: $caps_se_video_record, video file name: $video_file_name"
         log_node_response
         if [[ "${SE_VIDEO_SESSION_SUBFOLDER}" = "true" ]]; then
-          video_dir="${VIDEO_FOLDER}/${session_id}"
-          mkdir -p "${video_dir}"
-          echo "$(date -u +"${ts_format}") [${process_name}] - Created session subfolder: ${video_dir}"
+          # Group each recording under its session id. If the session id is empty for any reason,
+          # fall back to the Node container/Pod name so the video still lands in a unique subfolder.
+          subfolder_key="${session_id}"
+          if [ -z "${subfolder_key}" ] || [ "${subfolder_key}" = "null" ]; then
+            subfolder_key="${SE_NODE_CONTAINER_NAME}"
+          fi
+          if [ -n "${subfolder_key}" ]; then
+            video_dir="${VIDEO_FOLDER}/${subfolder_key}"
+            mkdir -p "${video_dir}"
+            echo "$(date -u +"${ts_format}") [${process_name}] - Created session subfolder: ${video_dir}"
+          else
+            video_dir="${VIDEO_FOLDER}"
+          fi
         else
           video_dir="${VIDEO_FOLDER}"
         fi

--- a/Video/video_service.py
+++ b/Video/video_service.py
@@ -768,10 +768,15 @@ class VideoService:
         record_video, video_filename = self.get_video_filename(session_id, capabilities)
 
         if record_video and self.session_subfolder:
-            session_subdir = Path(self.video_folder) / session_id
-            session_subdir.mkdir(parents=True, exist_ok=True)
-            video_filename = f"{session_id}/{video_filename}"
-            logger.info(f"Created session subfolder: {session_subdir}")
+            # Group each recording under its session id. If the session id is empty for any reason,
+            # fall back to the Node container/Pod name so the video still lands in a unique subfolder
+            # (important on Kubernetes where the assets volume is shared across Pods).
+            subfolder_key = session_id or os.environ.get("SE_NODE_CONTAINER_NAME", "").strip()
+            if subfolder_key:
+                session_subdir = Path(self.video_folder) / subfolder_key
+                session_subdir.mkdir(parents=True, exist_ok=True)
+                video_filename = f"{subfolder_key}/{video_filename}"
+                logger.info(f"Created session subfolder: {session_subdir}")
 
         retain_on_failure_cap = capabilities.get("se:retainOnFailure", None)
         if retain_on_failure_cap is None:


### PR DESCRIPTION
### Description
When `SE_VIDEO_SESSION_SUBFOLDER=true`, the recorder groups each video under its session id (`<video_folder>/<sessionId>/<name>.mp4`). This adds a fallback: if the session id is empty for any reason, the recorder uses `SE_NODE_CONTAINER_NAME` (the Node container / Pod name) as the subfolder key instead. Applied to both recorder backends:

- `Video/video.sh` (shell / polling)
- `Video/video_service.py` (event-driven)

If neither a session id nor `SE_NODE_CONTAINER_NAME` is available, it records flat as before.

### Motivation and Context
Pairs with the Grid core change in SeleniumHQ/selenium#17876, which makes the Kubernetes Dynamic Grid always use the per-session subfolder approach and removes the Node-side pod-wait + video relocation. With relocation gone, the recorder owns the final path — so it must always produce a per-session folder. On Kubernetes the assets volume is shared (ReadWriteMany) across Pods, so a flat recording would collide; falling back to the Pod name (passed by the Grid as `SE_NODE_CONTAINER_NAME` via the downward API) guarantees a unique folder even if a session id is ever missing.

### Types of changes
- [x] Bug fix (non-breaking change which fixes an issue)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist
- [x] I have read the contributing document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.

<sub>🤖 Generated with [Claude Code](https://claude.com/claude-code)</sub>