### PR TITLE
test(go): unit tests + CI coverage gate for exporter and external scaler

### DIFF
--- a/.github/workflows/go-test.yml
+++ b/.github/workflows/go-test.yml
@@ -1,0 +1,85 @@
+name: Go Unit Tests
+
+# Guards the in-repo Go modules against regressions introduced by Go toolchain
+# bumps or dependency updates. The job runs on every PR/push that touches either
+# module — including the `make update_go` and Renovate PRs that rewrite
+# go.mod/go.sum — and picks its Go version from each module's go.mod, so a
+# toolchain bump is exercised on the exact version it lands.
+
+on:
+  push:
+    branches:
+      - trunk
+    paths:
+      - '.monitoring/exporter/**'
+      - '.keda-external-scaler/**'
+      - '.github/workflows/go-test.yml'
+  pull_request:
+    paths:
+      - '.monitoring/exporter/**'
+      - '.keda-external-scaler/**'
+      - '.github/workflows/go-test.yml'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: ${{ matrix.name }}
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - name: selenium-grid-exporter
+            module: .monitoring/exporter
+          - name: keda-external-scaler
+            module: .keda-external-scaler
+    defaults:
+      run:
+        working-directory: ${{ matrix.module }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+
+      - name: Set up Go
+        uses: actions/setup-go@main
+        with:
+          # Track the Go version pinned in the module so update_go/Renovate bumps
+          # are validated on the version they introduce.
+          go-version-file: ${{ matrix.module }}/go.mod
+          check-latest: true
+
+      - name: Go version
+        run: go version
+
+      - name: Verify module dependencies
+        run: go mod verify
+
+      - name: Ensure go.mod/go.sum are tidy
+        # Catches dependency updates that forgot to run `go mod tidy`.
+        run: |
+          go mod tidy
+          git diff --exit-code -- go.mod go.sum
+
+      - name: Vet
+        run: go vet ./...
+
+      - name: Build
+        run: go build ./...
+
+      - name: Test (race + coverage)
+        run: go test ./... -race -covermode=atomic -coverprofile=cover.out
+
+      - name: Enforce coverage threshold
+        # Business logic must stay >=90% covered so a Go/deps bump can't silently
+        # erode test quality. Generated protobuf stubs (*.pb.go) are excluded.
+        run: |
+          grep -v '\.pb\.go:' cover.out > cover.filtered || cp cover.out cover.filtered
+          go tool cover -func=cover.filtered | tail -n 30
+          total=$(go tool cover -func=cover.filtered | awk '/^total:/ {print $3}' | tr -d '%')
+          echo "Coverage (excluding generated code): ${total}%"
+          awk -v t="$total" 'BEGIN { if (t+0 < 90.0) { printf "FAIL: coverage %.1f%% is below the 90%% threshold\n", t; exit 1 } }'

--- a/.keda-external-scaler/cmd/scaler/main.go
+++ b/.keda-external-scaler/cmd/scaler/main.go
@@ -56,23 +56,37 @@ func parseFlags(args []string) (config, error) {
 func main() {
 	logger := slog.New(slog.NewJSONHandler(os.Stderr, &slog.HandlerOptions{Level: slog.LevelInfo}))
 
-	cfg, err := parseFlags(os.Args[1:])
+	// Graceful shutdown on SIGTERM/SIGINT.
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
+	defer stop()
+
+	os.Exit(realMain(ctx, os.Args[1:], logger))
+}
+
+// realMain resolves configuration and runs the server, returning a process exit
+// code. It is split from main (which owns os.Exit and signal wiring) so it can
+// be exercised in tests.
+func realMain(ctx context.Context, args []string, logger *slog.Logger) int {
+	cfg, err := parseFlags(args)
 	if err != nil {
 		// flag already printed usage/error for -h and parse failures.
 		if errors.Is(err, flag.ErrHelp) {
-			return
+			return 0
 		}
 		logger.Error("invalid flags", "err", err)
-		os.Exit(2)
+		return 2
 	}
 
-	if err := run(cfg, logger); err != nil {
+	if err := run(ctx, cfg, logger); err != nil {
 		logger.Error("server exited with error", "err", err)
-		os.Exit(1)
+		return 1
 	}
+	return 0
 }
 
-func run(cfg config, logger *slog.Logger) error {
+// run starts the gRPC server and blocks until ctx is cancelled or Serve returns.
+// Cancelling ctx triggers a graceful drain.
+func run(ctx context.Context, cfg config, logger *slog.Logger) error {
 	env := collectGridEnv()
 
 	var opts []grpc.ServerOption
@@ -100,13 +114,15 @@ func run(cfg config, logger *slog.Logger) error {
 		return err
 	}
 
-	// Graceful shutdown on SIGTERM/SIGINT.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGTERM, os.Interrupt)
-	defer stop()
+	return serve(ctx, srv, healthSrv, lis, logger)
+}
 
+// serve runs srv on lis until ctx is cancelled (graceful drain) or Serve returns
+// on its own. It is split from run so the shutdown paths are unit-testable.
+func serve(ctx context.Context, srv *grpc.Server, healthSrv *health.Server, lis net.Listener, logger *slog.Logger) error {
 	serveErr := make(chan error, 1)
 	go func() {
-		logger.Info("selenium-grid external scaler listening", "address", cfg.listenAddr, "gridUrlFromEnv", env["SE_GRID_URL"] != "")
+		logger.Info("selenium-grid external scaler listening", "address", lis.Addr().String())
 		serveErr <- srv.Serve(lis)
 	}()
 

--- a/.keda-external-scaler/cmd/scaler/main_test.go
+++ b/.keda-external-scaler/cmd/scaler/main_test.go
@@ -1,0 +1,312 @@
+package main
+
+import (
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"io"
+	"log/slog"
+	"math/big"
+	"net"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/health"
+)
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewJSONHandler(io.Discard, nil))
+}
+
+// writeSelfSignedCert generates an ephemeral self-signed cert/key pair in dir
+// and returns their paths, for exercising the TLS-enabled server path.
+func writeSelfSignedCert(t *testing.T, dir string) (certPath, keyPath string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate key: %v", err)
+	}
+	tmpl := x509.Certificate{
+		SerialNumber: big.NewInt(1),
+		Subject:      pkix.Name{CommonName: "localhost"},
+		NotBefore:    time.Unix(0, 0),
+		NotAfter:     time.Unix(1<<31-1, 0),
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &tmpl, &tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create certificate: %v", err)
+	}
+	keyDER, err := x509.MarshalECPrivateKey(key)
+	if err != nil {
+		t.Fatalf("marshal key: %v", err)
+	}
+
+	certPath = filepath.Join(dir, "cert.pem")
+	keyPath = filepath.Join(dir, "key.pem")
+	if err := os.WriteFile(certPath, pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write cert: %v", err)
+	}
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "EC PRIVATE KEY", Bytes: keyDER}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return certPath, keyPath
+}
+
+func TestParseFlagsDefaults(t *testing.T) {
+	for _, k := range []string{"LISTEN_ADDRESS", "SE_GRID_HTTP_TIMEOUT", "TLS_CERT_FILE", "TLS_KEY_FILE"} {
+		t.Setenv(k, "")
+	}
+	cfg, err := parseFlags(nil)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if cfg.listenAddr != ":8080" {
+		t.Errorf("listenAddr = %q, want :8080", cfg.listenAddr)
+	}
+	if cfg.httpTimeout != 3*time.Second {
+		t.Errorf("httpTimeout = %v, want 3s", cfg.httpTimeout)
+	}
+	if cfg.tlsCertFile != "" || cfg.tlsKeyFile != "" {
+		t.Errorf("tls files = (%q,%q), want empty", cfg.tlsCertFile, cfg.tlsKeyFile)
+	}
+}
+
+func TestParseFlagsOverridesAndEnv(t *testing.T) {
+	t.Setenv("LISTEN_ADDRESS", ":9999")           // overridden by flag below
+	t.Setenv("SE_GRID_HTTP_TIMEOUT", "500")        // bare int → ms (env default)
+	t.Setenv("TLS_CERT_FILE", "/etc/cert.pem")
+	t.Setenv("TLS_KEY_FILE", "/etc/key.pem")
+
+	cfg, err := parseFlags([]string{"-listen-address", ":7000"})
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if cfg.listenAddr != ":7000" {
+		t.Errorf("listenAddr = %q, want flag value :7000", cfg.listenAddr)
+	}
+	if cfg.httpTimeout != 500*time.Millisecond {
+		t.Errorf("httpTimeout = %v, want 500ms from bare-int env", cfg.httpTimeout)
+	}
+	if cfg.tlsCertFile != "/etc/cert.pem" || cfg.tlsKeyFile != "/etc/key.pem" {
+		t.Errorf("tls files = (%q,%q), want env defaults", cfg.tlsCertFile, cfg.tlsKeyFile)
+	}
+}
+
+func TestParseFlagsInvalid(t *testing.T) {
+	if _, err := parseFlags([]string{"-unknown-flag"}); err == nil {
+		t.Error("expected error for unknown flag, got nil")
+	}
+}
+
+func TestEnvOr(t *testing.T) {
+	t.Setenv("SOME_KEY", "value")
+	if got := envOr("SOME_KEY", "fallback"); got != "value" {
+		t.Errorf("envOr(set) = %q, want value", got)
+	}
+	t.Setenv("SOME_KEY", "")
+	if got := envOr("SOME_KEY", "fallback"); got != "fallback" {
+		t.Errorf("envOr(empty) = %q, want fallback", got)
+	}
+}
+
+func TestEnvDurationOr(t *testing.T) {
+	tests := []struct {
+		name string
+		val  string
+		want time.Duration
+	}{
+		{"unset returns fallback", "", 2 * time.Second},
+		{"duration string", "1500ms", 1500 * time.Millisecond},
+		{"bare integer is milliseconds", "250", 250 * time.Millisecond},
+		{"garbage returns fallback", "not-a-duration", 2 * time.Second},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			t.Setenv("DUR_KEY", tt.val)
+			if got := envDurationOr("DUR_KEY", 2*time.Second); got != tt.want {
+				t.Errorf("envDurationOr(%q) = %v, want %v", tt.val, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCollectGridEnv(t *testing.T) {
+	// Clear all keys, then set a subset; only the set keys must appear.
+	for _, k := range gridEnvKeys {
+		t.Setenv(k, "")
+	}
+	t.Setenv("SE_GRID_URL", "http://grid:4444/graphql")
+	t.Setenv("SE_USERNAME", "admin")
+
+	env := collectGridEnv()
+	if env["SE_GRID_URL"] != "http://grid:4444/graphql" {
+		t.Errorf("SE_GRID_URL = %q, unexpected", env["SE_GRID_URL"])
+	}
+	if env["SE_USERNAME"] != "admin" {
+		t.Errorf("SE_USERNAME = %q, unexpected", env["SE_USERNAME"])
+	}
+	if _, ok := env["SE_PASSWORD"]; ok {
+		t.Error("unset SE_PASSWORD should be absent from the map")
+	}
+}
+
+func TestRealMainHelp(t *testing.T) {
+	if code := realMain(context.Background(), []string{"-h"}, discardLogger()); code != 0 {
+		t.Errorf("realMain(-h) = %d, want 0", code)
+	}
+}
+
+func TestRealMainInvalidFlags(t *testing.T) {
+	if code := realMain(context.Background(), []string{"-nope"}, discardLogger()); code != 2 {
+		t.Errorf("realMain(bad flag) = %d, want 2", code)
+	}
+}
+
+func TestRealMainRunError(t *testing.T) {
+	// Valid flags but an unbindable listen address: run fails, realMain → 1.
+	code := realMain(context.Background(), []string{"-listen-address", "256.256.256.256:99999"}, discardLogger())
+	if code != 1 {
+		t.Errorf("realMain(listen error) = %d, want 1", code)
+	}
+}
+
+func TestRealMainGracefulShutdown(t *testing.T) {
+	// Valid flags on an ephemeral port; cancelling the context drains the server
+	// and realMain returns success (0).
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan int, 1)
+	go func() {
+		done <- realMain(ctx, []string{"-listen-address", "127.0.0.1:0"}, discardLogger())
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case code := <-done:
+		if code != 0 {
+			t.Errorf("realMain graceful shutdown = %d, want 0", code)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("realMain did not return after context cancellation")
+	}
+}
+
+func TestRunListenError(t *testing.T) {
+	// An unbindable address makes net.Listen fail, exercising run's error return
+	// after the server has been fully assembled.
+	cfg := config{listenAddr: "256.256.256.256:99999", httpTimeout: time.Second}
+	if err := run(context.Background(), cfg, discardLogger()); err == nil {
+		t.Error("expected listen error, got nil")
+	}
+}
+
+func TestRunTLSError(t *testing.T) {
+	// Non-existent cert/key files make the TLS credential setup fail.
+	cfg := config{
+		listenAddr:  "127.0.0.1:0",
+		httpTimeout: time.Second,
+		tlsCertFile: filepath.Join(t.TempDir(), "missing-cert.pem"),
+		tlsKeyFile:  filepath.Join(t.TempDir(), "missing-key.pem"),
+	}
+	if err := run(context.Background(), cfg, discardLogger()); err == nil {
+		t.Error("expected TLS credential error, got nil")
+	}
+}
+
+func TestRunTLSGracefulShutdown(t *testing.T) {
+	// Valid cert/key enables TLS; cancelling the context drains cleanly. Covers
+	// the TLS-credential branch of run.
+	certPath, keyPath := writeSelfSignedCert(t, t.TempDir())
+	cfg := config{listenAddr: "127.0.0.1:0", httpTimeout: time.Second, tlsCertFile: certPath, tlsKeyFile: keyPath}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, cfg, discardLogger()) }()
+
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("run (TLS) graceful shutdown returned %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run (TLS) did not return after context cancellation")
+	}
+}
+
+func TestServeServerStopped(t *testing.T) {
+	// srv.Stop() makes Serve return grpc.ErrServerStopped, which serve treats as
+	// a clean exit (nil).
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	srv := grpc.NewServer()
+	hs := health.NewServer()
+
+	done := make(chan error, 1)
+	go func() { done <- serve(context.Background(), srv, hs, lis, discardLogger()) }()
+
+	time.Sleep(100 * time.Millisecond)
+	srv.Stop()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("serve after Stop = %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("serve did not return after Stop")
+	}
+}
+
+func TestServeListenerError(t *testing.T) {
+	// A closed listener makes Serve fail with a non-ErrServerStopped error, which
+	// serve must surface.
+	lis, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	lis.Close()
+
+	srv := grpc.NewServer()
+	defer srv.Stop()
+	hs := health.NewServer()
+
+	if err := serve(context.Background(), srv, hs, lis, discardLogger()); err == nil {
+		t.Error("expected serve error on closed listener, got nil")
+	}
+}
+
+func TestRunGracefulShutdown(t *testing.T) {
+	// Bind an ephemeral port and cancel the context: run must serve and then
+	// drain cleanly, returning nil.
+	cfg := config{listenAddr: "127.0.0.1:0", httpTimeout: time.Second}
+	ctx, cancel := context.WithCancel(context.Background())
+
+	done := make(chan error, 1)
+	go func() { done <- run(ctx, cfg, discardLogger()) }()
+
+	// Give the server a moment to start serving, then request shutdown.
+	time.Sleep(100 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("run graceful shutdown returned %v, want nil", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return after context cancellation")
+	}
+}

--- a/.keda-external-scaler/internal/gridscaler/grid_client_extra_test.go
+++ b/.keda-external-scaler/internal/gridscaler/grid_client_extra_test.go
@@ -1,0 +1,46 @@
+package gridscaler
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+)
+
+// TestGridClient_Query_InvalidURL covers the request-construction error path:
+// a URL containing a control character makes http.NewRequestWithContext fail
+// before any network call.
+func TestGridClient_Query_InvalidURL(t *testing.T) {
+	c := NewGridClient(3 * time.Second)
+	if _, err := c.Query(context.Background(), &Metadata{URL: "http://\x7f/graphql"}); err == nil {
+		t.Error("Query() error = nil, want non-nil for malformed URL")
+	}
+}
+
+// TestGridClient_Query_ShortBody covers the response-read error path: the server
+// promises more bytes via Content-Length than it delivers, then closes, so
+// io.ReadAll returns an unexpected-EOF error.
+func TestGridClient_Query_ShortBody(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			t.Fatal("ResponseWriter does not support hijacking")
+		}
+		conn, buf, err := hj.Hijack()
+		if err != nil {
+			t.Errorf("hijack error = %v", err)
+			return
+		}
+		// Content-Length claims 100 bytes but only 5 are written before close.
+		_, _ = buf.WriteString("HTTP/1.1 200 OK\r\nContent-Length: 100\r\n\r\nshort")
+		_ = buf.Flush()
+		_ = conn.Close()
+	}))
+	defer server.Close()
+
+	c := NewGridClient(3 * time.Second)
+	if _, err := c.Query(context.Background(), &Metadata{URL: server.URL}); err == nil {
+		t.Error("Query() error = nil, want non-nil for truncated response body")
+	}
+}

