### PR TITLE
test(exporter): fix malformed session StartTime breaking collector tests

### DIFF
--- a/.monitoring/exporter/collector_test.go
+++ b/.monitoring/exporter/collector_test.go
@@ -53,12 +53,12 @@ func (s *swapServer) set(body string) {
 func (s *swapServer) close() { s.srv.Close() }
 
 // chromeSession is the canonical active session used across the collector tests.
-// startTime 02/01/2.20.10:00:00 UTC == unix 1577959200.
+// startTime 02/01/2020 10:00:00 UTC == unix 1577959200.
 func chromeSession(t *testing.T) sessionEntry {
 	return sessionEntry{
 		ID:                    "s1",
 		Capabilities:          encode(t, caps{BrowserName: "chrome", BrowserVersion: "124", PlatformName: "linux", TestName: "login-test", ContainerName: "node-chrome-1"}),
-		StartTime:             "02/01/2.20.10:00:00",
+		StartTime:             "02/01/2020 10:00:00",
 		SessionDurationMillis: "42300",
 		NodeID:                "node-up",
 		NodeURI:               "http://node1:5555",


### PR DESCRIPTION
## Problem

The `Go Unit Tests` → `selenium-grid-exporter` job is failing on `trunk` ([run](https://github.com/SeleniumHQ/docker-selenium/actions/runs/31523742006/job/93886872986)):

```
--- FAIL: TestCollectFullSnapshot
    collector_test.go: selenium_grid_session_start_seconds{s1} missing
--- FAIL: TestSessionLifecycle
    collector_test.go: start_seconds missing while session active
--- FAIL: TestSessionDurationFallback
    collector_test.go: fallback duration = 0, want > 0
```

## Cause

The test fixture's `StartTime` was `"02/01/2.20.10:00:00"` — a malformed value that does not match the Grid time layout `dd/MM/yyyy HH:mm:ss` the exporter parses. `parseGridTime` returned `0`, so:
- `session_start_seconds` is suppressed (only emitted when `startUnix > 0`), and
- the duration wall-clock fallback (guarded by `startUnix > 0`) stayed `0`.

## Fix

Restore the intended `"02/01/2020 10:00:00"` (== unix `1577959200`, matching `chromeSessionStartUnix`).

## Verification

`go test ./... -race -covermode=atomic` passes locally; coverage 93.9% (gate ≥90% passes). Only the `selenium-grid-exporter` job was affected; `keda-external-scaler` was already green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)