### PR TITLE
K8s: Replace external scaler jobScalingStrategy with includeOngoingSessions

### DIFF
--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -79,9 +79,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: deployment
-          - k8s-version: 'v1.30.14'
+          - k8s-version: 'v1.31.14'
             cluster: 'minikube'
-            helm-version: 'v3.15.4'
+            helm-version: 'v3.16.4'
             docker-version: '27.5.1'
             python-version: '3.11'
             test-upgrade: true

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -49,9 +49,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
-            helm-version: 'v3.19.2'
+            helm-version: 'v3.20.2'
             docker-version: '29.1.1'
             python-version: '3.10'
             test-upgrade: true
@@ -59,9 +59,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: disabled
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
-            helm-version: 'v3.18.6'
+            helm-version: 'v3.19.5'
             docker-version: '29.1.1'
             python-version: '3.10'
             test-upgrade: true
@@ -69,9 +69,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: job
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
-            helm-version: 'v4.0.1'
+            helm-version: 'v4.1.4'
             docker-version: '29.1.1'
             python-version: '3.14'
             test-upgrade: true
@@ -79,9 +79,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: deployment
-          - k8s-version: 'v1.29.15'
+          - k8s-version: 'v1.30.14'
             cluster: 'minikube'
-            helm-version: 'v3.14.3'
+            helm-version: 'v3.15.4'
             docker-version: '27.5.1'
             python-version: '3.11'
             test-upgrade: true
@@ -89,9 +89,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: job_https
-          - k8s-version: 'v1.30.14'
+          - k8s-version: 'v1.31.14'
             cluster: 'minikube'
-            helm-version: 'v3.15.4'
+            helm-version: 'v3.16.4'
             docker-version: '27.5.1'
             python-version: '3.12'
             test-upgrade: true
@@ -99,9 +99,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: job_hostname
-          - k8s-version: 'v1.31.14'
+          - k8s-version: 'v1.32.13'
             cluster: 'minikube'
-            helm-version: 'v3.16.4'
+            helm-version: 'v3.17.4'
             docker-version: '27.5.1'
             python-version: '3.13'
             test-upgrade: true
@@ -109,9 +109,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: deployment_https
-          - k8s-version: 'v1.32.10'
+          - k8s-version: 'v1.33.13'
             cluster: 'minikube'
-            helm-version: 'v3.17.4'
+            helm-version: 'v3.18.6'
             docker-version: '28.5.2'
             python-version: '3.10'
             test-upgrade: true
@@ -119,9 +119,9 @@ jobs:
             os: ubuntu-22.04
             check-records-output: true
             test-strategy: playwright_connect_grid
-          - k8s-version: 'v1.32.10'
+          - k8s-version: 'v1.33.13'
             cluster: 'minikube'
-            helm-version: 'v3.18.6'
+            helm-version: 'v3.19.5'
             docker-version: '28.5.2'
             python-version: '3.10'
             test-upgrade: true

--- a/.github/workflows/k8s-dynamic-grid-test.yml
+++ b/.github/workflows/k8s-dynamic-grid-test.yml
@@ -26,13 +26,13 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
             docker-version: '29.1.1'
             python-version: '3.10'
             os: ubuntu-22.04
             mode: standalone
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
             docker-version: '29.1.1'
             python-version: '3.10'

--- a/.github/workflows/k8s-scaling-test.yml
+++ b/.github/workflows/k8s-scaling-test.yml
@@ -92,6 +92,27 @@ jobs:
             python-version: '3.12'
             os: ubuntu-22.04
             test-strategy: test_k8s_autoscaling_job_count_strategy_default
+          - k8s-version: 'v1.35.8'
+            cluster: 'minikube'
+            helm-version: 'v4.1.4'
+            docker-version: '29.1.1'
+            python-version: '3.13'
+            os: ubuntu-22.04
+            test-strategy: test_k8s_autoscaling_job_count_strategy_accurate_in_chaos
+          - k8s-version: 'v1.35.8'
+            cluster: 'minikube'
+            helm-version: 'v3.20.2'
+            docker-version: '29.1.1'
+            python-version: '3.13'
+            os: ubuntu-22.04
+            test-strategy: test_k8s_autoscaling_job_count_strategy_accurate_with_node_max_sessions
+          - k8s-version: 'v1.34.11'
+            cluster: 'minikube'
+            helm-version: 'v3.20.2'
+            docker-version: '29.1.1'
+            python-version: '3.12'
+            os: ubuntu-22.04
+            test-strategy: test_k8s_autoscaling_job_count_strategy_accurate
           - k8s-version: 'v1.31.14'
             cluster: 'minikube'
             helm-version: 'v3.16.4'

--- a/.github/workflows/k8s-scaling-test.yml
+++ b/.github/workflows/k8s-scaling-test.yml
@@ -71,44 +71,44 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
-            helm-version: 'v4.0.1'
+            helm-version: 'v4.1.4'
             docker-version: '29.1.1'
             python-version: '3.13'
             os: ubuntu-22.04
             test-strategy: test_k8s_autoscaling_job_count_strategy_default_in_chaos
-          - k8s-version: 'v1.34.2'
+          - k8s-version: 'v1.35.8'
             cluster: 'minikube'
-            helm-version: 'v3.19.2'
+            helm-version: 'v3.20.2'
             docker-version: '29.1.1'
             python-version: '3.13'
             os: ubuntu-22.04
             test-strategy: test_k8s_autoscaling_job_count_strategy_default_with_node_max_sessions
-          - k8s-version: 'v1.33.6'
+          - k8s-version: 'v1.34.11'
             cluster: 'minikube'