--- a/.keda-external-scaler/internal/gridscaler/logic_extra_test.go
+++ b/.keda-external-scaler/internal/gridscaler/logic_extra_test.go
@@ -1,0 +1,123 @@
+package gridscaler
+
+import (
+	"testing"
+
+	"github.com/go-logr/logr"
+)
+
+func Test_parseCapabilitiesToMap(t *testing.T) {
+	tests := []struct {
+		name    string
+		input   string
+		wantLen int
+		wantErr bool
+	}{
+		{"empty string yields empty map", "", 0, false},
+		{"valid json object is parsed", `{"myApp:version": "beta"}`, 1, false},
+		{"invalid json returns error", `{not valid`, 0, true},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := parseCapabilitiesToMap(tt.input)
+			if (err != nil) != tt.wantErr {
+				t.Fatalf("parseCapabilitiesToMap() error = %v, wantErr %v", err, tt.wantErr)
+			}
+			if tt.wantErr {
+				return
+			}
+			if len(got) != tt.wantLen {
+				t.Errorf("len = %d, want %d", len(got), tt.wantLen)
+			}
+		})
+	}
+}
+
+func Test_countMatchingSessions(t *testing.T) {
+	t.Run("counts sessions whose stereotype matches", func(t *testing.T) {
+		sessions := Sessions{
+			{Slot: Slot{Stereotype: `{"browserName": "chrome", "platformName": "linux"}`}},
+			{Slot: Slot{Stereotype: `{"browserName": "firefox", "platformName": "linux"}`}},
+		}
+		got := countMatchingSessions(sessions, "chrome", "", "chrome", "linux", map[string]interface{}{}, logr.Discard())
+		if got != 1 {
+			t.Errorf("countMatchingSessions() = %d, want 1", got)
+		}
+	})
+
+	t.Run("skips sessions with unparseable stereotype json", func(t *testing.T) {
+		sessions := Sessions{
+			{Slot: Slot{Stereotype: `not-json`}},
+			{Slot: Slot{Stereotype: `{"browserName": "chrome"}`}},
+		}
+		got := countMatchingSessions(sessions, "chrome", "", "chrome", "", map[string]interface{}{}, logr.Discard())
+		if got != 1 {
+			t.Errorf("countMatchingSessions() = %d, want 1 (bad-json session ignored)", got)
+		}
+	})
+}
+
+// Test_getCountFromSeleniumResponse_malformed covers the resilience branches of
+// getCountFromSeleniumResponse: malformed trigger capabilities, malformed queued
+// request capabilities, and malformed node stereotypes must be logged and
+// skipped rather than aborting the count.
+func Test_getCountFromSeleniumResponse_malformed(t *testing.T) {
+	t.Run("invalid trigger capabilities are tolerated", func(t *testing.T) {
+		body := []byte(`{"data":{"grid":{},"nodesInfo":{"nodes":[]},"sessionsInfo":{"sessionQueueRequests":[]}}}`)
+		// enableManagedDownloads=false so the nil map from the parse error is not written to.
+		newNodes, onGoing, err := getCountFromSeleniumResponse(body, "chrome", "", "chrome", "linux", 1, false, `{not valid`, logr.Discard())
+		if err != nil {
+			t.Fatalf("getCountFromSeleniumResponse() error = %v", err)
+		}
+		if newNodes != 0 || onGoing != 0 {
+			t.Errorf("got (%d,%d), want (0,0)", newNodes, onGoing)
+		}
+	})
+
+	t.Run("invalid queued request capabilities are skipped", func(t *testing.T) {
+		body := []byte(`{"data":{"grid":{},"nodesInfo":{"nodes":[]},"sessionsInfo":{"sessionQueueRequests":["not-json"]}}}`)
+		newNodes, onGoing, err := getCountFromSeleniumResponse(body, "chrome", "", "chrome", "linux", 1, true, "", logr.Discard())
+		if err != nil {
+			t.Fatalf("getCountFromSeleniumResponse() error = %v", err)
+		}
+		if newNodes != 0 || onGoing != 0 {
+			t.Errorf("got (%d,%d), want (0,0)", newNodes, onGoing)
+		}
+	})
+
+	t.Run("matched request against a node with invalid stereotypes still scales up", func(t *testing.T) {
+		body := []byte(`{
+			"data": {
+				"grid": { "sessionCount": 0, "maxSession": 1, "totalSlots": 1 },
+				"nodesInfo": {
+					"nodes": [
+						{
+							"id": "node-1",
+							"status": "UP",
+							"sessionCount": 0,
+							"maxSession": 1,
+							"slotCount": 1,
+							"stereotypes": "not-json",
+							"sessions": []
+						}
+					]
+				},
+				"sessionsInfo": {
+					"sessionQueueRequests": [
+						"{\"browserName\": \"chrome\", \"platformName\": \"linux\"}"
+					]
+				}
+			}
+		}`)
+		newNodes, onGoing, err := getCountFromSeleniumResponse(body, "chrome", "", "chrome", "linux", 1, true, "", logr.Discard())
+		if err != nil {
+			t.Fatalf("getCountFromSeleniumResponse() error = %v", err)
+		}
+		// The node's slots cannot be matched (unparseable stereotypes), so a new
+		// Node must be scaled up for the queued request.
+		if newNodes != 1 || onGoing != 0 {
+			t.Errorf("got (%d,%d), want (1,0)", newNodes, onGoing)
+		}
+	})
+}

