### PR TITLE
ci: reliable multi-arch build setup — QEMU + skip Docker reinstall

### DIFF
--- a/tests/charts/make/chart_setup_env.sh
+++ b/tests/charts/make/chart_setup_env.sh
@@ -18,6 +18,13 @@ on_failure() {
 }
 
 if [[ "${INSTALL_DOCKER}" != "true" ]]; then
+    # Docker is already present on the runner, so its installation is skipped.
+    # Still register QEMU/binfmt so multi-arch (e.g. linux/arm64) image builds can
+    # run under emulation; otherwise cross-arch RUN steps fail with
+    # "exec /bin/sh: exec format error".
+    if [ "${DOCKER_ENABLE_QEMU}" = "true" ]; then
+        docker run --privileged --rm tonistiigi/binfmt --install all
+    fi
     exit 0
 fi
 

--- a/tests/charts/make/chart_setup_env.sh
+++ b/tests/charts/make/chart_setup_env.sh
@@ -31,38 +31,47 @@ fi
 # Trap ERR signal and call on_failure function
 trap 'on_failure' ERR
 
-echo "Installing Docker for AMD64 / ARM64"
-sudo apt-get update -qq || true
-sudo apt-get install -yq ca-certificates curl wget jq
-sudo install -m 0755 -d /etc/apt/keyrings
-sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
-sudo chmod a+r /etc/apt/keyrings/docker.asc
-echo \
-    "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
-   $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
-sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
-sudo apt-get update -qq || true
-if [ -n "${DOCKER_VERSION}" ]; then
-  DOCKER_VERSION_EXPECT=$DOCKER_VERSION
-  if [[ "${DOCKER_VERSION}" == "20.10"* ]]; then
-    DOCKER_VERSION="=5:${DOCKER_VERSION}~3-0~$(. /etc/os-release; echo "$ID")-$(. /etc/os-release; echo "$VERSION_CODENAME")"
-  else
-    DOCKER_VERSION="=5:${DOCKER_VERSION}-1~$(. /etc/os-release; echo "$ID").$(. /etc/os-release; echo "$VERSION_ID")~$(. /etc/os-release; echo "$VERSION_CODENAME")"
-  fi
-  echo "Installing package docker-ce${DOCKER_VERSION}"
-  ALLOW_DOWNGRADE="--allow-downgrades"
-fi
-echo "Installing Docker CE packages..."
-timeout 5m sudo apt-get install -yqf ${ALLOW_DOWNGRADE} docker-ce${DOCKER_VERSION} docker-ce-cli${DOCKER_VERSION} || {
-    echo "Docker CE installation timed out or failed, retrying..."
-    sudo apt-get install -yf ${ALLOW_DOWNGRADE} docker-ce${DOCKER_VERSION} docker-ce-cli${DOCKER_VERSION}
-}
+DOCKER_VERSION_EXPECT=${DOCKER_VERSION}
+INSTALLED_DOCKER_VERSION="$(docker version --format '{{.Server.Version}}' 2>/dev/null || true)"
 