-            helm-version: 'v3.19.2'
+            helm-version: 'v3.20.2'
             docker-version: '29.1.1'
             python-version: '3.12'
             os: ubuntu-22.04
             test-strategy: test_k8s_autoscaling_job_count_strategy_default
-          - k8s-version: 'v1.30.14'
+          - k8s-version: 'v1.31.14'
             cluster: 'minikube'
-            helm-version: 'v3.15.4'
+            helm-version: 'v3.16.4'
             docker-version: '27.5.1'
             python-version: '3.12'
             os: ubuntu-22.04
             test-strategy: test_k8s_autoscaling_deployment_count_in_chaos
-          - k8s-version: 'v1.31.14'
+          - k8s-version: 'v1.32.13'
             cluster: 'minikube'
-            helm-version: 'v3.16.4'
+            helm-version: 'v3.17.4'
             docker-version: '28.5.2'
             python-version: '3.13'
             os: ubuntu-22.04
             test-strategy: test_k8s_autoscaling_deployment_count_with_node_max_sessions
-          - k8s-version: 'v1.32.10'
+          - k8s-version: 'v1.33.13'
             cluster: 'minikube'
-            helm-version: 'v3.17.4'
+            helm-version: 'v3.18.6'
             docker-version: '28.5.2'
             python-version: '3.11'
             os: ubuntu-22.04

--- a/.keda-external-scaler/PLAN.md
+++ b/.keda-external-scaler/PLAN.md
@@ -71,7 +71,7 @@ Everything downstream of T6 is sequential.
 - **Gate 1 (after T3):** `go test ./internal/gridscaler` green with unmodified
   upstream expectations → algorithm parity proven.
 - **Gate 2 (after T6):** in-process gRPC + fake Grid fixture test green,
-  including all four `jobScalingStrategy` conventions and activation threshold →
+  including both `includeOngoingSessions` conventions and activation threshold →
   wire-level parity proven.
 - **Gate 3 (after T8):** `make image` builds linux/amd64+arm64; container starts
   and serves health check.

--- a/.keda-external-scaler/README.md
+++ b/.keda-external-scaler/README.md
@@ -8,7 +8,7 @@ This is a functional extraction of KEDA's built-in `selenium-grid` scaler
 (`kedacore/keda/pkg/scalers/selenium_grid_scaler.go`), so that Selenium's
 autoscaling logic can be released on the docker-selenium cadence instead of
 KEDA's. The scaling algorithm — capability matching (mirroring Grid's
-`DefaultSlotMatcher`), slot reservation, and the per-`jobScalingStrategy` count
+`DefaultSlotMatcher`), slot reservation, and the `includeOngoingSessions` count
 conventions — is ported verbatim and covered by KEDA's own upstream test table.
 
 ## How it differs from the built-in scaler
@@ -43,13 +43,37 @@ the scaler):
 | `enableManagedDownloads` | `true` | |
 | `activationThreshold` | `0` | scale-from-zero threshold |
 | `unsafeSsl` | `false` | skip Grid TLS verification |