--- a/.keda-external-scaler/internal/gridscaler/metadata_extra_test.go
+++ b/.keda-external-scaler/internal/gridscaler/metadata_extra_test.go
@@ -1,0 +1,51 @@
+package gridscaler
+
+import "testing"
+
+// Test_parseMetadata_errorsAndNil covers the remaining parseMetadata branches:
+// a nil scalerMetadata map (no url → error) and the numeric/boolean parse
+// failures for nodeMaxSessions, unsafeSsl and enableManagedDownloads.
+func Test_parseMetadata_errorsAndNil(t *testing.T) {
+	tests := []struct {
+		name string
+		meta map[string]string
+	}{
+		{"nil metadata has no url and errors", nil},
+		{
+			"invalid nodeMaxSessions errors",
+			map[string]string{"url": "http://g", "browserName": "chrome", "nodeMaxSessions": "notint"},
+		},
+		{
+			"invalid unsafeSsl errors",
+			map[string]string{"url": "http://g", "browserName": "chrome", "unsafeSsl": "notbool"},
+		},
+		{
+			"invalid enableManagedDownloads errors",
+			map[string]string{"url": "http://g", "browserName": "chrome", "enableManagedDownloads": "notbool"},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if _, err := parseMetadata(tt.meta, nil); err == nil {
+				t.Errorf("parseMetadata() error = nil, want non-nil")
+			}
+		})
+	}
+}
+
+// Test_parseMetadata_nodeMaxSessions confirms a valid nodeMaxSessions is parsed
+// so the success side of that branch is also exercised.
+func Test_parseMetadata_nodeMaxSessions(t *testing.T) {
+	meta, err := parseMetadata(map[string]string{
+		"url":             "http://g",
+		"browserName":     "chrome",
+		"nodeMaxSessions": "5",
+	}, nil)
+	if err != nil {
+		t.Fatalf("parseMetadata() error = %v", err)
+	}
+	if meta.NodeMaxSessions != 5 {
+		t.Errorf("NodeMaxSessions = %d, want 5", meta.NodeMaxSessions)
+	}
+}

--- a/.keda-external-scaler/internal/gridscaler/platform_test.go
+++ b/.keda-external-scaler/internal/gridscaler/platform_test.go
@@ -1,0 +1,95 @@
+package gridscaler
+
+import "testing"
+
+// Test_GetPlatform exercises every branch of the OS/arch dispatch in
+// GetPlatform, mirroring the platform-name enum used by Selenium Grid core
+// (Platform.java). Inputs are matched case-insensitively, so aliases and mixed
+// case must resolve to the same Platform.
+func Test_GetPlatform(t *testing.T) {
+	tests := []struct {
+		name  string
+		input string
+		want  Platform
+	}{
+		// Windows family.
+		{"windows", "windows", Windows},
+		{"windows is case-insensitive", "Windows", Windows},
+		{"windows server 2003 alias", "windows server 2003", XP},
+		{"xp alias", "xp", XP},
+		{"winnt alias", "winnt", XP},
+		{"windows_nt alias", "windows_nt", XP},
+		{"windows nt alias", "windows nt", XP},
+		{"windows server 2008 alias", "windows server 2008", Vista},
+		{"windows vista", "windows vista", Vista},
+		{"windows 7", "windows 7", Win7},
+		{"win7 alias", "win7", Win7},
+		{"windows server 2012 alias", "windows server 2012", Win8},
+		{"windows 8", "windows 8", Win8},
+		{"win8 alias", "win8", Win8},
+		{"windows 8.1", "windows 8.1", Win8_1},
+		{"win8.1 alias", "win8.1", Win8_1},
+		{"windows 10", "windows 10", Win10},
+		{"win10 alias", "win10", Win10},
+		{"windows 11", "windows 11", Win11},
+		{"win11 alias", "win11", Win11},
+
+		// Mac family.
+		{"mac", "mac", Mac},
+		{"darwin alias", "darwin", Mac},
+		{"macos alias", "macos", Mac},
+		{"mac os x alias", "mac os x", Mac},
+		{"os x alias", "os x", Mac},
+		{"snow leopard", "snow leopard", SnowLeopard},
+		{"os x 10.6", "os x 10.6", SnowLeopard},
+		{"mountain lion", "mountain lion", MountainLion},
+		{"os x 10.8", "os x 10.8", MountainLion},
+		{"mavericks", "mavericks", Mavericks},
+		{"os x 10.9", "os x 10.9", Mavericks},
+		{"yosemite", "yosemite", Yosemite},
+		{"os x 10.10", "os x 10.10", Yosemite},
+		{"el capitan", "el capitan", ElCapitan},
+		{"os x 10.11", "os x 10.11", ElCapitan},
+		{"sierra", "sierra", Sierra},
+		{"os x 10.12", "os x 10.12", Sierra},
+		{"high sierra", "high sierra", HighSierra},
+		{"os x 10.13", "os x 10.13", HighSierra},
+		{"mojave", "mojave", Mojave},
+		{"os x 10.14", "os x 10.14", Mojave},
+		{"catalina", "catalina", Catalina},
+		{"os x 10.15", "os x 10.15", Catalina},
+		{"big sur", "big sur", BigSur},
+		{"os x 11.0", "os x 11.0", BigSur},
+		{"monterey", "monterey", Monterey},
+		{"os x 12.0", "os x 12.0", Monterey},
+		{"ventura", "ventura", Ventura},
+		{"os x 13.0", "os x 13.0", Ventura},
+		{"sonoma", "sonoma", Sonoma},
+		{"os x 14.0", "os x 14.0", Sonoma},
+		{"sequoia", "sequoia", Sequoia},
+		{"os x 15.0", "os x 15.0", Sequoia},
+
+		// Unix family and other top-level platforms.
+		{"linux", "linux", Linux},
+		{"linux is case-insensitive", "Linux", Linux},
+		{"bsd", "bsd", Bsd},
+		{"solaris", "solaris", Solaris},
+		{"android", "android", Android},
+		{"dalvik alias", "dalvik", Android},
+		{"ios", "ios", IOS},
+		{"any", "any", Any},
+		{"empty string resolves to any", "", Any},
+
+		// Default: an unknown name is echoed back lowercased with no family.
+		{"unknown name lowercased with no family", "MyCustomOS", Platform{"mycustomos", nil}},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := GetPlatform(tt.input)
+			if got != tt.want {
+				t.Errorf("GetPlatform(%q) = %+v, want %+v", tt.input, got, tt.want)
+			}
+		})
+	}
+}

