### PR TITLE
fix(edge): install Edge browser + driver from NDViet archive when Microsoft prunes old versions

### DIFF
--- a/NodeEdge/Dockerfile
+++ b/NodeEdge/Dockerfile
@@ -14,13 +14,18 @@ USER root
 #  e.g. microsoft-edge-beta=88.0.692.0-1
 #============================================
 ARG EDGE_VERSION="microsoft-edge-stable"
+# Microsoft prunes old versions from packages.microsoft.com, so version-specific
+# installs are pulled from the per-version archive (mirrors the Google Chrome
+# approach with NDViet/google-chrome-stable). Latest still comes from the repo.
+ARG EDGE_ARCHIVE_SITE="https://github.com/NDViet/microsoft-edge-stable/releases/download"
 RUN wget -q -O - https://packages.microsoft.com/keys/microsoft.asc | gpg --dearmor | tee /etc/apt/trusted.gpg.d/microsoft.gpg >/dev/null \
   && echo "deb https://packages.microsoft.com/repos/edge stable main" > /etc/apt/sources.list.d/microsoft-edge.list \
   && apt-get update -qqy \
   && if echo "${EDGE_VERSION}" | grep -qE "microsoft-edge-stable[_|=][0-9]*"; \
     then \
-      EDGE_VERSION=$(echo "$EDGE_VERSION" | tr '=' '_') \
-      && wget -qO microsoft-edge.deb "https://packages.microsoft.com/repos/edge/pool/main/m/microsoft-edge-stable/${EDGE_VERSION}_$(dpkg --print-architecture).deb" \
+      EDGE_VERSION_NUMBER=$(echo "$EDGE_VERSION" | cut -d'=' -f2) \
+      && EDGE_VERSION=$(echo "$EDGE_VERSION" | tr '=' '_') \
+      && wget -qO microsoft-edge.deb "${EDGE_ARCHIVE_SITE}/${EDGE_VERSION_NUMBER}/${EDGE_VERSION}_$(dpkg --print-architecture).deb" \
       && apt-get -qqy --no-install-recommends install --allow-downgrades ./microsoft-edge.deb \
       && rm -rf microsoft-edge.deb ; \
     else \
@@ -38,16 +43,23 @@ RUN /opt/bin/wrap_edge_binary
 # Edge webdriver
 #============================================
 # can specify versions by EDGE_DRIVER_VERSION
-# Latest released version will be used by default
+# Latest released version will be used by default. Microsoft prunes old
+# msedgedriver builds (and the LATEST_RELEASE_<major> pointer), so for pruned
+# versions the exact browser version is used and the download falls back to the
+# per-version archive (NDViet/microsoft-edge-stable), mirroring the browser deb.
 #============================================
 ARG EDGE_DRIVER_VERSION
 RUN DRIVER_ARCH=$(if [ "$(dpkg --print-architecture)" = "amd64" ]; then echo "linux64"; else echo "linux-aarch64"; fi) \
   && if [ -z "$EDGE_DRIVER_VERSION" ]; \
   then EDGE_MAJOR_VERSION=$(microsoft-edge --version | sed -E "s/.* ([0-9]+)(\.[0-9]+){3}.*/\1/") \
-    && EDGE_DRIVER_VERSION=$(wget --no-verbose -O - "https://msedgedriver.microsoft.com/LATEST_RELEASE_${EDGE_MAJOR_VERSION}_LINUX" | tr -cd "\11\12\15\40-\176" | tr -d "\r"); \
+    && EDGE_DRIVER_VERSION=$(wget --no-verbose -O - "https://msedgedriver.microsoft.com/LATEST_RELEASE_${EDGE_MAJOR_VERSION}_LINUX" | tr -cd "\11\12\15\40-\176" | tr -d "\r" || true) ; \
+    if [ -z "$EDGE_DRIVER_VERSION" ]; \
+    then EDGE_DRIVER_VERSION=$(microsoft-edge --version | sed -E "s/.* ([0-9]+(\.[0-9]+){3}).*/\1/") ; \
+    fi ; \
   fi \
   && echo "Using msedgedriver version: "$EDGE_DRIVER_VERSION \
-  && wget --no-verbose -O /tmp/msedgedriver_${DRIVER_ARCH}.zip https://msedgedriver.microsoft.com/$EDGE_DRIVER_VERSION/edgedriver_${DRIVER_ARCH}.zip \
+  && ( wget --no-verbose -O /tmp/msedgedriver_${DRIVER_ARCH}.zip "https://msedgedriver.microsoft.com/$EDGE_DRIVER_VERSION/edgedriver_${DRIVER_ARCH}.zip" \
+    || wget --no-verbose -O /tmp/msedgedriver_${DRIVER_ARCH}.zip "${EDGE_ARCHIVE_SITE}/${EDGE_DRIVER_VERSION}-1/edgedriver_${DRIVER_ARCH}.zip" ) \
   && rm -rf /opt/selenium/msedgedriver \
   && unzip /tmp/msedgedriver_${DRIVER_ARCH}.zip -d /opt/selenium \
   && rm /tmp/msedgedriver_${DRIVER_ARCH}.zip \


### PR DESCRIPTION
## Problem

Microsoft prunes old versions from its endpoints, breaking backward-compatible Edge image builds ([failing run](https://github.com/SeleniumHQ/docker-selenium/actions/runs/31558898235/job/94009822709), Edge 114):

- **Browser deb** — old versions removed from `packages.microsoft.com/repos/edge/pool`.
- **Driver** — old `msedgedriver` builds **and** the `LATEST_RELEASE_<major>_LINUX` pointer removed from `msedgedriver.microsoft.com` (Azure `BlobNotFound`). This is the actual 404 in the linked run.

I verified both `msedgedriver.microsoft.com/114.0.1823.82/edgedriver_linux64.zip` and the `LATEST_RELEASE_114` pointer return 404, and the `azureedge.net` CDN is decommissioned.

## Fix (mirrors the Google Chrome / NDViet approach)

`NodeEdge/Dockerfile`:

1. **Browser** — version-specific debs are pulled from the per-version archive `https://github.com/NDViet/microsoft-edge-stable` (tag `<version>-1`, asset `microsoft-edge-stable_<version>-1_amd64.deb`). Latest (unpinned) still installs from the Microsoft repo.
2. **Driver** — when `LATEST_RELEASE_<major>` is gone, resolve the exact browser version (Edge ships the driver in lockstep), then download from Microsoft first and **fall back** to the same archive (`edgedriver_linux64.zip` on the `<version>-1` release tag).

`EDGE_ARCHIVE_SITE` is overridable via build-arg.

## Archived drivers for 114 / 115

The msedgedriver for 114/115 was no longer available from Microsoft or common mirrors (npmmirror only goes back to major 124), so I extracted the genuine binaries from the previously-published `selenium/node-edge:114.0.1823.82-*` / `:115.0.1901.203-*` images (verified ELF x86-64 with matching embedded versions) and archived them:

- `NDViet/microsoft-edge-stable` @ `114.0.1823.82-1` → `edgedriver_linux64.zip` (+ deb)
- `NDViet/microsoft-edge-stable` @ `115.0.1901.203-1` → `edgedriver_linux64.zip` (+ deb)

Both download URLs return `200`.

## Verification

`sh -n` on the driver logic passes; a mocked simulation confirms `LATEST_RELEASE` 404 → exact browser version → Microsoft 404 → archive URL (`.../114.0.1823.82-1/edgedriver_linux64.zip`, verified 200). Final confirmation: a re-run of the Edge 114/115 backward-compatible build.

🤖 Generated with [Claude Code](https://claude.com/claude-code)