-| `jobScalingStrategy` | `default` | `default`\|`custom`\|`accurate`\|`eager`; must match the ScaledJob's `scalingStrategy.strategy` |
+| `includeOngoingSessions` | `true` | count on-going sessions toward the metric; must be `false` for ScaledJob `scalingStrategy.strategy` `accurate` or `eager` (see [On-going sessions](#on-going-sessions)) |
 | `authType` | `""` | `Basic` (default) or a bearer scheme like `OAuth2`/`Bearer` |
 | `username` / `password` | — | Grid basic auth |
 | `accessToken` | — | Grid bearer token (with non-Basic `authType`) |
 
 Any key may also be supplied as `<key>FromEnv` (KEDA resolves it from the scale
 target's container env before sending).
+
+### On-going sessions
+
+The metric this scaler returns is the number of Nodes the Grid needs. On-going
+sessions are work the Grid is already serving, so whether they belong in that
+number depends on which Job count KEDA's executor deducts for you
+(`pkg/scaling/executor/scale_jobs.go`):
+
+| ScaledJob strategy | KEDA deducts | `includeOngoingSessions` | Metric emitted |
+|---|---|---|---|
+| `default` | running Job count | `true` (default) | queued requests + on-going sessions |
+| `custom` | `customScalingRunningJobPercentage` of running Job count | `true` (default) | queued requests + on-going sessions |
+| `accurate` | pending Job count | **`false`** | queued requests only |
+| `eager` | running + pending Job count (bounded by `maxScale`) | **`false`** | queued requests only |
+| _ScaledObject (HPA)_ | running replicas via HPA | `true` (default) | queued requests + on-going sessions |
+
+`accurate` and `eager` never re-add running work, so counting on-going sessions
+there double-counts sessions already in progress and produces runaway Node
+creation that never scales back down
+([#3167](https://github.com/SeleniumHQ/docker-selenium/issues/3167)).
+
+The Selenium Grid Helm chart derives this for you from
+`autoscaling.scaledJobOptions.scalingStrategy.strategy`; set
+`<node>.hpa.includeOngoingSessions` to override.
 
 ## Authentication
 

--- a/.keda-external-scaler/SPEC.md
+++ b/.keda-external-scaler/SPEC.md
@@ -77,9 +77,10 @@ response — already mirrored at `.keda/scalers/selenium_grid_scaler.go`):
   requests, reserve free matching slots on existing UP nodes, then pack remaining
   requests onto hypothetical new nodes of capacity `nodeMaxSessions`; also count
   matching ongoing sessions
-- The metric convention per `jobScalingStrategy`:
-  - `default`/`custom` (and all ScaledObjects): `count = newRequestNodes + onGoingSessions`
-  - `accurate`/`eager`: `count = newRequestNodes`
+- The metric convention per `includeOngoingSessions`:
+  - `true` (default; correct for ScaledJob `default`/`custom` and all
+    ScaledObjects): `count = newRequestNodes + onGoingSessions`
+  - `false` (required for ScaledJob `accurate`/`eager`): `count = newRequestNodes`
 - Activation: `count > activationThreshold`
 
 ## Tech Stack
@@ -151,7 +152,7 @@ triggers:
       enableManagedDownloads: "true"
       activationThreshold: "0"
       unsafeSsl: "false"                # Grid TLS verification
-      jobScalingStrategy: default       # default|custom|accurate|eager
+      includeOngoingSessions: "true"    # set "false" for accurate|eager ScaledJobs
       authType: Basic                   # optional
       usernameFromEnv: SE_USERNAME      # resolved by KEDA from scale-target env
       passwordFromEnv: SE_PASSWORD
@@ -166,7 +167,7 @@ entirely by mounting them into the scaler Deployment.
 
 All values arrive as strings in the map; the server performs the same
 defaulting/validation the `keda:` struct tags did (`nodeMaxSessions=1`,
-`enableManagedDownloads=true`, `jobScalingStrategy∈{default,custom,accurate,eager}`,
+`enableManagedDownloads=true`, `includeOngoingSessions=true`,
 `sessionBrowserName←browserName`).
 
 ## Code Style
@@ -236,7 +237,7 @@ logging; no global mutable state except an HTTP client cache keyed by
    the same GraphQL fixture (verified by the shared test table).
 3. `GetMetricSpec` returns `selenium-grid[-browser][-version][-platform]` with
    `targetSize: 1`, matching the built-in naming after KEDA strips the index prefix.
-4. All four `jobScalingStrategy` values produce the two documented count
+4. Both `includeOngoingSessions` values produce the two documented count
    conventions (`+onGoingSessions` vs queue-only).
 5. Missing/invalid metadata yields `InvalidArgument`; Grid unreachable yields a
    non-OK status and KEDA logs it without crashing the server.

--- a/.keda-external-scaler/TASKS.md
+++ b/.keda-external-scaler/TASKS.md
@@ -29,7 +29,7 @@ parallel after T1. See [PLAN.md](PLAN.md) for rationale.
 - [ ] **T4: Metadata parsing with env fallback**
   - Acceptance: `parseMetadata(map[string]string, envDefaults)` reproduces the
     `keda:` tag behavior (defaults `nodeMaxSessions=1`,
-    `enableManagedDownloads=true`, `jobScalingStrategy` enum validation,
+    `enableManagedDownloads=true`, `includeOngoingSessions=true`,
     `sessionBrowserName←browserName`, required `url`); strips `FromEnv` key
     suffixes; precedence `<name>` > `<name>FromEnv` > `SE_*` server env.
   - Verify: `go test ./internal/gridscaler -run TestParseMetadata`
@@ -47,11 +47,11 @@ parallel after T1. See [PLAN.md](PLAN.md) for rationale.
 - [ ] **T6: gRPC server implementation (parity gate 2)**
   - Acceptance: `GetMetricSpec` returns normalized
     `selenium-grid[-browser][-version][-platform]` with `targetSize=1`;
-    `GetMetrics` returns count per `jobScalingStrategy` convention; `IsActive`
+    `GetMetrics` returns count per `includeOngoingSessions` convention; `IsActive`
     returns `count > activationThreshold`; `StreamIsActive` returns
     `Unimplemented`; bad metadata → `InvalidArgument`, Grid failure → `Internal`.
   - Verify: `go test ./internal/gridscaler -run TestServer -race` (in-process
-    grpc server + fake Grid fixtures covering all four strategies)
+    grpc server + fake Grid fixtures covering both count conventions)
   - Files: `internal/gridscaler/server.go`, `internal/gridscaler/server_test.go`
 
 - [ ] **T7: Binary entrypoint**

--- a/.keda-external-scaler/cmd/scaler/main_test.go
+++ b/.keda-external-scaler/cmd/scaler/main_test.go
@@ -79,8 +79,8 @@ func TestParseFlagsDefaults(t *testing.T) {
 }
 
 func TestParseFlagsOverridesAndEnv(t *testing.T) {
-	t.Setenv("LISTEN_ADDRESS", ":9999")           // overridden by flag below
-	t.Setenv("SE_GRID_HTTP_TIMEOUT", "500")        // bare int → ms (env default)
+	t.Setenv("LISTEN_ADDRESS", ":9999")     // overridden by flag below
+	t.Setenv("SE_GRID_HTTP_TIMEOUT", "500") // bare int → ms (env default)
 	t.Setenv("TLS_CERT_FILE", "/etc/cert.pem")
 	t.Setenv("TLS_KEY_FILE", "/etc/key.pem")
 

--- a/.keda-external-scaler/deploy/scaledjob-example.yaml
+++ b/.keda-external-scaler/deploy/scaledjob-example.yaml
@@ -5,8 +5,9 @@
 # `selenium-grid` scaler, so migrating from it is a mechanical change of `type`
 # plus adding `scalerAddress`.
 #
-# jobScalingStrategy MUST match spec.scalingStrategy.strategy below so the
-# emitted metric matches how KEDA computes effective max scale for Jobs.
+# includeOngoingSessions MUST agree with spec.scalingStrategy.strategy below so
+# the emitted metric matches how KEDA computes effective max scale for Jobs:
+# leave it "true" for `default`/`custom`, set it "false" for `accurate`/`eager`.
 apiVersion: keda.sh/v1alpha1
 kind: ScaledJob
 metadata:
@@ -42,7 +43,9 @@ spec:
         url: http://selenium-hub.selenium.svc:4444/graphql
         browserName: chrome
         nodeMaxSessions: "1"
-        jobScalingStrategy: default
+        # strategy below is `default`, which deducts running Jobs, so on-going
+        # sessions must stay in the metric. Set "false" for accurate/eager.
+        includeOngoingSessions: "true"
         activationThreshold: "0"
         # For basic-auth Grids, resolve credentials from the Job's own env:
         # usernameFromEnv: SE_ROUTER_USERNAME

--- a/.keda-external-scaler/deploy/scaledobject-example.yaml
+++ b/.keda-external-scaler/deploy/scaledobject-example.yaml
@@ -1,8 +1,9 @@
 # Example ScaledObject (Deployment-based scaling) using the external scaler.
 #
-# ScaledObjects always use the "total desired" convention, so jobScalingStrategy
-# is left at its default. The scaler reports queued requests plus on-going
-# sessions, which the HPA divides by the target value (1) to get replicas.
+# ScaledObjects always use the "total desired" convention, so
+# includeOngoingSessions is left at its default of true. The scaler reports
+# queued requests plus on-going sessions, which the HPA divides by the target
+# value (1) to get replicas.
 apiVersion: keda.sh/v1alpha1
 kind: ScaledObject
 metadata:

--- a/.keda-external-scaler/internal/gridscaler/metadata.go
+++ b/.keda-external-scaler/internal/gridscaler/metadata.go
@@ -23,7 +23,7 @@ type Metadata struct {
 	NodeMaxSessions        int64
 	EnableManagedDownloads bool
 	Capabilities           string
-	JobScalingStrategy     string
+	IncludeOngoingSessions bool
 
 	TargetValue int64
 }
@@ -39,13 +39,6 @@ var envFallbacks = map[string]string{
 	"username":    "SE_USERNAME",
 	"password":    "SE_PASSWORD",
 	"accessToken": "SE_ACCESS_TOKEN",
-}
-
-var validJobScalingStrategies = map[string]struct{}{
-	"default":  {},
-	"custom":   {},
-	"accurate": {},
-	"eager":    {},
 }
 
 // parseMetadata builds a Metadata from the scalerMetadata map KEDA sends and the
@@ -83,7 +76,7 @@ func parseMetadata(scalerMetadata map[string]string, env map[string]string) (*Me
 		TargetValue:            1,
 		NodeMaxSessions:        1,
 		EnableManagedDownloads: true,
-		JobScalingStrategy:     "default",
+		IncludeOngoingSessions: true,
 	}
 
 	meta.URL = lookup("url")
@@ -133,11 +126,12 @@ func parseMetadata(scalerMetadata map[string]string, env map[string]string) (*Me
 		meta.EnableManagedDownloads = b
 	}
 
-	if v := lookup("jobScalingStrategy"); v != "" {
-		if _, ok := validJobScalingStrategies[v]; !ok {
-			return nil, fmt.Errorf("invalid jobScalingStrategy %q, must be one of default, custom, accurate, eager", v)
+	if v := lookup("includeOngoingSessions"); v != "" {
+		b, err := strconv.ParseBool(v)
+		if err != nil {
+			return nil, fmt.Errorf("parsing includeOngoingSessions: %w", err)
 		}
-		meta.JobScalingStrategy = v
+		meta.IncludeOngoingSessions = b
 	}
 
 	if meta.SessionBrowserName == "" {

--- a/.keda-external-scaler/internal/gridscaler/metadata_test.go
+++ b/.keda-external-scaler/internal/gridscaler/metadata_test.go
@@ -43,7 +43,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -60,7 +60,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -76,7 +76,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -97,7 +97,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -117,7 +117,7 @@ func Test_parseMetadata(t *testing.T) {
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
 				Capabilities:           "{\"myApp:version\": \"beta\"}",
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -136,7 +136,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -158,7 +158,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -196,7 +196,7 @@ func Test_parseMetadata(t *testing.T) {
 				NodeMaxSessions:        3,
 				TargetValue:            1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -216,24 +216,24 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
-			name: "invalid jobScalingStrategy should throw an error",
+			name: "invalid includeOngoingSessions should throw an error",
 			meta: map[string]string{
-				"url":                "http://selenium-hub:4444/graphql",
-				"browserName":        "chrome",
-				"jobScalingStrategy": "bogus",
+				"url":                    "http://selenium-hub:4444/graphql",
+				"browserName":            "chrome",
+				"includeOngoingSessions": "bogus",
 			},
 			wantErr: true,
 		},
 		{
-			name: "accurate jobScalingStrategy is accepted",
+			name: "includeOngoingSessions can be disabled",
 			meta: map[string]string{
-				"url":                "http://selenium-hub:4444/graphql",
-				"browserName":        "chrome",
-				"jobScalingStrategy": "accurate",
+				"url":                    "http://selenium-hub:4444/graphql",
+				"browserName":            "chrome",
+				"includeOngoingSessions": "false",
 			},
 			want: &Metadata{
 				URL:                    "http://selenium-hub:4444/graphql",
@@ -242,7 +242,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "accurate",
+				IncludeOngoingSessions: false,
 			},
 		},
 		{
@@ -259,7 +259,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: false,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		// External-scaler-specific: *FromEnv and server-env fallback resolution.
@@ -280,7 +280,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -300,7 +300,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 		{
@@ -319,7 +319,7 @@ func Test_parseMetadata(t *testing.T) {
 				TargetValue:            1,
 				NodeMaxSessions:        1,
 				EnableManagedDownloads: true,
-				JobScalingStrategy:     "default",
+				IncludeOngoingSessions: true,
 			},
 		},
 	}

--- a/.keda-external-scaler/internal/gridscaler/server.go
+++ b/.keda-external-scaler/internal/gridscaler/server.go
@@ -81,10 +81,19 @@ func (s *Server) StreamIsActive(*pb.ScaledObjectRef, grpc.ServerStreamingServer[
 	return status.Error(codes.Unimplemented, "StreamIsActive is not supported; use KEDA trigger type 'external', not 'external-push'")
 }
 
-// scrapeAndCount queries the Grid and computes the node count for meta, applying
-// the jobScalingStrategy convention: default/custom (and ScaledObjects) report
-// queued requests plus on-going sessions; accurate/eager report queued requests
-// only, to avoid double-counting in-progress work (SeleniumHQ/docker-selenium#3167).
+// scrapeAndCount queries the Grid and computes the node count for meta.
+//
+// On-going sessions are work the Grid is already serving, so whether they belong
+// in the count depends on whether the consumer subtracts already-running work for
+// us. ScaledObjects (HPA), and ScaledJobs using the "default" or "custom"
+// strategy, deduct the running Job count from the desired scale, so on-going
+// sessions cancel out in that deduction and the count must include them for the
+// arithmetic to resolve to the number of *new* Nodes to create. ScaledJobs using
+// "accurate" deduct the pending Job count and "eager" deducts running plus pending
+// (bounded by maxScale); neither re-adds running work, so including on-going
+// sessions double-counts work already in progress and causes runaway Job creation
+// that never scales back down (SeleniumHQ/docker-selenium#3167). Set
+// includeOngoingSessions=false for those two strategies.
 func (s *Server) scrapeAndCount(ctx context.Context, meta *Metadata) (int64, error) {
 	b, err := s.grid.Query(ctx, meta)
 	if err != nil {
@@ -96,10 +105,9 @@ func (s *Server) scrapeAndCount(ctx context.Context, meta *Metadata) (int64, err
 	if err != nil {
 		return 0, err
 	}
-	count := newRequestNodes + onGoingSessions
-	switch meta.JobScalingStrategy {
-	case "accurate", "eager":
-		count = newRequestNodes
+	count := newRequestNodes
+	if meta.IncludeOngoingSessions {
+		count += onGoingSessions
 	}
 	return count, nil
 }

--- a/.keda-external-scaler/internal/gridscaler/server_test.go
+++ b/.keda-external-scaler/internal/gridscaler/server_test.go
@@ -47,7 +47,7 @@ func newTestClient(t *testing.T, env map[string]string) pb.ExternalScalerClient 
 
 // fixtureGrid: 2 queued chrome requests + 1 on-going chrome session on a fully
 // occupied Node → newRequestNodes=2, onGoingSessions=1. Same fixture as KEDA's
-// Test_GetMetricsAndActivity_JobScalingStrategy.
+// Test_GetMetricsAndActivity_IncludeOngoingSessions.
 const fixtureGrid = `{
 	"data": {
 		"grid": { "sessionCount": 1, "maxSession": 1, "totalSlots": 1 },
@@ -89,31 +89,33 @@ func fakeGrid(t *testing.T, body string) *httptest.Server {
 	return server
 }
 
-// Ported from KEDA Test_GetMetricsAndActivity_JobScalingStrategy: expected metric
-// values are unchanged. default/custom include on-going sessions (3);
-// accurate/eager exclude them (2).
-func TestServer_GetMetrics_JobScalingStrategy(t *testing.T) {
+// Ported from KEDA Test_GetMetricsAndActivity_IncludeOngoingSessions: unset and
+// "true" include on-going sessions (3); "false" — the value required for the
+// accurate and eager ScaledJob strategies — excludes them (2).
+func TestServer_GetMetrics_IncludeOngoingSessions(t *testing.T) {
 	grid := fakeGrid(t, fixtureGrid)
 	client := newTestClient(t, nil)
 
 	tests := []struct {
-		name               string
-		jobScalingStrategy string
-		wantMetric         int64
+		name                   string
+		includeOngoingSessions string
+		wantMetric             int64
 	}{
-		{"default strategy includes on-going sessions", "default", 3},
-		{"custom strategy includes on-going sessions", "custom", 3},
-		{"accurate strategy excludes on-going sessions", "accurate", 2},
-		{"eager strategy excludes on-going sessions", "eager", 2},
+		{"unset defaults to including on-going sessions", "", 3},
+		{"true includes on-going sessions", "true", 3},
+		{"false excludes on-going sessions", "false", 2},
 	}
 
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			ref := &pb.ScaledObjectRef{ScalerMetadata: map[string]string{
-				"url":                grid.URL,
-				"browserName":        "chrome",
-				"jobScalingStrategy": tt.jobScalingStrategy,
-			}}
+			meta := map[string]string{
+				"url":         grid.URL,
+				"browserName": "chrome",
+			}
+			if tt.includeOngoingSessions != "" {
+				meta["includeOngoingSessions"] = tt.includeOngoingSessions
+			}
+			ref := &pb.ScaledObjectRef{ScalerMetadata: meta}
 
 			metrics, err := client.GetMetrics(context.Background(), &pb.GetMetricsRequest{
 				ScaledObjectRef: ref,

--- a/Makefile
+++ b/Makefile
@@ -1472,6 +1472,18 @@ test_k8s_autoscaling_job_count_strategy_default:
 	VERSION=$(TAG_VERSION) VIDEO_TAG=$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) KEDA_BASED_NAME=$(KEDA_BASED_NAME) KEDA_BASED_TAG=$(KEDA_BASED_TAG) NAMESPACE=$(NAMESPACE) BINDING_VERSION=$(BINDING_VERSION) BASE_VERSION=$(BASE_VERSION) \
 	./tests/charts/make/chart_test.sh JobAutoscaling
 
+test_k8s_autoscaling_job_count_strategy_accurate_in_chaos:
+	MATRIX_TESTS=AutoScalingTestsScaleChaos SCALING_STRATEGY=accurate \
+	make test_k8s_autoscaling_job_count_strategy_default
+
+test_k8s_autoscaling_job_count_strategy_accurate_with_node_max_sessions:
+	TEST_NODE_MAX_SESSIONS=3 SCALING_STRATEGY=accurate \
+	make test_k8s_autoscaling_job_count_strategy_default
+
+test_k8s_autoscaling_job_count_strategy_accurate:
+	SCALING_STRATEGY=accurate \
+	make test_k8s_autoscaling_job_count_strategy_default
+
 test_k8s_autoscaling_deployment_count_in_chaos:
 	MATRIX_TESTS=AutoScalingTestsScaleChaos \
 	make test_k8s_autoscaling_deployment_count

--- a/charts/selenium-grid/README.md
+++ b/charts/selenium-grid/README.md
@@ -291,6 +291,7 @@ Understand list trigger parameters
 - `unsafeSsl` - Skip certificate validation when connecting over HTTPS. (Default: `false`, Optional)
 - `activationThreshold` - Target value for activating the scaler. Learn more about activation [here](./../concepts/scaling-deployments.md#activating-and-scaling-thresholds). (Default: `0`, Optional)
 - `nodeMaxSessions` - Number of maximum sessions that can run in parallel on a Node. Update this parameter align with node config `--max-sessions` (`SE_NODE_MAX_SESSIONS`) to have the correct scaling behavior. (Default: `1`, Optional).
+- `includeOngoingSessions` - Whether on-going sessions are counted toward the metric. (Default: `true`, Optional). When `autoscaling.scalingType` is `job`, the chart derives this from `autoscaling.scaledJobOptions.scalingStrategy.strategy`: strategies `default` and `custom` deduct the running Job count, so on-going sessions cancel out in that deduction and must stay in the metric (`true`); strategies `accurate` and `eager` deduct the pending (and running) Job count without re-adding running work, so counting on-going sessions there double-counts work in progress and causes runaway Node creation ([#3167](https://github.com/SeleniumHQ/docker-selenium/issues/3167)), hence `false`. Set `<node>.hpa.includeOngoingSessions` to override the derived value.
 
 Understand list trigger authentication
 

--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -287,8 +287,9 @@ triggers:
     {{- if $useExternalScaler }}
       scalerAddress: {{ include "seleniumGrid.externalScaler.address" $ | quote }}
     {{- end }}
-    {{- if and (eq $.Values.autoscaling.scalingType "job") (not (hasKey (default dict .node.hpa) "jobScalingStrategy")) }}
-      jobScalingStrategy: {{ dig "scalingStrategy" "strategy" "default" $spec | quote }}
+    {{- if and (eq $.Values.autoscaling.scalingType "job") (not (hasKey (default dict .node.hpa) "includeOngoingSessions")) }}
+      {{- /* accurate/eager deduct pending (and running) Jobs without re-adding running work, so on-going sessions must be excluded from the metric - see SeleniumHQ/docker-selenium#3167 */}}
+      includeOngoingSessions: {{ ternary "false" "true" (has (dig "scalingStrategy" "strategy" "default" $spec) (list "accurate" "eager")) | quote }}
     {{- end }}
     {{- with .node.hpa }}
       {{- range $key, $value := . }}

--- a/tests/AutoscalingTests/common.py
+++ b/tests/AutoscalingTests/common.py
@@ -1,11 +1,13 @@
 import concurrent.futures
 import csv
+import math
 import os
 import random
 import signal
 import subprocess
 import time
 import unittest
+from collections import Counter
 
 from csv2md.table import Table
 from selenium import webdriver
@@ -57,25 +59,38 @@ def create_session(browser_name):
     return driver
 
 
-def wait_for_count_matches(sessions, timeout=10, interval=5):
+def expected_pod_count(sessions, node_max_sessions):
+    # Each browser type scales independently (its own ScaledJob/trigger), so the
+    # expected pod count is the sum of per-browser ceilings, not a single ceiling
+    # over the total - packing sessions across types would understate it.
+    counts = Counter(browser_name for _, browser_name in sessions)
+    return sum(math.ceil(count / node_max_sessions) for count in counts.values())
+
+
+def wait_for_count_matches(sessions, node_max_sessions=1, timeout=60, interval=5):
+    # Regression guard for https://github.com/SeleniumHQ/docker-selenium/issues/3167:
+    # a ScaledJob strategy that double-counts on-going sessions never converges
+    # pod count to the expected value, so a bounded poll that hard-fails on timeout
+    # catches that runaway growth instead of only warning about it.
+    expected = expected_pod_count(sessions, node_max_sessions)
     elapsed = 0
+    pod_count = get_pod_count()
     while elapsed < timeout:
         pod_count = get_pod_count()
-        if pod_count == len(sessions):
-            break
-        print(f"VALIDATING: Waiting for pods to match sessions... ({elapsed}/{timeout} seconds elapsed)")
+        if pod_count == expected:
+            print(f"PASS: Pod count ({pod_count}) matches expected ({expected}) after {elapsed} seconds.")
+            return
+        print(f"VALIDATING: pod_count={pod_count}, expected={expected}... ({elapsed}/{timeout} seconds elapsed)")
         time.sleep(interval)
         elapsed += interval
-    if pod_count != len(sessions):
-        print(
-            f"WARN: Mismatch between pod count and session count after {timeout} seconds. Gaps: {pod_count - len(sessions)}"
-        )
-    else:
-        print(f"PASS: Pod count matches session count after {elapsed} seconds.")
+    raise AssertionError(
+        f"Pod count mismatch: expected {expected} pods for {len(sessions)} sessions "
+        f"(node_max_sessions={node_max_sessions}), got {pod_count} after {timeout} seconds"
+    )
 
 
 def close_all_sessions(sessions):
-    for session in sessions:
+    for session, _ in sessions:
         session.quit()
     sessions.clear()
     return sessions
@@ -84,13 +99,15 @@ def close_all_sessions(sessions):
 def create_sessions_in_parallel(new_request_sessions):
     failed_jobs = 0
     with concurrent.futures.ThreadPoolExecutor() as executor:
-        futures = [
-            executor.submit(create_session, random.choice(list(BROWSER.keys()))) for _ in range(new_request_sessions)
-        ]
+        futures = {
+            executor.submit(create_session, browser_name): browser_name
+            for browser_name in (random.choice(list(BROWSER.keys())) for _ in range(new_request_sessions))
+        }
         sessions = []
         for future in concurrent.futures.as_completed(futures):
+            browser_name = futures[future]
             try:
-                sessions.append(future.result())
+                sessions.append((future.result(), browser_name))
             except Exception as e:
                 print(f"ERROR: Failed to create session: {e}")
                 failed_jobs += 1
@@ -102,7 +119,7 @@ def randomly_quit_sessions(sessions, sublist_size):
     if sessions:
         sessions_to_quit = random.sample(sessions, min(sublist_size, len(sessions)))
         for session in sessions_to_quit:
-            session.quit()
+            session[0].quit()
             sessions.remove(session)
         print(f"QUIT: {len(sessions_to_quit)} sessions have been randomly quit.")
         return len(sessions_to_quit)

--- a/tests/AutoscalingTests/test_scale_chaos.py
+++ b/tests/AutoscalingTests/test_scale_chaos.py
@@ -42,6 +42,8 @@ class SeleniumAutoscalingTests(unittest.TestCase):
                 print(f"ADDING: Created {new_request_sessions} new sessions in {elapsed_time:.2f} seconds.")
                 print(f"INFO: Total sessions: {total_sessions}")
                 print(f"INFO: Total pods: {total_pods}")
+                wait_for_count_matches(SESSIONS, TEST_NODE_MAX_SESSIONS)
+                total_pods = get_pod_count()
                 closed_session = randomly_quit_sessions(SESSIONS, random.randint(3, 12))
                 RESULTS.append(
                     {

--- a/tests/AutoscalingTests/test_scale_up.py
+++ b/tests/AutoscalingTests/test_scale_up.py
@@ -42,6 +42,8 @@ class SeleniumAutoscalingTests(unittest.TestCase):
                 print(f"ADDING: Created {new_request_sessions} new sessions in {elapsed_time:.2f} seconds.")
                 print(f"INFO: Total sessions: {total_sessions}")
                 print(f"INFO: Total pods: {total_pods}")
+                wait_for_count_matches(SESSIONS, TEST_NODE_MAX_SESSIONS)
+                total_pods = get_pod_count()
                 if iteration % 5 == 0:
                     closed_session = randomly_quit_sessions(SESSIONS, 20)
                 else:

--- a/tests/charts/ci/multiple-nodes-platform-version-values.yaml
+++ b/tests/charts/ci/multiple-nodes-platform-version-values.yaml
@@ -1,0 +1,95 @@
+# Test-only overlay for TEST_MULTIPLE_VERSIONS scale testing (see chart_test.sh).
+#
+# This intentionally does NOT mirror charts/selenium-grid/multiple-nodes-platform-version.yaml,
+# which is shipped chart documentation/example content and stays on the default
+# (Docker Hub) registry for real users.
+#
+# Two differences from that shipped file:
+#   1. imageRegistry is pinned to ghcr.io/seleniumhq for every previous-version Node.
+#      Those tags are never built locally in CI, so they are always pulled from a
+#      registry, and anonymous Docker Hub pulls hit the rate limit when a scale test
+#      brings up many previous-version Nodes at once. GHCR pulls are anonymous and
+#      unmetered for public images.
+#   2. The version range is pruned to just what tests/SeleniumTests/__init__.py
+#      actually requests (LIST_CHROMIUM_VERSIONS / LIST_FIREFOX_VERSIONS = 144.0-147.0),
+#      instead of the full historical list. Versions outside that range never receive
+#      a session request during the test, so they never scale up and never pull an
+#      image anyway - keeping them here would only add scaler triggers with no
+#      effect on coverage. Keep this range in sync with LIST_CHROMIUM_VERSIONS /
+#      LIST_FIREFOX_VERSIONS if those change.
+crossBrowsers:
+  chromeNode:
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-latest'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: ''
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-146'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '146.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '146.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-145'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '145.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '145.0'
+    - nameOverride: '{{ $.Release.Name }}-node-chrome-144'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '144.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '144.0'
+  firefoxNode:
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-latest'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: ''
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-147'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '147.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '147.0'
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-146'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '146.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '146.0'
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-145'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '145.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '145.0'
+    - nameOverride: '{{ $.Release.Name }}-node-firefox-144'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '144.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '144.0'
+  edgeNode:
+    - nameOverride: '{{ $.Release.Name }}-node-edge-latest'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: ''
+    - nameOverride: '{{ $.Release.Name }}-node-edge-146'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '146.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '146.0'
+    - nameOverride: '{{ $.Release.Name }}-node-edge-145'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '145.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '145.0'
+    - nameOverride: '{{ $.Release.Name }}-node-edge-144'
+      imageRegistry: ghcr.io/seleniumhq
+      imageTag: '144.0-20260808'
+      hpa:
+        platformName: 'Linux'
+        browserVersion: '144.0'

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -481,8 +481,12 @@ if [ "${SELENIUM_GRID_PROTOCOL}" = "https" ]; then
 fi
 
 if [ "${TEST_MULTIPLE_VERSIONS}" = "true" ]; then
+  # Test-only overlay, not the chart's shipped multiple-nodes-platform-version.yaml:
+  # points previous-version Nodes at GHCR (Docker Hub anonymous pulls hit the rate
+  # limit under scale testing) and prunes the range to what the tests actually
+  # request. See tests/charts/ci/multiple-nodes-platform-version-values.yaml.
   HELM_COMMAND_SET_BASE_VALUES="${HELM_COMMAND_SET_BASE_VALUES} \
-  --values ${CHART_PATH}/multiple-nodes-platform-version.yaml \
+  --values ${TEST_VALUES_PATH}/multiple-nodes-platform-version-values.yaml \
   "
 elif [ "${TEST_MULTIPLE_PLATFORMS}" = "true" ] && [ "${TEST_MULTIPLE_PLATFORMS_RELAY}" != "true" ]; then
   HELM_COMMAND_SET_BASE_VALUES="${HELM_COMMAND_SET_BASE_VALUES} \


### PR DESCRIPTION
Aligns the Selenium Grid KEDA **external scaler** with the trigger param merged into the **built-in scaler** upstream ([kedacore/keda#8107](https://github.com/kedacore/keda/pull/8107)), so migrating between the two stays a mechanical swap of trigger `type`.

## Why

The external scaler shipped with `jobScalingStrategy` (`default`\|`custom`\|`accurate`\|`eager`) and derived the count convention from it. Upstream settled on a plain boolean instead, matching how other scalers expose the same choice — AWS SQS `scaleOnInFlight`, RabbitMQ `excludeUnacknowledged`, Beanstalkd `includeDelayed`, Temporal `includeRunningWorkflowCount`.

The underlying behaviour is unchanged: whether on-going sessions belong in the metric depends on which Job count KEDA's executor deducts for you (`pkg/scaling/executor/scale_jobs.go`).

| ScaledJob strategy | KEDA deducts | `includeOngoingSessions` | Metric emitted |
|---|---|---|---|
| `default` | running Job count | `true` (default) | queued requests + on-going sessions |
| `custom` | `customScalingRunningJobPercentage` of running Job count | `true` (default) | queued requests + on-going sessions |
| `accurate` | pending Job count | **`false`** | queued requests only |
| `eager` | running + pending Job count (bounded by `maxScale`) | **`false`** | queued requests only |
| _ScaledObject (HPA)_ | running replicas via HPA | `true` (default) | queued requests + on-going sessions |

## Changes

**External scaler** (`.keda-external-scaler/`)
- `internal/gridscaler/metadata.go` — `JobScalingStrategy string` → `IncludeOngoingSessions bool` (default `true`); enum validation replaced by `strconv.ParseBool`.
- `internal/gridscaler/server.go` — `scrapeAndCount` adds `onGoingSessions` only when the flag is set, mirroring upstream `GetMetricsAndActivity`.
- Tests — `TestServer_GetMetrics_JobScalingStrategy` → `TestServer_GetMetrics_IncludeOngoingSessions` (unset → 3, `true` → 3, `false` → 2 on the same fixture KEDA uses); metadata table covers the new default, `"false"`, and an invalid-bool error.
- Docs/examples — `README.md` (metadata table + new *On-going sessions* section), `SPEC.md`, `PLAN.md`, `TASKS.md`, `deploy/scaledjob-example.yaml`, `deploy/scaledobject-example.yaml`.

**Helm chart**
- `templates/_helpers.tpl` derives `includeOngoingSessions` from `autoscaling.scaledJobOptions.scalingStrategy.strategy`: `false` for `accurate`/`eager`, `true` otherwise. Override key is now `<node>.hpa.includeOngoingSessions`.
- The chart default strategy is `accurate`, so the default render now emits `includeOngoingSessions: "false"` — this is the fix for the runaway Node creation in #3167.
- `charts/selenium-grid/README.md` documents the param and the derivation.

## Notes

- `jobScalingStrategy` is **removed** rather than deprecated. It only ever existed on the external scaler and was never read by the built-in one, so nothing else in the chart or upstream consumes it.
- The patched built-in scaler copy in `.keda/scalers/selenium_grid_scaler.go` is deliberately left tracking upstream `main`; it picks the param up when kedacore/keda#8107 merges. Until then the built-in trigger path ignores the emitted key (KEDA ignores unknown trigger metadata), i.e. unchanged behaviour.

## Verification

- `go mod verify`, `go mod tidy` (clean), `go vet`, `go build`, `go test ./... -race -covermode=atomic` all pass; coverage excluding generated stubs is **97.1%** (gate is 90%). `gofmt -l` is clean module-wide — this also picks up a pre-existing comment-alignment nit in `cmd/scaler/main_test.go`.
- `helm lint` clean. Rendered and checked: `accurate`/`eager` → `"false"`, `default`/`custom` → `"true"`, `scalingType=deployment` → key omitted (scaler default `true` is correct for HPA), built-in trigger path, and `<node>.hpa.includeOngoingSessions` override.
- `tests/charts/templates/test_scaled_job.py` passes. `test.py` has one failure (`selenium-grid-overview` dashboard ConfigMaps mismatch) that reproduces identically on unmodified `trunk` — pre-existing and unrelated.

Relates to #3167

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Hwsdd5D5hWWXiPJ1hdPBzh