--- a/.keda-external-scaler/internal/gridscaler/server_extra_test.go
+++ b/.keda-external-scaler/internal/gridscaler/server_extra_test.go
@@ -1,0 +1,80 @@
+package gridscaler
+
+import (
+	"context"
+	"testing"
+
+	"google.golang.org/grpc/codes"
+	"google.golang.org/grpc/status"
+
+	pb "github.com/SeleniumHQ/docker-selenium/keda-external-scaler/externalscaler"
+)
+
+// TestServer_GetMetrics_InvalidMetadata covers the metadata-parse error path of
+// GetMetrics (missing url with no env fallback → InvalidArgument).
+func TestServer_GetMetrics_InvalidMetadata(t *testing.T) {
+	client := newTestClient(t, nil)
+	_, err := client.GetMetrics(context.Background(), &pb.GetMetricsRequest{
+		ScaledObjectRef: &pb.ScaledObjectRef{ScalerMetadata: map[string]string{"browserName": "chrome"}},
+		MetricName:      "selenium-grid-chrome",
+	})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("GetMetrics() code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+// TestServer_GetMetrics_InvalidGridBody covers scrapeAndCount's
+// getCountFromSeleniumResponse error path: a 200 response whose body is not the
+// expected JSON must surface as Internal.
+func TestServer_GetMetrics_InvalidGridBody(t *testing.T) {
+	grid := fakeGrid(t, `this is not json`)
+	client := newTestClient(t, nil)
+	_, err := client.GetMetrics(context.Background(), &pb.GetMetricsRequest{
+		ScaledObjectRef: &pb.ScaledObjectRef{ScalerMetadata: map[string]string{"url": grid.URL, "browserName": "chrome"}},
+		MetricName:      "selenium-grid-chrome",
+	})
+	if status.Code(err) != codes.Internal {
+		t.Errorf("GetMetrics() code = %v, want Internal", status.Code(err))
+	}
+}
+
+// TestServer_IsActive_InvalidMetadata covers IsActive's metadata-parse error
+// path → InvalidArgument.
+func TestServer_IsActive_InvalidMetadata(t *testing.T) {
+	client := newTestClient(t, nil)
+	_, err := client.IsActive(context.Background(), &pb.ScaledObjectRef{ScalerMetadata: map[string]string{"browserName": "chrome"}})
+	if status.Code(err) != codes.InvalidArgument {
+		t.Errorf("IsActive() code = %v, want InvalidArgument", status.Code(err))
+	}
+}
+
+// TestServer_IsActive_GridUnreachable covers IsActive's scrapeAndCount error
+// path: an unreachable Grid → Internal.
+func TestServer_IsActive_GridUnreachable(t *testing.T) {
+	client := newTestClient(t, nil)
+	_, err := client.IsActive(context.Background(), &pb.ScaledObjectRef{
+		ScalerMetadata: map[string]string{"url": "http://192.0.2.1:4444/graphql", "browserName": "chrome"},
+	})
+	if status.Code(err) != codes.Internal {
+		t.Errorf("IsActive() code = %v, want Internal", status.Code(err))
+	}
+}
+
+// TestServer_IsActive_BelowActivationThreshold confirms IsActive reports false
+// when the node count does not exceed activationThreshold. The fixture yields a
+// count of 3, so a threshold of 3 must not activate.
+func TestServer_IsActive_BelowActivationThreshold(t *testing.T) {
+	grid := fakeGrid(t, fixtureGrid)
+	client := newTestClient(t, nil)
+	resp, err := client.IsActive(context.Background(), &pb.ScaledObjectRef{ScalerMetadata: map[string]string{
+		"url":                 grid.URL,
+		"browserName":         "chrome",
+		"activationThreshold": "3",
+	}})
+	if err != nil {
+		t.Fatalf("IsActive() error = %v", err)
+	}
+	if resp.Result {
+		t.Error("IsActive() = true, want false (count 3 not > threshold 3)")
+	}
+}

--- a/.monitoring/exporter/collector_test.go
+++ b/.monitoring/exporter/collector_test.go
@@ -1,0 +1,416 @@
+package main
+
+import (
+	"encoding/json"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/prometheus/client_golang/prometheus"
+	"github.com/prometheus/client_golang/prometheus/testutil"
+	dto "github.com/prometheus/client_model/go"
+	"net/http"
+	"net/http/httptest"
+)
+
+// ── test helpers ──────────────────────────────────────────────────────────────
+
+func encode(t *testing.T, v any) string {
+	t.Helper()
+	b, err := json.Marshal(v)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	return string(b)
+}
+
+// swapServer serves a body that the test can change between scrapes, so a single
+// collector can be driven through a multi-scrape lifecycle.
+type swapServer struct {
+	mu   sync.Mutex
+	body string
+	srv  *httptest.Server
+}
+
+func newSwapServer(initial string) *swapServer {
+	s := &swapServer{body: initial}
+	s.srv = httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		s.mu.Lock()
+		body := s.body
+		s.mu.Unlock()
+		_, _ = w.Write([]byte(body))
+	}))
+	return s
+}
+
+func (s *swapServer) set(body string) {
+	s.mu.Lock()
+	s.body = body
+	s.mu.Unlock()
+}
+
+func (s *swapServer) close() { s.srv.Close() }
+
+// chromeSession is the canonical active session used across the collector tests.
+// startTime 02/01/2020 10:00:00 UTC == unix 1577959200.
+func chromeSession(t *testing.T) sessionEntry {
+	return sessionEntry{
+		ID:                    "s1",
+		Capabilities:          encode(t, caps{BrowserName: "chrome", BrowserVersion: "124", PlatformName: "linux", TestName: "login-test", ContainerName: "node-chrome-1"}),
+		StartTime:             "02/01/2020 10:00:00",
+		SessionDurationMillis: "42300",
+		NodeID:                "node-up",
+		NodeURI:               "http://node1:5555",
+	}
+}
+
+const chromeSessionStartUnix = 1577959200
+
+// gridResponse renders a full GraphQL data envelope with the given sessions and
+// queue. Two nodes are always present: one UP (chrome), one DRAINING (firefox).
+func gridResponse(t *testing.T, sessions []sessionEntry, queue []string) string {
+	t.Helper()
+	chromeStereo := encode(t, []stereotypeEntry{{Stereotype: caps{BrowserName: "chrome", BrowserVersion: "124", PlatformName: "linux"}, Slots: 4}})
+	firefoxStereo := encode(t, []stereotypeEntry{{Stereotype: caps{BrowserName: "firefox", BrowserVersion: "125", PlatformName: "linux"}, Slots: 4}})
+
+	resp := gqlResponse{Data: &gridData{
+		Grid: gridSummary{
+			URI: "http://hub:4444", TotalSlots: 8, NodeCount: 2, MaxSession: 8,
+			SessionCount: len(sessions), SessionQueueSize: len(queue), Version: "4.47.0",
+		},
+		NodesInfo: nodesInfo{Nodes: []nodeInfo{
+			{ID: "node-up", URI: "http://node1:5555", Status: "UP", MaxSession: 4, SlotCount: 4, SessionCount: 1, Stereotypes: chromeStereo, Version: "4.47.0", OsInfo: osInfo{Arch: "arm64", Name: "Linux", Version: "6.1"}},
+			{ID: "node-draining", URI: "http://node2:5555", Status: "DRAINING", MaxSession: 4, SlotCount: 4, SessionCount: 0, Stereotypes: firefoxStereo, Version: "4.47.0", OsInfo: osInfo{Arch: "amd64", Name: "Linux", Version: "5.15"}},
+		}},
+		SessionsInfo: sessionsInfo{SessionQueueRequests: queue, Sessions: sessions},
+	}}
+	return encode(t, resp)
+}
+
+// newTestCollector wires a collector to a swappable server and registers it on a
+// pedantic registry so Gather() performs one scrape per call.
+func newTestCollector(t *testing.T, initialBody string, retainFor time.Duration) (*collector, *swapServer, *prometheus.Registry) {
+	t.Helper()
+	s := newSwapServer(initialBody)
+	t.Cleanup(s.close)
+
+	client := newGridClient(s.srv.URL, "", "", 5*time.Second)
+	c := newCollector(client, 5*time.Second, time.UTC, retainFor)
+
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(c)
+	return c, s, reg
+}
+
+func gather(t *testing.T, reg *prometheus.Registry) []*dto.MetricFamily {
+	t.Helper()
+	mfs, err := reg.Gather()
+	if err != nil {
+		t.Fatalf("gather: %v", err)
+	}
+	return mfs
+}
+
+// scalar returns the value of an unlabeled single-series metric family.
+func scalar(t *testing.T, mfs []*dto.MetricFamily, name string) float64 {
+	t.Helper()
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		if len(mf.GetMetric()) != 1 {
+			t.Fatalf("%s: expected 1 series, got %d", name, len(mf.GetMetric()))
+		}
+		return metricValue(mf.GetMetric()[0])
+	}
+	t.Fatalf("metric %s not found", name)
+	return 0
+}
+
+// series finds a metric within a family matching all the given labels.
+func series(mfs []*dto.MetricFamily, name string, labels map[string]string) (*dto.Metric, bool) {
+	for _, mf := range mfs {
+		if mf.GetName() != name {
+			continue
+		}
+		for _, m := range mf.GetMetric() {
+			got := map[string]string{}
+			for _, lp := range m.GetLabel() {
+				got[lp.GetName()] = lp.GetValue()
+			}
+			match := true
+			for k, v := range labels {
+				if got[k] != v {
+					match = false
+					break
+				}
+			}
+			if match {
+				return m, true
+			}
+		}
+	}
+	return nil, false
+}
+
+func metricValue(m *dto.Metric) float64 {
+	if m.GetGauge() != nil {
+		return m.GetGauge().GetValue()
+	}
+	if m.GetCounter() != nil {
+		return m.GetCounter().GetValue()
+	}
+	return 0
+}
+
+// ── tests ─────────────────────────────────────────────────────────────────────
+
+func TestCollectorDescribe(t *testing.T) {
+	c := newCollector(nil, time.Second, time.UTC, time.Minute)
+	ch := make(chan *prometheus.Desc, 64)
+	c.Describe(ch)
+	close(ch)
+
+	const want = 20 // every metric the collector can emit must be described
+	if got := len(ch); got != want {
+		t.Errorf("Describe emitted %d descriptors, want %d", got, want)
+	}
+}
+
+func TestCollectScrapeFailure(t *testing.T) {
+	// Point the collector at a closed server so the scrape errors out.
+	s := newSwapServer("")
+	url := s.srv.URL
+	s.close()
+
+	client := newGridClient(url, "", "", time.Second)
+	c := newCollector(client, time.Second, time.UTC, time.Minute)
+	reg := prometheus.NewPedanticRegistry()
+	reg.MustRegister(c)
+
+	// Health must always be emitted, reporting failure.
+	expected := `
+# HELP selenium_grid_scrape_success 1 if the last scrape of the Grid GraphQL endpoint succeeded, 0 otherwise.
+# TYPE selenium_grid_scrape_success gauge
+selenium_grid_scrape_success 0
+`
+	if err := testutil.CollectAndCompare(c, strings.NewReader(expected), "selenium_grid_scrape_success"); err != nil {
+		t.Errorf("scrape_success mismatch: %v", err)
+	}
+	// No grid data must be emitted when the scrape fails.
+	if n := testutil.CollectAndCount(c, "selenium_grid_total_slots"); n != 0 {
+		t.Errorf("expected no grid metrics on failure, got %d total_slots series", n)
+	}
+}
+
+func TestCollectFullSnapshot(t *testing.T) {
+	queue := []string{encode(t, map[string]string{"browserName": "chrome", "browserVersion": "124", "platformName": "linux"})}
+	body := gridResponse(t, []sessionEntry{chromeSession(t)}, queue)
+	_, _, reg := newTestCollector(t, body, time.Minute)
+
+	mfs := gather(t, reg)
+
+	// Node status score mapping (UP=1, DRAINING=0.5) with the full label set.
+	if m, ok := series(mfs, "selenium_grid_node_status", map[string]string{
+		"node_id": "node-up", "uri": "http://node1:5555", "version": "4.47.0",
+		"os_name": "Linux", "os_arch": "arm64", "os_version": "6.1",
+	}); !ok {
+		t.Error("node_status{node-up} missing or labels wrong")
+	} else if v := metricValue(m); v != 1 {
+		t.Errorf("node-up status = %v, want 1 (UP)", v)
+	}
+	if m, ok := series(mfs, "selenium_grid_node_status", map[string]string{
+		"node_id": "node-draining", "uri": "http://node2:5555", "version": "4.47.0",
+		"os_name": "Linux", "os_arch": "amd64", "os_version": "5.15",
+	}); !ok {
+		t.Error("node_status{node-draining} missing or labels wrong")
+	} else if v := metricValue(m); v != 0.5 {
+		t.Errorf("node-draining status = %v, want 0.5 (DRAINING)", v)
+	}
+
+	// Stereotype slots are broken out per (node, browser, version, platform).
+	if m, ok := series(mfs, "selenium_grid_node_stereotype_slots_total", map[string]string{
+		"node_id": "node-up", "browser_name": "chrome", "browser_version": "124", "platform_name": "linux",
+	}); !ok {
+		t.Error("stereotype_slots{node-up,chrome} missing")
+	} else if v := metricValue(m); v != 4 {
+		t.Errorf("stereotype_slots = %v, want 4", v)
+	}
+	if _, ok := series(mfs, "selenium_grid_node_stereotype_slots_total", map[string]string{
+		"node_id": "node-draining", "browser_name": "firefox", "browser_version": "125", "platform_name": "linux",
+	}); !ok {
+		t.Error("stereotype_slots{node-draining,firefox} missing")
+	}
+	checks := map[string]float64{
+		"selenium_grid_scrape_success":     1,
+		"selenium_grid_total_slots":        8,
+		"selenium_grid_node_count":         2,
+		"selenium_grid_max_sessions":       8,
+		"selenium_grid_session_count":      1,
+		"selenium_grid_session_queue_size": 1,
+		"selenium_grid_sessions_completed_total": 0,
+	}
+	for name, want := range checks {
+		if got := scalar(t, mfs, name); got != want {
+			t.Errorf("%s = %v, want %v", name, got, want)
+		}
+	}
+
+	capLabels := map[string]string{"browser_name": "chrome", "browser_version": "124", "platform_name": "linux"}
+	if m, ok := series(mfs, "selenium_grid_sessions_active", capLabels); !ok {
+		t.Error("selenium_grid_sessions_active{chrome} missing")
+	} else if v := metricValue(m); v != 1 {
+		t.Errorf("sessions_active = %v, want 1", v)
+	}
+	if m, ok := series(mfs, "selenium_grid_session_queue_requests", capLabels); !ok {
+		t.Error("selenium_grid_session_queue_requests{chrome} missing")
+	} else if v := metricValue(m); v != 1 {
+		t.Errorf("session_queue_requests = %v, want 1", v)
+	}
+
+	sessLabels := map[string]string{"session_id": "s1", "test_name": "login-test", "container_name": "node-chrome-1"}
+	if m, ok := series(mfs, "selenium_grid_session_start_seconds", sessLabels); !ok {
+		t.Error("selenium_grid_session_start_seconds{s1} missing")
+	} else if v := metricValue(m); v != chromeSessionStartUnix {
+		t.Errorf("session_start_seconds = %v, want %d", v, chromeSessionStartUnix)
+	}
+	if m, ok := series(mfs, "selenium_grid_session_duration_seconds", sessLabels); !ok {
+		t.Error("selenium_grid_session_duration_seconds{s1} missing")
+	} else if v := metricValue(m); v != 42.3 {
+		t.Errorf("session_duration_seconds = %v, want 42.3", v)
+	}
+}
+
+func TestSessionLifecycle(t *testing.T) {
+	// retainFor = 0 so a stopped session is pruned on the scrape after the one
+	// that recorded its stop.
+	body1 := gridResponse(t, []sessionEntry{chromeSession(t)}, nil)
+	c, s, reg := newTestCollector(t, body1, 0)
+	_ = c
+
+	sessLabels := map[string]string{"session_id": "s1"}
+
+	// Scrape 1: session active — start recorded, no stop, nothing completed yet.
+	mfs := gather(t, reg)
+	if v := scalar(t, mfs, "selenium_grid_sessions_completed_total"); v != 0 {
+		t.Errorf("after scrape 1 completed = %v, want 0", v)
+	}
+	if _, ok := series(mfs, "selenium_grid_session_start_seconds", sessLabels); !ok {
+		t.Error("start_seconds missing while session active")
+	}
+	if _, ok := series(mfs, "selenium_grid_session_stop_seconds", sessLabels); ok {
+		t.Error("stop_seconds present while session still active")
+	}
+
+	// Scrape 2: session gone — stop recorded, completed counter increments.
+	s.set(gridResponse(t, nil, nil))
+	mfs = gather(t, reg)
+	if v := scalar(t, mfs, "selenium_grid_sessions_completed_total"); v != 1 {
+		t.Errorf("after scrape 2 completed = %v, want 1", v)
+	}
+	stop, ok := series(mfs, "selenium_grid_session_stop_seconds", sessLabels)
+	if !ok {
+		t.Fatal("stop_seconds missing after session ended")
+	}
+	if metricValue(stop) <= 0 {
+		t.Errorf("stop_seconds = %v, want > 0", metricValue(stop))
+	}
+	if _, ok := series(mfs, "selenium_grid_session_start_seconds", sessLabels); !ok {
+		t.Error("start_seconds should still be retained on the stop scrape")
+	}
+
+	// Scrape 3: retention window (0) elapsed — stopped session pruned, but the
+	// completed counter is monotonic and must hold.
+	mfs = gather(t, reg)
+	if v := scalar(t, mfs, "selenium_grid_sessions_completed_total"); v != 1 {
+		t.Errorf("after scrape 3 completed = %v, want 1 (monotonic)", v)
+	}
+	if _, ok := series(mfs, "selenium_grid_session_stop_seconds", sessLabels); ok {
+		t.Error("stop_seconds should be pruned after the retention window")
+	}
+}
+
+func TestSessionDurationFallback(t *testing.T) {
+	// Grid hasn't reported a duration yet (0 millis); the collector must fall
+	// back to wall-clock using the parsed startTime.
+	s := chromeSession(t)
+	s.SessionDurationMillis = "0"
+	c, _, reg := newTestCollector(t, gridResponse(t, []sessionEntry{s}, nil), time.Minute)
+	_ = c
+
+	mfs := gather(t, reg)
+	m, ok := series(mfs, "selenium_grid_session_duration_seconds", map[string]string{"session_id": "s1"})
+	if !ok {
+		t.Fatal("session_duration_seconds{s1} missing")
+	}
+	// startTime is in 2020, so wall-clock duration is a large positive number.
+	if v := metricValue(m); v <= 0 {
+		t.Errorf("fallback duration = %v, want > 0", v)
+	}
+}
+
+func TestNodeDeregistration(t *testing.T) {
+	c, s, reg := newTestCollector(t, gridResponse(t, nil, nil), time.Minute)
+	_ = c
+
+	mfs := gather(t, reg)
+	if _, ok := series(mfs, "selenium_grid_node_status", map[string]string{"node_id": "node-draining"}); !ok {
+		t.Fatal("node-draining should be present on scrape 1")
+	}
+
+	// Grid now reports only node-up; node-draining has de-registered.
+	onlyUp := `{"data":{"grid":{"nodeCount":1,"totalSlots":4,"version":"4.47.0"},` +
+		`"nodesInfo":{"nodes":[{"id":"node-up","uri":"http://node1:5555","status":"UP","maxSession":4,"slotCount":4,"sessionCount":0,"stereotypes":"[]","version":"4.47.0","osInfo":{"arch":"arm64","name":"Linux","version":"6.1"}}]},` +
+		`"sessionsInfo":{"sessionQueueRequests":[],"sessions":[]}}}`
+	s.set(onlyUp)
+
+	mfs = gather(t, reg)
+	if _, ok := series(mfs, "selenium_grid_node_status", map[string]string{"node_id": "node-up"}); !ok {
+		t.Error("node-up should still be present after scrape 2")
+	}
+	if _, ok := series(mfs, "selenium_grid_node_status", map[string]string{"node_id": "node-draining"}); ok {
+		t.Error("node-draining should be dropped after it de-registers")
+	}
+}
+
+func TestNodeStatusScoreTransition(t *testing.T) {
+	// node-up is UP on scrape 1, then flips to DRAINING on scrape 2.
+	c, s, reg := newTestCollector(t, gridResponse(t, nil, nil), time.Minute)
+	_ = c
+
+	upLabels := map[string]string{"node_id": "node-up"}
+
+	mfs := gather(t, reg)
+	if m, ok := series(mfs, "selenium_grid_node_status", upLabels); !ok {
+		t.Fatal("node_status{node-up} missing")
+	} else if v := metricValue(m); v != 1 {
+		t.Errorf("node-up status = %v, want 1 (UP)", v)
+	}
+	// status_duration is reported against the current status label.
+	if _, ok := series(mfs, "selenium_grid_node_status_duration_seconds",
+		map[string]string{"node_id": "node-up", "status": "UP"}); !ok {
+		t.Error("node_status_duration{node-up,UP} missing on scrape 1")
+	}
+
+	// Flip node-up to DRAINING.
+	flipped := strings.Replace(gridResponse(t, nil, nil),
+		`"id":"node-up","uri":"http://node1:5555","status":"UP"`,
+		`"id":"node-up","uri":"http://node1:5555","status":"DRAINING"`, 1)
+	if flipped == gridResponse(t, nil, nil) {
+		t.Fatal("test setup: status replacement did not match the response body")
+	}
+	s.set(flipped)
+
+	mfs = gather(t, reg)
+	if m, ok := series(mfs, "selenium_grid_node_status", upLabels); !ok {
+		t.Fatal("node_status{node-up} missing after flip")
+	} else if v := metricValue(m); v != 0.5 {
+		t.Errorf("node-up status = %v, want 0.5 (DRAINING)", v)
+	}
+	// The duration must now be tracked against DRAINING (clock reset on change).
+	if _, ok := series(mfs, "selenium_grid_node_status_duration_seconds",
+		map[string]string{"node_id": "node-up", "status": "DRAINING"}); !ok {
+		t.Error("node_status_duration{node-up,DRAINING} missing after status change")
+	}
+}