-echo "Installing Docker plugins and container runtime..."
-timeout 5m sudo apt-get install -yqf ${ALLOW_DOWNGRADE} containerd.io docker-buildx-plugin docker-compose-plugin || {
-    echo "Docker plugins installation timed out or failed, retrying..."
-    sudo apt-get install -yf ${ALLOW_DOWNGRADE} containerd.io docker-buildx-plugin docker-compose-plugin
-}
+# GitHub-hosted runners already ship Docker, buildx and compose. Reinstalling them
+# from apt on every run is redundant and is the slowest/flakiest part of this setup
+# (frequent apt timeouts that exceed the retry action's window). Only (re)install
+# Docker CE when a specific version is requested that differs from what is already
+# present; otherwise use the runner's pre-installed Docker.
+if [ -z "${DOCKER_VERSION}" ]; then
+    echo "No specific Docker version requested; using pre-installed Docker ${INSTALLED_DOCKER_VERSION:-unknown}."
+elif [ "${DOCKER_VERSION}" = "${INSTALLED_DOCKER_VERSION}" ]; then
+    echo "Docker ${DOCKER_VERSION} is already installed; skipping reinstall."
+else
+    echo "Installing Docker CE ${DOCKER_VERSION} for AMD64 / ARM64 (runner has ${INSTALLED_DOCKER_VERSION:-none})"
+    sudo apt-get update -qq || true
+    sudo apt-get install -yq ca-certificates curl wget jq
+    sudo install -m 0755 -d /etc/apt/keyrings
+    sudo curl -fsSL https://download.docker.com/linux/ubuntu/gpg -o /etc/apt/keyrings/docker.asc
+    sudo chmod a+r /etc/apt/keyrings/docker.asc
+    echo \
+        "deb [arch=$(dpkg --print-architecture) signed-by=/etc/apt/keyrings/docker.asc] https://download.docker.com/linux/ubuntu \
+       $(. /etc/os-release && echo "$VERSION_CODENAME") stable" | \
+    sudo tee /etc/apt/sources.list.d/docker.list > /dev/null
+    sudo apt-get update -qq || true
+    if [[ "${DOCKER_VERSION}" == "20.10"* ]]; then
+        DOCKER_VERSION="=5:${DOCKER_VERSION}~3-0~$(. /etc/os-release; echo "$ID")-$(. /etc/os-release; echo "$VERSION_CODENAME")"
+    else
+        DOCKER_VERSION="=5:${DOCKER_VERSION}-1~$(. /etc/os-release; echo "$ID").$(. /etc/os-release; echo "$VERSION_ID")~$(. /etc/os-release; echo "$VERSION_CODENAME")"
+    fi
+    ALLOW_DOWNGRADE="--allow-downgrades"
+    echo "Installing Docker CE packages docker-ce${DOCKER_VERSION}..."
+    timeout 5m sudo apt-get install -yqf ${ALLOW_DOWNGRADE} docker-ce${DOCKER_VERSION} docker-ce-cli${DOCKER_VERSION} || {
+        echo "Docker CE installation timed out or failed, retrying..."
+        sudo apt-get install -yf ${ALLOW_DOWNGRADE} docker-ce${DOCKER_VERSION} docker-ce-cli${DOCKER_VERSION}
+    }
+    echo "Installing Docker plugins and container runtime..."
+    timeout 5m sudo apt-get install -yqf ${ALLOW_DOWNGRADE} containerd.io docker-buildx-plugin docker-compose-plugin || {
+        echo "Docker plugins installation timed out or failed, retrying..."
+        sudo apt-get install -yf ${ALLOW_DOWNGRADE} containerd.io docker-buildx-plugin docker-compose-plugin
+    }
+fi
 
 echo "Installing cross-compilation tools (may take a while)..."
 timeout 5m sudo apt-get install -yqf gcc-aarch64-linux-gnu qemu-user-static || {

--- a/tests/charts/make/chart_setup_env.sh
+++ b/tests/charts/make/chart_setup_env.sh
@@ -31,6 +31,12 @@ fi
 # Trap ERR signal and call on_failure function
 trap 'on_failure' ERR
 
+# Refresh the apt index up front so the package installs below (qemu-user-static,
+# conntrack, ...) don't 404 on a stale cached index. Previously this happened as a
+# side effect of the Docker reinstall's `apt-get update`; that reinstall is now
+# skipped when the runner already has the requested Docker, so do it explicitly.
+sudo apt-get update -qq || true
+
 DOCKER_VERSION_EXPECT=${DOCKER_VERSION}
 INSTALLED_DOCKER_VERSION="$(docker version --format '{{.Server.Version}}' 2>/dev/null || true)"
 


### PR DESCRIPTION
Two related fixes to `tests/charts/make/chart_setup_env.sh` (the script behind the **Set up containerd image store feature** step), both about making multi-arch builds work reliably without reinstalling Docker.

## 1. Register QEMU/binfmt when `INSTALL_DOCKER=false`

The Chrome deploy workflow ([failing run](https://github.com/SeleniumHQ/docker-selenium/actions/runs/31525653178/job/93909352003)) builds `linux/amd64,linux/arm64` since #3187, but its setup runs `INSTALL_DOCKER=false make setup_dev_env`, which short-circuited the script **before** the `tonistiigi/binfmt` registration. The arm64 build then failed at the first `RUN`:

```
#12 [linux/arm64  3/11] RUN ... /opt/bin/install-chrome.sh
#12 0.155 exec /bin/sh: exec format error
```

Fix: register QEMU/binfmt (still gated by `DOCKER_ENABLE_QEMU`) in the `INSTALL_DOCKER=false` path too, reusing the runner's pre-installed Docker. Firefox/deploy/nightly already worked because they use `INSTALL_DOCKER=true`; Edge was unaffected because it is amd64-only.

## 2. Don't reinstall Docker by default (setup reliability)

The `INSTALL_DOCKER=true` path (K8s/chart jobs) reinstalled Docker CE + plugins from apt on **every** run, even though GitHub runners already ship Docker/buildx/compose. That network apt reinstall is the slowest/flakiest part of setup and frequently exceeds the retry action's 10-minute window ([example](https://github.com/SeleniumHQ/docker-selenium/actions/runs/31532115814/job/93914525417?pr=3204) → `kill EPERM` at 10:00).

Fix: only (re)install Docker CE when a specific `DOCKER_VERSION` is requested **and differs** from what's already on the runner; otherwise use the pre-installed Docker. The downstream version-match guard is preserved, so version-pinned jobs still fail fast if the expected version isn't active.

## Result

- Multi-arch (arm64) builds get QEMU emulation in both the `INSTALL_DOCKER=false` and `true` paths.
- No redundant Docker reinstall → faster, far less apt-timeout flakiness.
- Behavior for genuinely version-pinned jobs (a different Docker version than the runner's) is unchanged.

Validated with `bash -n`. Best confirmed by a green re-run of the Chrome deploy + K8s workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
