### PR TITLE
fix(chart): expose external scaler securityContext with seccompProfile (#3196)

### DIFF
--- a/charts/selenium-grid/CONFIGURATION.md
+++ b/charts/selenium-grid/CONFIGURATION.md
@@ -461,6 +461,7 @@ A Helm chart for creating a Selenium Grid Server in Kubernetes
 | autoscaling.externalScaler.nodeSelector | object | `{}` | Node selector for the external scaler |
 | autoscaling.externalScaler.tolerations | list | `[]` | Tolerations for the external scaler |
 | autoscaling.externalScaler.resources | object | `{"limits":{"cpu":"200m","memory":"128Mi"},"requests":{"cpu":"50m","memory":"32Mi"}}` | Resources for the external scaler container |
+| autoscaling.externalScaler.securityContext | object | `{"allowPrivilegeEscalation":false,"capabilities":{"drop":["ALL"]},"readOnlyRootFilesystem":true,"runAsGroup":65532,"runAsNonRoot":true,"runAsUser":65532,"seccompProfile":{"type":"RuntimeDefault"}}` | SecurityContext for the external scaler container. Defaults comply with Pod Security Admission `restricted` and Kyverno seccomp policies; override to customize. |
 | autoscaling.defaultTriggerType | string | `"selenium-grid"` | Default type of trigger to use (`selenium-grid` is build-in scaler in KEDA) |
 | autoscaling.defaultTriggerName | string | `"seleniumGrid"` | Default alias name of trigger type (which is used in formula if you want to add scalingModifiers to advanced spec) |
 | autoscaling.scaledOptions | object | `{"maxReplicaCount":24,"minReplicaCount":0,"pollingInterval":20,"triggers":[]}` | Options for KEDA scaled resources (keep only common options used for both ScaledJob and ScaledObject) |

--- a/charts/selenium-grid/templates/external-scaler.yaml
+++ b/charts/selenium-grid/templates/external-scaler.yaml
@@ -77,14 +77,10 @@ spec:
           resources:
             {{- toYaml . | nindent 12 }}
           {{- end }}
+          {{- with $scaler.securityContext }}
           securityContext:
-            allowPrivilegeEscalation: false
-            readOnlyRootFilesystem: true
-            runAsNonRoot: true
-            runAsUser: 65532
-            runAsGroup: 65532
-            capabilities:
-              drop: ["ALL"]
+            {{- toYaml . | nindent 12 }}
+          {{- end }}
       {{- with $scaler.nodeSelector }}
       nodeSelector:
         {{- toYaml . | nindent 8 }}

--- a/charts/selenium-grid/values.yaml
+++ b/charts/selenium-grid/values.yaml
@@ -1216,6 +1216,17 @@ autoscaling:
       limits:
         cpu: 200m
         memory: 128Mi
+    # -- SecurityContext for the external scaler container. Defaults comply with Pod Security Admission `restricted` and Kyverno seccomp policies; override to customize.
+    securityContext:
+      allowPrivilegeEscalation: false
+      readOnlyRootFilesystem: true
+      runAsNonRoot: true
+      runAsUser: 65532
+      runAsGroup: 65532
+      seccompProfile:
+        type: RuntimeDefault
+      capabilities:
+        drop: ["ALL"]
   # -- Default type of trigger to use (`selenium-grid` is build-in scaler in KEDA)
   defaultTriggerType: "selenium-grid"
   # -- Default alias name of trigger type (which is used in formula if you want to add scalingModifiers to advanced spec)


### PR DESCRIPTION
## Fixes #3196

The KEDA external scaler `Deployment` introduced in chart 0.57.0 hardcodes its container `securityContext` and omits `seccompProfile`. On clusters enforcing Pod Security Admission `restricted` or Kyverno `restrict-seccomp-strict`, the deployment is rejected:

> validation error: ... spec.securityContext.seccompProfile.type ... must be set to `RuntimeDefault` or `Localhost`.

Because the values were hardcoded, users had no values-level way to fix it — the only workaround was disabling the external scaler entirely (`autoscaling.externalScaler.enabled: false`).

## Changes

- **`values.yaml`** — Add a configurable `autoscaling.externalScaler.securityContext` value (matching the pattern used by other chart components such as `hub` and the nodes). Its default preserves the previously hardened settings **and adds `seccompProfile: {type: RuntimeDefault}`**, so the chart is PSA `restricted` compliant out of the box.
- **`templates/external-scaler.yaml`** — Render the value via `{{- with $scaler.securityContext }}` instead of hardcoding, so it is fully overridable (and can be disabled by setting it to `null`).
- **`CONFIGURATION.md`** — Regenerated via helm-docs.

This addresses both remediation options requested in the issue: the securityContext is now configurable **and** compliant by default.

## Verification

- `helm lint` passes.
- Default render now emits `seccompProfile.type: RuntimeDefault` alongside the existing hardening.
- Override render (e.g. `--set autoscaling.externalScaler.securityContext.seccompProfile.type=Localhost`) merges correctly.
- Setting the value to `null` cleanly omits the block for users who manage security context at the pod level.

🤖 Generated with [Claude Code](https://claude.com/claude-code)