--- a/.monitoring/exporter/go.mod
+++ b/.monitoring/exporter/go.mod
@@ -2,13 +2,16 @@ module selenium-grid-exporter
 
 go 1.26.5
 
-require github.com/prometheus/client_golang v1.24.1
+require (
+	github.com/prometheus/client_golang v1.24.1
+	github.com/prometheus/client_model v0.6.2
+)
 
 require (
 	github.com/beorn7/perks v1.0.1 // indirect
 	github.com/cespare/xxhash/v2 v2.3.0 // indirect
+	github.com/kylelemons/godebug v1.1.0 // indirect
 	github.com/munnerz/goautoneg v0.0.0-20191010083416-a7dc8b61c822 // indirect
-	github.com/prometheus/client_model v0.6.2 // indirect
 	github.com/prometheus/common v0.70.1 // indirect
 	github.com/prometheus/procfs v0.21.1 // indirect
 	golang.org/x/sys v0.47.0 // indirect

--- a/.monitoring/exporter/graphql_test.go
+++ b/.monitoring/exporter/graphql_test.go
@@ -1,0 +1,268 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestParseGridTime(t *testing.T) {
+	hcm, err := time.LoadLocation("Asia/Ho_Chi_Minh")
+	if err != nil {
+		t.Fatalf("load location: %v", err)
+	}
+
+	tests := []struct {
+		name string
+		in   string
+		loc  *time.Location
+		want float64
+	}{
+		{
+			name: "valid UTC",
+			in:   "02/01/2006 15:04:05",
+			loc:  time.UTC,
+			want: float64(time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC).Unix()),
+		},
+		{
+			name: "valid non-UTC honours location",
+			in:   "02/01/2006 15:04:05",
+			loc:  hcm,
+			want: float64(time.Date(2006, 1, 2, 15, 4, 5, 0, hcm).Unix()),
+		},
+		{
+			name: "nil location defaults to UTC",
+			in:   "02/01/2006 15:04:05",
+			loc:  nil,
+			want: float64(time.Date(2006, 1, 2, 15, 4, 5, 0, time.UTC).Unix()),
+		},
+		{
+			name: "empty string returns zero",
+			in:   "",
+			loc:  time.UTC,
+			want: 0,
+		},
+		{
+			name: "unparseable string returns zero",
+			in:   "2006-01-02T15:04:05Z", // wrong layout (RFC3339, not Grid's dd/MM/yyyy)
+			loc:  time.UTC,
+			want: 0,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseGridTime(tt.in, tt.loc); got != tt.want {
+				t.Errorf("parseGridTime(%q) = %v, want %v", tt.in, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseCaps(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want caps
+	}{
+		{
+			name: "full capabilities incl se: prefixed",
+			raw:  `{"browserName":"chrome","browserVersion":"124","platformName":"linux","se:name":"login-test","se:containerName":"node-chrome-1"}`,
+			want: caps{BrowserName: "chrome", BrowserVersion: "124", PlatformName: "linux", TestName: "login-test", ContainerName: "node-chrome-1"},
+		},
+		{
+			name: "partial capabilities leave the rest empty",
+			raw:  `{"browserName":"firefox"}`,
+			want: caps{BrowserName: "firefox"},
+		},
+		{
+			name: "empty string yields zero caps without panic",
+			raw:  "",
+			want: caps{},
+		},
+		{
+			name: "malformed json yields zero caps without panic",
+			raw:  `{"browserName":`,
+			want: caps{},
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := parseCaps(tt.raw); got != tt.want {
+				t.Errorf("parseCaps(%q) = %+v, want %+v", tt.raw, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseStereotypes(t *testing.T) {
+	t.Run("valid stereotype array", func(t *testing.T) {
+		raw := `[{"stereotype":{"browserName":"chrome","browserVersion":"124","platformName":"linux"},"slots":4},` +
+			`{"stereotype":{"browserName":"firefox","browserVersion":"125","platformName":"linux"},"slots":2}]`
+		got := parseStereotypes(raw)
+		if len(got) != 2 {
+			t.Fatalf("expected 2 entries, got %d", len(got))
+		}
+		if got[0].Slots != 4 || got[0].Stereotype.BrowserName != "chrome" {
+			t.Errorf("entry[0] = %+v, unexpected", got[0])
+		}
+		if got[1].Slots != 2 || got[1].Stereotype.BrowserName != "firefox" {
+			t.Errorf("entry[1] = %+v, unexpected", got[1])
+		}
+	})
+
+	t.Run("malformed json yields nil without panic", func(t *testing.T) {
+		if got := parseStereotypes(`[{"stereotype":`); len(got) != 0 {
+			t.Errorf("expected empty slice, got %+v", got)
+		}
+	})
+
+	t.Run("empty string yields nil without panic", func(t *testing.T) {
+		if got := parseStereotypes(""); len(got) != 0 {
+			t.Errorf("expected empty slice, got %+v", got)
+		}
+	})
+}
+
+// okResponseBody builds a minimal valid GraphQL data envelope for the client tests.
+func okResponseBody(t *testing.T) string {
+	t.Helper()
+	resp := gqlResponse{Data: &gridData{
+		Grid: gridSummary{Version: "4.47.0", NodeCount: 1, TotalSlots: 4},
+	}}
+	b, err := json.Marshal(resp)
+	if err != nil {
+		t.Fatalf("marshal response: %v", err)
+	}
+	return string(b)
+}
+
+func TestGridClientQuerySuccess(t *testing.T) {
+	var gotBody string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("method = %s, want POST", r.Method)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("Content-Type = %q, want application/json", ct)
+		}
+		raw, _ := io.ReadAll(r.Body)
+		gotBody = string(raw)
+		_, _ = io.WriteString(w, okResponseBody(t))
+	}))
+	defer srv.Close()
+
+	client := newGridClient(srv.URL, "", "", 5*time.Second)
+	data, err := client.query(context.Background())
+	if err != nil {
+		t.Fatalf("query: %v", err)
+	}
+	if data.Grid.Version != "4.47.0" || data.Grid.NodeCount != 1 {
+		t.Errorf("decoded grid = %+v, unexpected", data.Grid)
+	}
+	// The request body must carry the GraphQL query so a server-side schema
+	// change (or a marshaling regression) is caught.
+	var sent gqlRequest
+	if err := json.Unmarshal([]byte(gotBody), &sent); err != nil {
+		t.Fatalf("request body not valid JSON: %v (%s)", err, gotBody)
+	}
+	if !strings.Contains(sent.Query, "nodesInfo") || !strings.Contains(sent.Query, "sessionsInfo") {
+		t.Errorf("request query missing expected fields: %s", sent.Query)
+	}
+}
+
+func TestGridClientQueryBasicAuth(t *testing.T) {
+	t.Run("credentials set send Authorization header", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			user, pass, ok := r.BasicAuth()
+			if !ok || user != "admin" || pass != "secret" {
+				t.Errorf("basic auth = (%q,%q,%v), want (admin,secret,true)", user, pass, ok)
+			}
+			_, _ = io.WriteString(w, okResponseBody(t))
+		}))
+		defer srv.Close()
+
+		client := newGridClient(srv.URL, "admin", "secret", 5*time.Second)
+		if _, err := client.query(context.Background()); err != nil {
+			t.Fatalf("query: %v", err)
+		}
+	})
+
+	t.Run("no credentials omit Authorization header", func(t *testing.T) {
+		srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+			if _, _, ok := r.BasicAuth(); ok {
+				t.Error("Authorization header set despite empty credentials")
+			}
+			_, _ = io.WriteString(w, okResponseBody(t))
+		}))
+		defer srv.Close()
+
+		client := newGridClient(srv.URL, "", "", 5*time.Second)
+		if _, err := client.query(context.Background()); err != nil {
+			t.Fatalf("query: %v", err)
+		}
+	})
+}
+
+func TestGridClientQueryErrors(t *testing.T) {
+	tests := []struct {
+		name    string
+		body    string
+		wantErr string
+	}{
+		{
+			name:    "graphql errors array surfaces first message",
+			body:    `{"errors":[{"message":"unauthorized"}]}`,
+			wantErr: "unauthorized",
+		},
+		{
+			name:    "null data is an error",
+			body:    `{"data":null}`,
+			wantErr: "empty data",
+		},
+		{
+			name:    "malformed json body is a decode error",
+			body:    `{not-json`,
+			wantErr: "decode response",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				_, _ = io.WriteString(w, tt.body)
+			}))
+			defer srv.Close()
+
+			client := newGridClient(srv.URL, "", "", 5*time.Second)
+			_, err := client.query(context.Background())
+			if err == nil {
+				t.Fatal("expected error, got nil")
+			}
+			if !strings.Contains(err.Error(), tt.wantErr) {
+				t.Errorf("error = %q, want it to contain %q", err.Error(), tt.wantErr)
+			}
+		})
+	}
+}
+
+func TestGridClientQueryContextCancelled(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		<-r.Context().Done() // never respond; wait for the client to give up
+	}))
+	defer srv.Close()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before the call
+
+	client := newGridClient(srv.URL, "", "", 5*time.Second)
+	if _, err := client.query(ctx); err == nil {
+		t.Fatal("expected error from cancelled context, got nil")
+	}
+}

--- a/.monitoring/exporter/main.go
+++ b/.monitoring/exporter/main.go
@@ -29,47 +29,85 @@ func defaultEndpoint() string {
 	return fmt.Sprintf("%s://localhost:%s%s/graphql", protocol, port, subPath)
 }
 
-func main() {
+// config holds the resolved runtime settings for the exporter.
+type config struct {
+	gridURL       string
+	listenAddr    string
+	scrapeTimeout time.Duration
+	metricsPath   string
+	gridTimezone  string
+	retainStopped time.Duration
+	username      string
+	password      string
+}
+
+// parseFlags resolves the exporter configuration from command-line args, falling
+// back to the Hub/Router environment variables for defaults. It uses a dedicated
+// FlagSet (rather than the global one) so it is safe to call from tests.
+func parseFlags(name string, args []string) (config, error) {
 	defaultTZ := os.Getenv("TZ")
 	if defaultTZ == "" {
 		defaultTZ = "UTC"
 	}
 
-	var (
-		gridURL       = flag.String("grid-url", defaultEndpoint(), "Selenium Grid GraphQL endpoint; defaults to $SE_SERVER_PROTOCOL://localhost:$SE_ROUTER_PORT/$SE_SUB_PATH/graphql")
-		listenAddr    = flag.String("listen-address", ":9615", "Address to expose /metrics on")
-		scrapeTimeout = flag.Duration("scrape-timeout", 10*time.Second, "Timeout for each GraphQL scrape")
-		metricsPath   = flag.String("metrics-path", "/metrics", "Path under which to expose metrics")
-		gridTimezone  = flag.String("grid-timezone", defaultTZ, "Timezone of the Grid server (used to parse session startTime, e.g. Asia/Ho_Chi_Minh); defaults to $TZ")
-		retainStopped = flag.Duration("retain-stopped", 5*time.Minute, "How long to keep start/stop metrics for ended sessions")
-		username      = flag.String("username", os.Getenv("SE_ROUTER_USERNAME"), "Grid basic-auth username; defaults to $SE_ROUTER_USERNAME")
-		password      = flag.String("password", os.Getenv("SE_ROUTER_PASSWORD"), "Grid basic-auth password; defaults to $SE_ROUTER_PASSWORD")
-	)
-	flag.Parse()
+	fs := flag.NewFlagSet(name, flag.ContinueOnError)
+	var cfg config
+	fs.StringVar(&cfg.gridURL, "grid-url", defaultEndpoint(), "Selenium Grid GraphQL endpoint; defaults to $SE_SERVER_PROTOCOL://localhost:$SE_ROUTER_PORT/$SE_SUB_PATH/graphql")
+	fs.StringVar(&cfg.listenAddr, "listen-address", ":9615", "Address to expose /metrics on")
+	fs.DurationVar(&cfg.scrapeTimeout, "scrape-timeout", 10*time.Second, "Timeout for each GraphQL scrape")
+	fs.StringVar(&cfg.metricsPath, "metrics-path", "/metrics", "Path under which to expose metrics")
+	fs.StringVar(&cfg.gridTimezone, "grid-timezone", defaultTZ, "Timezone of the Grid server (used to parse session startTime, e.g. Asia/Ho_Chi_Minh); defaults to $TZ")
+	fs.DurationVar(&cfg.retainStopped, "retain-stopped", 5*time.Minute, "How long to keep start/stop metrics for ended sessions")
+	fs.StringVar(&cfg.username, "username", os.Getenv("SE_ROUTER_USERNAME"), "Grid basic-auth username; defaults to $SE_ROUTER_USERNAME")
+	fs.StringVar(&cfg.password, "password", os.Getenv("SE_ROUTER_PASSWORD"), "Grid basic-auth password; defaults to $SE_ROUTER_PASSWORD")
 
-	loc, err := time.LoadLocation(*gridTimezone)
+	if err := fs.Parse(args); err != nil {
+		return config{}, err
+	}
+	return cfg, nil
+}
+
+// newServer wires the collector, registry, and HTTP handlers into an
+// http.Server. It returns an error for invalid configuration (e.g. an unknown
+// timezone) so the caller can decide how to fail.
+func newServer(cfg config) (*http.Server, error) {
+	loc, err := time.LoadLocation(cfg.gridTimezone)
 	if err != nil {
-		log.Fatalf("invalid -grid-timezone %q: %v", *gridTimezone, err)
+		return nil, fmt.Errorf("invalid -grid-timezone %q: %w", cfg.gridTimezone, err)
 	}
 
-	client := newGridClient(*gridURL, *username, *password, *scrapeTimeout)
-	col := newCollector(client, *scrapeTimeout, loc, *retainStopped)
+	client := newGridClient(cfg.gridURL, cfg.username, cfg.password, cfg.scrapeTimeout)
+	col := newCollector(client, cfg.scrapeTimeout, loc, cfg.retainStopped)
 
 	reg := prometheus.NewRegistry()
 	reg.MustRegister(col)
 
 	mux := http.NewServeMux()
-	mux.Handle(*metricsPath, promhttp.HandlerFor(reg, promhttp.HandlerOpts{
+	mux.Handle(cfg.metricsPath, promhttp.HandlerFor(reg, promhttp.HandlerOpts{
 		ErrorHandling: promhttp.ContinueOnError,
 	}))
 	mux.HandleFunc("/", func(w http.ResponseWriter, r *http.Request) {
 		_, _ = w.Write([]byte(`<html><head><title>Selenium Grid Exporter</title></head>
 <body><h1>Selenium Grid Exporter</h1>
-<p><a href="` + *metricsPath + `">Metrics</a></p></body></html>`))
+<p><a href="` + cfg.metricsPath + `">Metrics</a></p></body></html>`))
 	})
 
-	log.Printf("selenium-grid-exporter listening on %s (grid: %s, tz: %s)", *listenAddr, *gridURL, loc)
-	if err := http.ListenAndServe(*listenAddr, mux); err != nil {
+	return &http.Server{Addr: cfg.listenAddr, Handler: mux}, nil
+}
+
+func main() {
+	cfg, err := parseFlags(os.Args[0], os.Args[1:])
+	if err != nil {
+		log.Fatalf("parse flags: %v", err)
+	}
+
+	srv, err := newServer(cfg)
+	if err != nil {
+		log.Fatalf("%v", err)
+	}
+
+	log.Printf("selenium-grid-exporter listening on %s (grid: %s, tz: %s)", cfg.listenAddr, cfg.gridURL, cfg.gridTimezone)
+	if err := srv.ListenAndServe(); err != nil {
 		log.Fatalf("listen: %v", err)
 	}
 }

--- a/.monitoring/exporter/main_test.go
+++ b/.monitoring/exporter/main_test.go
@@ -1,0 +1,194 @@
+package main
+
+import (
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestDefaultEndpoint(t *testing.T) {
+	tests := []struct {
+		name     string
+		protocol string
+		port     string
+		subPath  string
+		want     string
+	}{
+		{
+			name: "all defaults",
+			want: "http://localhost:4444/graphql",
+		},
+		{
+			name:     "custom protocol and port",
+			protocol: "https",
+			port:     "443",
+			want:     "https://localhost:443/graphql",
+		},
+		{
+			name:    "sub path with leading slash",
+			subPath: "/selenium",
+			want:    "http://localhost:4444/selenium/graphql",
+		},
+		{
+			name:    "sub path with trailing slash is trimmed",
+			subPath: "/selenium/",
+			want:    "http://localhost:4444/selenium/graphql",
+		},
+		{
+			name:    "bare slash sub path collapses cleanly",
+			subPath: "/",
+			want:    "http://localhost:4444/graphql",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// t.Setenv both sets the value and restores the prior one on cleanup,
+			// so each case runs with a known, isolated environment.
+			t.Setenv("SE_SERVER_PROTOCOL", tt.protocol)
+			t.Setenv("SE_ROUTER_PORT", tt.port)
+			t.Setenv("SE_SUB_PATH", tt.subPath)
+
+			if got := defaultEndpoint(); got != tt.want {
+				t.Errorf("defaultEndpoint() = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestParseFlagsDefaults(t *testing.T) {
+	// Clear the env so defaults are deterministic.
+	for _, k := range []string{"TZ", "SE_SERVER_PROTOCOL", "SE_ROUTER_PORT", "SE_SUB_PATH", "SE_ROUTER_USERNAME", "SE_ROUTER_PASSWORD"} {
+		t.Setenv(k, "")
+	}
+
+	cfg, err := parseFlags("exporter", nil)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if cfg.listenAddr != ":9615" {
+		t.Errorf("listenAddr = %q, want :9615", cfg.listenAddr)
+	}
+	if cfg.metricsPath != "/metrics" {
+		t.Errorf("metricsPath = %q, want /metrics", cfg.metricsPath)
+	}
+	if cfg.scrapeTimeout != 10*time.Second {
+		t.Errorf("scrapeTimeout = %v, want 10s", cfg.scrapeTimeout)
+	}
+	if cfg.retainStopped != 5*time.Minute {
+		t.Errorf("retainStopped = %v, want 5m", cfg.retainStopped)
+	}
+	if cfg.gridTimezone != "UTC" {
+		t.Errorf("gridTimezone = %q, want UTC (fallback when $TZ unset)", cfg.gridTimezone)
+	}
+	if cfg.gridURL != "http://localhost:4444/graphql" {
+		t.Errorf("gridURL = %q, unexpected default", cfg.gridURL)
+	}
+}
+
+func TestParseFlagsOverrides(t *testing.T) {
+	t.Setenv("TZ", "")
+	args := []string{
+		"-grid-url", "https://hub:4444/selenium/graphql",
+		"-listen-address", ":8080",
+		"-scrape-timeout", "3s",
+		"-metrics-path", "/m",
+		"-grid-timezone", "Asia/Ho_Chi_Minh",
+		"-retain-stopped", "1m",
+		"-username", "admin",
+		"-password", "secret",
+	}
+	cfg, err := parseFlags("exporter", args)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	want := config{
+		gridURL:       "https://hub:4444/selenium/graphql",
+		listenAddr:    ":8080",
+		scrapeTimeout: 3 * time.Second,
+		metricsPath:   "/m",
+		gridTimezone:  "Asia/Ho_Chi_Minh",
+		retainStopped: time.Minute,
+		username:      "admin",
+		password:      "secret",
+	}
+	if cfg != want {
+		t.Errorf("parseFlags() = %+v, want %+v", cfg, want)
+	}
+}
+
+func TestParseFlagsEnvDefaults(t *testing.T) {
+	t.Setenv("TZ", "Europe/Berlin")
+	t.Setenv("SE_ROUTER_USERNAME", "envuser")
+	t.Setenv("SE_ROUTER_PASSWORD", "envpass")
+
+	cfg, err := parseFlags("exporter", nil)
+	if err != nil {
+		t.Fatalf("parseFlags: %v", err)
+	}
+	if cfg.gridTimezone != "Europe/Berlin" {
+		t.Errorf("gridTimezone = %q, want Europe/Berlin from $TZ", cfg.gridTimezone)
+	}
+	if cfg.username != "envuser" || cfg.password != "envpass" {
+		t.Errorf("credentials = (%q,%q), want env defaults", cfg.username, cfg.password)
+	}
+}
+
+func TestParseFlagsInvalid(t *testing.T) {
+	if _, err := parseFlags("exporter", []string{"-scrape-timeout", "not-a-duration"}); err == nil {
+		t.Error("expected error for invalid duration flag, got nil")
+	}
+}
+
+func TestNewServerInvalidTimezone(t *testing.T) {
+	_, err := newServer(config{gridTimezone: "Not/AZone", metricsPath: "/metrics"})
+	if err == nil {
+		t.Fatal("expected error for invalid timezone, got nil")
+	}
+	if !strings.Contains(err.Error(), "grid-timezone") {
+		t.Errorf("error = %q, want it to mention grid-timezone", err.Error())
+	}
+}
+
+func TestNewServerHandlers(t *testing.T) {
+	srv, err := newServer(config{
+		gridURL:       "http://127.0.0.1:0/graphql", // unreachable; landing page needs no scrape
+		listenAddr:    ":0",
+		scrapeTimeout: time.Second,
+		metricsPath:   "/metrics",
+		gridTimezone:  "UTC",
+		retainStopped: time.Minute,
+	})
+	if err != nil {
+		t.Fatalf("newServer: %v", err)
+	}
+	if srv.Addr != ":0" {
+		t.Errorf("server Addr = %q, want :0", srv.Addr)
+	}
+
+	// Landing page links to the metrics path.
+	rec := httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("landing page status = %d, want 200", rec.Code)
+	}
+	body, _ := io.ReadAll(rec.Result().Body)
+	if !strings.Contains(string(body), `href="/metrics"`) {
+		t.Errorf("landing page missing metrics link: %s", body)
+	}
+
+	// The metrics endpoint is registered and exposes exporter health even when
+	// the Grid is unreachable (scrape_success 0).
+	rec = httptest.NewRecorder()
+	srv.Handler.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	if rec.Code != http.StatusOK {
+		t.Errorf("metrics status = %d, want 200", rec.Code)
+	}
+	metrics, _ := io.ReadAll(rec.Result().Body)
+	if !strings.Contains(string(metrics), "selenium_grid_scrape_success") {
+		t.Errorf("metrics output missing scrape_success: %s", metrics)
+	}
+}

--- a/Makefile
+++ b/Makefile
@@ -148,6 +148,19 @@ build_exporter:
 	cd .monitoring/exporter && go mod edit -go=$$(go env GOVERSION | sed 's/go//') && go mod tidy \
 	&& go build -ldflags="-s -w" -o ../../bin/selenium-grid-exporter .
 
+# Unit-test the Grid monitoring exporter. Run this after a Go toolchain or
+# dependency bump (e.g. `make update_go`) to catch regressions before release.
+test_exporter:
+	cd .monitoring/exporter && go vet ./... && go test ./... -race -covermode=atomic -cover
+
+# Unit-test the KEDA external scaler module.
+test_scaler:
+	cd .keda-external-scaler && go vet ./... && go test ./... -race -covermode=atomic -cover
+
+# Test every in-repo Go module. Mirrors the go-test.yml CI workflow; run after
+# `make update_go` to validate a toolchain/dependency bump locally.
+test_go_modules: test_exporter test_scaler
+
 # Container image providing the Go toolchain used by `update_go`. Defaults to the
 # latest stable Go so no host Go install is needed and updates always track upstream.
 GO_IMAGE ?= 'latest'
@@ -1494,6 +1507,9 @@ test_k8s_dynamic_grid_hub_node:
 	base \
 	build \
 	build_exporter \
+	test_exporter \
+	test_scaler \
+	test_go_modules \
 	update_go \
 	ci \
 	chrome \


### PR DESCRIPTION
## Motivation

The two in-repo Go modules — the **Grid monitoring exporter** (`.monitoring/exporter`) and the **KEDA external scaler** (`.keda-external-scaler`) — had **no CI job running `go test`**. They were only compiled implicitly during Hub/Router image builds, so a Go toolchain bump (`make update_go`) or a Renovate dependency update could silently break them. This PR adds unit/functional tests and a CI gate that keeps them green and well-covered.

## What's included

### CI — `.github/workflows/go-test.yml`
- Matrix over both modules; triggers on any push/PR touching either module **or** the workflow (so `update_go`/Renovate `go.mod`/`go.sum` bumps run it), plus `workflow_dispatch`.
- Picks Go via `go-version-file` from each module's `go.mod`, so a toolchain bump is validated on the exact version it introduces.
- Steps: `go mod verify`, a `go mod tidy` diff-guard (catches incomplete dep updates), `go vet`, `go build`, `go test -race`, and a **coverage gate that fails under 90%** (generated protobuf `*.pb.go` excluded).

### Grid monitoring exporter — 87.7% → **93.9%**
- Extracted testable `parseFlags` / `newServer` seams from `main()` (behavior-preserving).
- New tests: capability/stereotype/time parsing, GraphQL client (auth, error paths, cancellation), the full metric contract, and the stateful session lifecycle (start → stop detection → completed counter → retention prune), node status scoring, de-registration, and duration fallback.

### KEDA external scaler
- `internal/gridscaler` (business logic): 84.7% → **99.6%** — table-driven tests for `GetPlatform` and the error/resilience branches. No production code changed here.
- `cmd/scaler` (entrypoint): 0% → **92.9%** — small behavior-preserving refactor splitting `main()` into a testable `realMain(ctx, …)` plus a `serve()` seam; tests cover flag/env parsing, graceful shutdown (plain + TLS), listen errors, and unexpected server death.
- Combined non-generated coverage: **98.3%**.

### Makefile
- `test_exporter`, `test_scaler`, and `test_go_modules` targets for local parity with CI (run after `make update_go`).

## Notes
- Generated protobuf (`externalscaler/*.pb.go`) is excluded from the coverage metric, as is conventional.
- Minor behavior change in `cmd/scaler`: one startup log field (`gridUrlFromEnv`) was dropped and the listen address is now logged as the resolved `lis.Addr()`.

## Verification
`go vet`, `go test ./... -race`, the ≥90% gate, and `go mod tidy` (no diff) all pass for both modules.

🤖 Generated with [Claude Code](https://claude.com/claude-code)