### PR TITLE
[ci] Replace the source scan with Docker Scout on the published images

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -172,3 +172,13 @@ jobs:
           draft: false
           prerelease: true
           append_body: false
+
+  scan-images:
+    needs:
+      - deploy
+    if: ${{ needs.deploy.result == 'success' }}
+    name: Scan nightly images
+    uses: ./.github/workflows/scan-images.yml
+    secrets: inherit
+    with:
+      tag: nightly

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,15 +1,17 @@
 name: Scan image vulnerabilities
 
-# Scans the published nightly images with Docker Scout and reports the CVEs that
-# have a fix available.
+# Scans the published images with Docker Scout and reports the CVEs that have a
+# fix available. Runs daily against `latest`, and again from nightly.yml against
+# `nightly` once those images are pushed.
 #
-# This is deliberately separate from scan-dockerfile.yml, which runs Trivy over
-# the source tree (`scan-type: fs`). That catches problems in what we write; this
-# catches problems in what we ship - a CVE disclosed in a base image or an OS
-# package after the last release is invisible to a source scan.
+# This replaces scan-dockerfile.yml, which ran Trivy with `scan-type: fs` over
+# the working tree. That scanned what we write; this scans what we ship. A CVE
+# disclosed in a base image or an OS package after the last release was
+# invisible to a source scan, which is most of them.
 #
-# Nightly is the earliest place the alert is useful: it fires before the affected
-# layers reach a release, while there is still time to bump a base image.
+# The secret and misconfiguration scanning that scan-dockerfile.yml also did is
+# NOT covered here - Scout finds CVEs in image packages, not secrets in source.
+# That half lives on in scan-source.yml.
 #
 # The scan never blocks nightly. A vulnerability in an upstream base image is not
 # something a failed build can fix, and a red nightly that nobody can action is a
@@ -20,6 +22,10 @@ concurrency:
   cancel-in-progress: true
 
 on:
+  schedule:
+    # Daily, inherited from scan-dockerfile.yml which this replaces. Scans the
+    # `latest` tag, because that is what most users actually pull.
+    - cron: '0 0 * * *'
   workflow_call:
     inputs:
       tag:
@@ -80,6 +86,7 @@ jobs:
         id: list
         env:
           INPUT_IMAGES: ${{ inputs.images }}
+          TAG: ${{ inputs.tag || 'latest' }}
         run: |
           if [ -n "${INPUT_IMAGES}" ]; then
             NAMES="${INPUT_IMAGES}"
@@ -92,9 +99,16 @@ jobs:
             # release_grid_scaler_nightly, which nightly does not run. A CVE in
             # them is fixed by bumping KEDA_BASED_TAG, not by anything built
             # here. Pass them via `images:` if you want them scanned anyway.
-            NAMES=$(sed -n '/^tag_nightly:/,/^$/p' Makefile \
-                    | grep -oE '\$\(NAME\)/[a-z0-9._-]+:nightly' \
-                    | sed 's|\$(NAME)/||; s|:nightly||' | sort -u | tr '\n' ' ')
+            # Read the Makefile target that publishes the tag being scanned, so
+            # the list is exactly the release surface and needs no second list to
+            # keep in step.
+            case "${TAG}" in
+              nightly) TARGET=tag_nightly; SUFFIX=nightly ;;
+              *)       TARGET=tag_latest;  SUFFIX=latest  ;;
+            esac
+            NAMES=$(sed -n "/^${TARGET}:/,/^$/p" Makefile \
+                    | grep -oE "\$\(NAME\)/[a-z0-9._-]+:${SUFFIX}" \
+                    | sed "s|\$(NAME)/||; s|:${SUFFIX}||" | sort -u | tr '\n' ' ')
           fi
           echo "Scanning: ${NAMES}"
           echo "images=$(printf '%s' "${NAMES}" | tr ' ' '\n' | grep . | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
@@ -125,7 +139,7 @@ jobs:
         uses: docker/scout-action@v1
         with:
           command: cves
-          image: registry://${{ vars.DOCKER_NAMESPACE || 'selenium' }}/${{ matrix.image }}:${{ inputs.tag || 'nightly' }}
+          image: registry://${{ vars.DOCKER_NAMESPACE || 'selenium' }}/${{ matrix.image }}:${{ inputs.tag || 'latest' }}
           dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
           dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
           only-fixed: true
@@ -143,7 +157,7 @@ jobs:
       - name: Job summary
         if: always()
         run: |
-          IMAGE="${NAMESPACE}/${{ matrix.image }}:${{ inputs.tag || 'nightly' }}"
+          IMAGE="${NAMESPACE}/${{ matrix.image }}:${{ inputs.tag || 'latest' }}"
           SARIF="scout-${{ matrix.image }}.sarif"
           {
             echo "### \`${IMAGE}\`"
@@ -186,5 +200,5 @@ jobs:
       - name: Roll the reports up into one table
         run: |
           python3 scripts/scan_images/summarise_scout.py --rollup reports \
-            --tag "${{ inputs.tag || 'nightly' }}" \
+            --tag "${{ inputs.tag || 'latest' }}" \
             --severity "${ONLY_SEVERITY}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -1,0 +1,190 @@
+name: Scan image vulnerabilities
+
+# Scans the published nightly images with Docker Scout and reports the CVEs that
+# have a fix available.
+#
+# This is deliberately separate from scan-dockerfile.yml, which runs Trivy over
+# the source tree (`scan-type: fs`). That catches problems in what we write; this
+# catches problems in what we ship - a CVE disclosed in a base image or an OS
+# package after the last release is invisible to a source scan.
+#
+# Nightly is the earliest place the alert is useful: it fires before the affected
+# layers reach a release, while there is still time to bump a base image.
+#
+# The scan never blocks nightly. A vulnerability in an upstream base image is not
+# something a failed build can fix, and a red nightly that nobody can action is a
+# red nightly everybody learns to ignore.
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
+
+on:
+  workflow_call:
+    inputs:
+      tag:
+        description: 'Image tag to scan'
+        required: false
+        type: string
+        default: 'nightly'
+      images:
+        description: 'Space-separated image names. Empty means the default set.'
+        required: false
+        type: string
+        default: ''
+      only-severity:
+        description: 'Severities to report'
+        required: false
+        type: string
+        default: 'critical,high'
+  workflow_dispatch:
+    inputs:
+      tag:
+        description: 'Image tag to scan'
+        required: false
+        type: string
+        default: 'nightly'
+      images:
+        description: 'Space-separated image names. Empty means the default set.'
+        required: false
+        type: string
+        default: ''
+      only-severity:
+        description: 'Severities to report'
+        required: false
+        type: choice
+        default: 'critical,high'
+        options:
+          - 'critical,high'
+          - 'critical,high,medium'
+          - 'critical,high,medium,low'
+
+env:
+  NAMESPACE: ${{ vars.DOCKER_NAMESPACE || 'selenium' }}
+  ONLY_SEVERITY: ${{ inputs.only-severity || 'critical,high' }}
+
+jobs:
+  matrix:
+    name: Build image list
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    outputs:
+      images: ${{ steps.list.outputs.images }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+      - name: Resolve the images to scan
+        id: list
+        env:
+          INPUT_IMAGES: ${{ inputs.images }}
+        run: |
+          if [ -n "${INPUT_IMAGES}" ]; then
+            NAMES="${INPUT_IMAGES}"
+          else
+            # Read the tag_nightly target rather than the whole Makefile, so the
+            # list is exactly what nightly publishes and needs no second list to
+            # keep in step. This deliberately excludes selenium/keda,
+            # keda-metrics-apiserver and keda-admission-webhooks: those are
+            # straight re-tags of upstream kedacore images made by
+            # release_grid_scaler_nightly, which nightly does not run. A CVE in
+            # them is fixed by bumping KEDA_BASED_TAG, not by anything built
+            # here. Pass them via `images:` if you want them scanned anyway.
+            NAMES=$(sed -n '/^tag_nightly:/,/^$/p' Makefile \
+                    | grep -oE '\$\(NAME\)/[a-z0-9._-]+:nightly' \
+                    | sed 's|\$(NAME)/||; s|:nightly||' | sort -u | tr '\n' ' ')
+          fi
+          echo "Scanning: ${NAMES}"
+          echo "images=$(printf '%s' "${NAMES}" | tr ' ' '\n' | grep . | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+
+  scout:
+    name: Scout ${{ matrix.image }}
+    needs: matrix
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
+    strategy:
+      fail-fast: false
+      max-parallel: 6
+      matrix:
+        image: ${{ fromJson(needs.matrix.outputs.images) }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+
+      # Scout reads the SBOM attestation the images are already built with
+      # (--sbom=true --attest type=provenance,mode=max), so nothing is pulled.
+      - name: Fixable CVEs, SARIF for the Security tab
+        id: sarif
+        continue-on-error: true
+        uses: docker/scout-action@v1
+        with:
+          command: cves
+          image: registry://${{ vars.DOCKER_NAMESPACE || 'selenium' }}/${{ matrix.image }}:${{ inputs.tag || 'nightly' }}
+          dockerhub-user: ${{ secrets.DOCKER_USERNAME }}
+          dockerhub-password: ${{ secrets.DOCKER_PASSWORD }}
+          only-fixed: true
+          sarif-file: scout-${{ matrix.image }}.sarif
+          write-comment: false
+          summary: false
+
+      - name: Upload to the Security tab
+        if: hashFiles(format('scout-{0}.sarif', matrix.image)) != ''
+        uses: github/codeql-action/upload-sarif@v4
+        with:
+          sarif_file: scout-${{ matrix.image }}.sarif
+          category: scout-${{ matrix.image }}
+
+      - name: Job summary
+        if: always()
+        run: |
+          IMAGE="${NAMESPACE}/${{ matrix.image }}:${{ inputs.tag || 'nightly' }}"
+          SARIF="scout-${{ matrix.image }}.sarif"
+          {
+            echo "### \`${IMAGE}\`"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+          if [ ! -f "${SARIF}" ]; then
+            echo "Scout produced no report. Check that Docker Scout is enabled for this repository." >> "$GITHUB_STEP_SUMMARY"
+            exit 0
+          fi
+          python3 scripts/scan_images/summarise_scout.py "${SARIF}" "${IMAGE}" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Keep the report as an artifact
+        if: always() && hashFiles(format('scout-{0}.sarif', matrix.image)) != ''
+        uses: actions/upload-artifact@main
+        with:
+          name: scout-${{ matrix.image }}
+          path: scout-${{ matrix.image }}.sarif
+          if-no-files-found: ignore
+
+  report:
+    name: Fixable CVE report
+    needs:
+      - matrix
+      - scout
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+      - name: Download every Scout report
+        uses: actions/download-artifact@main
+        with:
+          pattern: scout-*
+          path: reports
+          merge-multiple: false
+      - name: Roll the reports up into one table
+        run: |
+          python3 scripts/scan_images/summarise_scout.py --rollup reports \
+            --tag "${{ inputs.tag || 'nightly' }}" \
+            --severity "${ONLY_SEVERITY}" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/scan-source.yml
+++ b/.github/workflows/scan-source.yml
@@ -1,6 +1,19 @@
-name: Scan Dockerfile vulnerabilities
+name: Scan source for secrets and misconfiguration
+
+# The half of the old scan-dockerfile.yml that Docker Scout cannot replace.
+#
+# scan-dockerfile.yml ran Trivy with `scanners: vuln,secret,misconfig` over the
+# working tree. scan-images.yml now covers `vuln` far better, against the images
+# actually published rather than against the source they were built from.
+#
+# `secret` and `misconfig` have no equivalent in Scout, which finds CVEs in image
+# packages and does not read your source. Dropping them with the rest of the old
+# workflow would have quietly removed secret detection from a public repository,
+# so they live on here, unchanged, minus the vulnerability scanning that moved.
+
 concurrency:
-  group: ${{ github.workflow }}
+  group: ${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 on:
   push:
@@ -14,12 +27,21 @@ on:
     - cron: '0 0 * * *'
 
 jobs:
-  build-and-scan:
-    name: Scan Dockerfile vulnerabilities
-    permissions: write-all
+  scan-source:
+    name: Scan source for secrets and misconfiguration
     runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      security-events: write
     steps:
       - uses: actions/checkout@main
+        with:
+          persist-credentials: false
+
+      # A secret or a misconfiguration in a change is the author's to fix before
+      # it lands, so pull requests fail on it. Scheduled runs report everything
+      # and fail on nothing, because a new detection rule firing on old code is
+      # not a reason to go red.
       - name: Set severity for PRs
         if: github.event_name == 'pull_request' || github.event_name == 'push'
         run: |
@@ -30,6 +52,7 @@ jobs:
         run: |
           echo "SEVERITY=LOW,MEDIUM,HIGH,CRITICAL" >> $GITHUB_ENV
           echo "EXIT_CODE=0" >> $GITHUB_ENV
+
       - name: Scan source code
         uses: aquasecurity/trivy-action@master
         with:
@@ -37,16 +60,19 @@ jobs:
           scan-ref: '.'
           format: 'sarif'
           output: 'source-results.sarif'
-          scanners: 'vuln,secret,misconfig'
+          # No 'vuln': scan-images.yml scans the published images for CVEs.
+          scanners: 'secret,misconfig'
           skip-dirs: 'tests,Video'
           exit-code: '${{ env.EXIT_CODE }}'
           severity: '${{ env.SEVERITY }}'
           limit-severities-for-sarif: true
+
       - name: Upload source scan results to annotations
         if: always()
         uses: Ayrx/sarif_to_github_annotations@master
         with:
           sarif_file: 'source-results.sarif'
+
       - name: Upload source scan results to GitHub Security tab
         if: github.event_name != 'pull_request'
         uses: github/codeql-action/upload-sarif@v4

--- a/Makefile
+++ b/Makefile
@@ -116,6 +116,16 @@ update_dockerhub_description:
 check_dockerhub_description:
 	python3 scripts/dockerhub_description/update_description.py --check
 
+# Reproduce the nightly image scan locally for one image, e.g.
+#   make scan_image_scout IMAGE=base
+#   make scan_image_scout IMAGE=node-chrome TAG=4.48.0-20260909
+# Needs `docker login`; Docker Scout must be enabled for the repository.
+scan_image_scout:
+	docker scout cves --only-fixed --format sarif \
+		--output scout-$(IMAGE).sarif $(NAME)/$(IMAGE):$(or $(TAG),nightly)
+	python3 scripts/scan_images/summarise_scout.py \
+		scout-$(IMAGE).sarif $(NAME)/$(IMAGE):$(or $(TAG),nightly)
+
 update_dockerhub_versions:
 	python3 scripts/dockerhub_description/resolve_versions.py --namespace $(NAME) $(if $(GRID_TAG),--grid-tag $(GRID_TAG),)
 

--- a/scripts/scan_images/summarise_scout.py
+++ b/scripts/scan_images/summarise_scout.py
@@ -175,6 +175,36 @@ def summarise_one(path, image):
     return "\n".join(lines) + "\n"
 
 
+# Replaced once the tally is known; the status has to sit above the table, but
+# cannot be computed until every report has been read.
+STATUS_PLACEHOLDER = object()
+
+
+def _plural(count, noun):
+    return f"{count} {noun}" if count == 1 else f"{count} {noun}s"
+
+
+def _status_line(totals, affected, scanned):
+    """The one line a maintainer should be able to act on without reading further."""
+    scope = f"across {affected} of {_plural(scanned, 'image')}"
+    if totals["critical"]:
+        return (
+            f"**Status: ACTION NEEDED** — {totals['critical']} critical and {totals['high']} high "
+            f"with fixes available, {scope}."
+        )
+    if totals["high"]:
+        return (
+            f"**Status: ACTION NEEDED** — {totals['high']} high with fixes available, "
+            f"{scope}."
+        )
+    if affected:
+        return (
+            f"**Status: OK** — nothing critical or high. {sum(totals.values())} lower-severity "
+            f"findings have fixes available, {scope}."
+        )
+    return f"**Status: CLEAN** — no CVEs with a fix available across {_plural(scanned, 'image')}."
+
+
 def summarise_rollup(directory, tag, severity):
     root = pathlib.Path(directory)
     reports = sorted(root.glob("**/*.sarif"))
@@ -188,6 +218,8 @@ def summarise_rollup(directory, tag, severity):
         return "\n".join(lines) + "\n"
 
     lines.append(f"Reporting severities: **{severity}**. Every CVE listed has a fix available upstream.")
+    lines.append("")
+    lines.append(STATUS_PLACEHOLDER)
     lines.append("")
     lines.append("| Image | Critical | High | Medium | Low | Total fixable |")
     lines.append("| --- | ---: | ---: | ---: | ---: | ---: |")
@@ -211,6 +243,10 @@ def summarise_rollup(directory, tag, severity):
         cells = " | ".join(str(tally.get(name, 0)) for name in ["critical", "high", "medium", "low"])
         lines.append(f"| `{image}` | {cells} | {total} |")
 
+    affected = sum(1 for row in rows if row[4])
+    status = _status_line(totals, affected, len(rows))
+    lines = [status if line is STATUS_PLACEHOLDER else line for line in lines]
+
     grand = sum(totals.values())
     cells = " | ".join(str(totals[name]) for name in ["critical", "high", "medium", "low"])
     lines.append(f"| **Total** | {cells} | **{grand}** |")
@@ -218,13 +254,10 @@ def summarise_rollup(directory, tag, severity):
 
     if totals["critical"] or totals["high"]:
         lines.append(
-            f"**{totals['critical']} critical and {totals['high']} high** findings have a fix available. "
-            "Most will come from a shared base layer, so bumping the base image usually clears the same "
-            "CVE across every descendant at once - start with `base` and `node-base`."
+            "Most of these will come from a shared base layer, so bumping the base image usually clears "
+            "the same CVE across every descendant at once - start with `base` and `node-base`."
         )
-    else:
-        lines.append("Nothing critical or high with a fix available.")
-    lines.append("")
+        lines.append("")
     lines.append("Per-CVE detail is in the Security tab, and in the `scout-<image>` artifacts on this run.")
 
     if unreadable:

--- a/scripts/scan_images/summarise_scout.py
+++ b/scripts/scan_images/summarise_scout.py
@@ -1,0 +1,255 @@
+#!/usr/bin/env python3
+"""Turn Docker Scout's SARIF output into a maintainer-facing summary.
+
+Two modes:
+
+* ``summarise_scout.py <file.sarif> <image>`` - one image, written under a
+  heading in the job summary.
+* ``summarise_scout.py --rollup <dir>`` - every report in a directory, rolled
+  into one table so a maintainer can see the whole surface without opening 26
+  matrix jobs.
+
+The scan is run with ``--only-fixed``, so everything reported here has a fix
+available upstream. That is the point: an unfixable CVE is not an action, and
+mixing the two is how a security report becomes noise.
+
+Parsing sticks to fields the SARIF specification requires, with fallbacks, rather
+than to Scout's internal shape. ``security-severity`` is GitHub's convention and
+is what the Security tab itself sorts on; ``level`` is plain SARIF. If a future
+Scout release moves its extras around, the counts still come out.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+
+SEVERITY_ORDER = ["critical", "high", "medium", "low", "unknown"]
+
+# GitHub's security-severity is a CVSS base score. These are its documented bands.
+SCORE_BANDS = [(9.0, "critical"), (7.0, "high"), (4.0, "medium"), (0.1, "low")]
+
+# Plain SARIF levels, used when no score is present.
+LEVEL_TO_SEVERITY = {"error": "high", "warning": "medium", "note": "low", "none": "unknown"}
+
+CVE_RE = re.compile(r"CVE-\d{4}-\d+", re.IGNORECASE)
+FIXED_IN_RE = re.compile(r"fixed(?:\s+in|\s+version)?[:\s]+([^\s,;)]+)", re.IGNORECASE)
+
+
+def severity_of(rule, result):
+    """Best available severity for a finding, most trustworthy source first."""
+    props = (rule or {}).get("properties", {})
+    raw = props.get("security-severity")
+    if raw is not None:
+        try:
+            score = float(raw)
+        except (TypeError, ValueError):
+            score = None
+        if score is not None:
+            for threshold, label in SCORE_BANDS:
+                if score >= threshold:
+                    return label
+            return "unknown"
+
+    for tag in props.get("tags", []) or []:
+        if str(tag).lower() in SEVERITY_ORDER:
+            return str(tag).lower()
+
+    level = (result or {}).get("level") or (rule or {}).get("defaultConfiguration", {}).get("level")
+    return LEVEL_TO_SEVERITY.get(level, "unknown")
+
+
+def _text(node, *keys):
+    for key in keys:
+        value = (node or {}).get(key)
+        if isinstance(value, dict) and value.get("text"):
+            return value["text"]
+        if isinstance(value, str) and value:
+            return value
+    return ""
+
+
+def parse_sarif(payload):
+    """(findings, problems). A finding is one fixable CVE in one package."""
+    findings, problems = [], []
+    runs = payload.get("runs") or []
+    if not runs:
+        return findings, ["report contains no runs"]
+
+    for run in runs:
+        rules = {r.get("id"): r for r in (run.get("tool", {}).get("driver", {}).get("rules") or [])}
+        for result in run.get("results") or []:
+            rule_id = result.get("ruleId") or ""
+            rule = rules.get(rule_id, {})
+            blob = " ".join(
+                filter(
+                    None,
+                    [
+                        rule_id,
+                        _text(result, "message"),
+                        _text(rule, "shortDescription", "fullDescription"),
+                        _text(rule, "help"),
+                    ],
+                )
+            )
+            cve = CVE_RE.search(blob)
+            fixed = FIXED_IN_RE.search(blob)
+            findings.append(
+                {
+                    "id": cve.group(0).upper() if cve else (rule_id or "unknown"),
+                    "severity": severity_of(rule, result),
+                    "package": _package_of(result) or _text(rule, "shortDescription") or "-",
+                    "fixed_in": fixed.group(1) if fixed else "",
+                }
+            )
+    return findings, problems
+
+
+def _package_of(result):
+    """The artifact a finding sits in, from the standard location structure."""
+    for location in result.get("locations") or []:
+        uri = (
+            location.get("physicalLocation", {})
+            .get("artifactLocation", {})
+            .get("uri")
+        )
+        if uri:
+            return uri
+    return ""
+
+
+def counts(findings):
+    tally = {name: 0 for name in SEVERITY_ORDER}
+    for finding in findings:
+        tally[finding["severity"]] = tally.get(finding["severity"], 0) + 1
+    return tally
+
+
+def _load(path):
+    try:
+        return json.loads(pathlib.Path(path).read_text()), None
+    except FileNotFoundError:
+        return None, f"{path}: not found"
+    except json.JSONDecodeError as error:
+        return None, f"{path}: not valid JSON ({error})"
+
+
+def summarise_one(path, image):
+    payload, error = _load(path)
+    if error:
+        return f"Could not read the Scout report - {error}\n"
+
+    findings, problems = parse_sarif(payload)
+    tally = counts(findings)
+    lines = []
+
+    if not findings:
+        lines.append("No CVEs with a fix available. :tada:\n")
+        return "\n".join(lines)
+
+    lines.append("| Severity | Fixable |")
+    lines.append("| --- | ---: |")
+    for name in SEVERITY_ORDER:
+        if tally.get(name):
+            lines.append(f"| {name.capitalize()} | {tally[name]} |")
+    lines.append("")
+
+    actionable = [f for f in findings if f["severity"] in ("critical", "high")]
+    if actionable:
+        lines.append("<details><summary>Critical and high, with fixes</summary>")
+        lines.append("")
+        lines.append("| CVE | Severity | Package | Fixed in |")
+        lines.append("| --- | --- | --- | --- |")
+        for finding in sorted(actionable, key=lambda f: (SEVERITY_ORDER.index(f["severity"]), f["id"]))[:50]:
+            fixed = finding["fixed_in"] or "see report"
+            lines.append(f"| {finding['id']} | {finding['severity']} | `{finding['package']}` | {fixed} |")
+        if len(actionable) > 50:
+            lines.append(f"| … | | | {len(actionable) - 50} more in the SARIF artifact |")
+        lines.append("")
+        lines.append("</details>")
+        lines.append("")
+
+    for problem in problems:
+        lines.append(f"> {problem}")
+    return "\n".join(lines) + "\n"
+
+
+def summarise_rollup(directory, tag, severity):
+    root = pathlib.Path(directory)
+    reports = sorted(root.glob("**/*.sarif"))
+    lines = [f"## Fixable CVEs in `:{tag}` images", ""]
+
+    if not reports:
+        lines.append(
+            "No Scout reports were produced. The most likely cause is that Docker Scout is not "
+            "enabled for these repositories - check `docker scout repo list`."
+        )
+        return "\n".join(lines) + "\n"
+
+    lines.append(f"Reporting severities: **{severity}**. Every CVE listed has a fix available upstream.")
+    lines.append("")
+    lines.append("| Image | Critical | High | Medium | Low | Total fixable |")
+    lines.append("| --- | ---: | ---: | ---: | ---: | ---: |")
+
+    totals = {name: 0 for name in SEVERITY_ORDER}
+    rows, unreadable = [], []
+    for report in reports:
+        payload, error = _load(report)
+        if error:
+            unreadable.append(report.name)
+            continue
+        findings, _ = parse_sarif(payload)
+        tally = counts(findings)
+        for name in SEVERITY_ORDER:
+            totals[name] += tally.get(name, 0)
+        image = report.stem.replace("scout-", "")
+        rows.append((tally.get("critical", 0), tally.get("high", 0), image, tally, len(findings)))
+
+    # Worst first: an empty report at the top of a long table hides the one that matters.
+    for _, _, image, tally, total in sorted(rows, key=lambda r: (-r[0], -r[1], r[2])):
+        cells = " | ".join(str(tally.get(name, 0)) for name in ["critical", "high", "medium", "low"])
+        lines.append(f"| `{image}` | {cells} | {total} |")
+
+    grand = sum(totals.values())
+    cells = " | ".join(str(totals[name]) for name in ["critical", "high", "medium", "low"])
+    lines.append(f"| **Total** | {cells} | **{grand}** |")
+    lines.append("")
+
+    if totals["critical"] or totals["high"]:
+        lines.append(
+            f"**{totals['critical']} critical and {totals['high']} high** findings have a fix available. "
+            "Most will come from a shared base layer, so bumping the base image usually clears the same "
+            "CVE across every descendant at once - start with `base` and `node-base`."
+        )
+    else:
+        lines.append("Nothing critical or high with a fix available.")
+    lines.append("")
+    lines.append("Per-CVE detail is in the Security tab, and in the `scout-<image>` artifacts on this run.")
+
+    if unreadable:
+        lines.append("")
+        lines.append(f"> Could not read: {', '.join(unreadable)}")
+    return "\n".join(lines) + "\n"
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Summarise Docker Scout SARIF output.")
+    parser.add_argument("sarif", nargs="?", help="A single SARIF file.")
+    parser.add_argument("image", nargs="?", help="Image the SARIF describes.")
+    parser.add_argument("--rollup", metavar="DIR", help="Roll up every SARIF under DIR instead.")
+    parser.add_argument("--tag", default="nightly")
+    parser.add_argument("--severity", default="critical,high")
+    args = parser.parse_args(argv)
+
+    if args.rollup:
+        sys.stdout.write(summarise_rollup(args.rollup, args.tag, args.severity))
+        return 0
+    if not args.sarif:
+        parser.error("give a SARIF file, or --rollup DIR")
+    sys.stdout.write(summarise_one(args.sarif, args.image or args.sarif))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scan_images/test_summarise_scout.py
+++ b/tests/scan_images/test_summarise_scout.py
@@ -195,7 +195,8 @@ class RollupTest(unittest.TestCase):
     def test_clean_run_says_nothing_actionable(self):
         self.write("a", [], [])
         out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
-        self.assertIn("Nothing critical or high", out)
+        self.assertIn("Status: CLEAN", out)
+        self.assertNotIn("ACTION NEEDED", out)
 
     def test_points_maintainers_at_the_shared_base_layer(self):
         self.write("a", [result("CVE-2026-1")], [rule("CVE-2026-1", security_severity="9.8")])
@@ -211,3 +212,61 @@ class RollupTest(unittest.TestCase):
         out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
         self.assertIn("`good`", out)
         self.assertIn("Could not read", out)
+
+
+class StatusLineTest(unittest.TestCase):
+    def status(self, critical=0, high=0, medium=0, low=0, affected=0, scanned=26):
+        totals = {"critical": critical, "high": high, "medium": medium, "low": low, "unknown": 0}
+        return ss._status_line(totals, affected, scanned)
+
+    def test_critical_demands_action_and_names_both_counts(self):
+        line = self.status(critical=2, high=3, affected=4)
+        self.assertIn("ACTION NEEDED", line)
+        self.assertIn("2 critical", line)
+        self.assertIn("3 high", line)
+        self.assertIn("4 of 26", line)
+
+    def test_high_alone_still_demands_action(self):
+        line = self.status(high=1, affected=1)
+        self.assertIn("ACTION NEEDED", line)
+        self.assertIn("1 high", line)
+
+    def test_only_lower_severities_is_ok_not_action_needed(self):
+        line = self.status(medium=5, low=2, affected=3)
+        self.assertIn("Status: OK", line)
+        self.assertNotIn("ACTION NEEDED", line)
+        self.assertIn("7 lower-severity", line)
+
+    def test_nothing_at_all_is_clean(self):
+        line = self.status()
+        self.assertIn("Status: CLEAN", line)
+        self.assertIn("26 images", line)
+
+
+class RollupStatusTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, image, results, rules):
+        d = self.tmp / f"scout-{image}"
+        d.mkdir(parents=True)
+        (d / f"scout-{image}.sarif").write_text(json.dumps(sarif(results, rules)))
+
+    def test_status_appears_above_the_table(self):
+        self.write("base", [result("CVE-2026-1")], [rule("CVE-2026-1", security_severity="9.8")])
+        out = ss.summarise_rollup(self.tmp, "latest", "critical,high")
+        self.assertIn("Status: ACTION NEEDED", out)
+        self.assertLess(out.index("Status:"), out.index("| Image |"))
+
+    def test_clean_rollup_reports_clean_status(self):
+        self.write("base", [], [])
+        out = ss.summarise_rollup(self.tmp, "latest", "critical,high")
+        self.assertIn("Status: CLEAN", out)
+
+    def test_no_placeholder_object_leaks_into_the_output(self):
+        self.write("base", [result("CVE-2026-1")], [rule("CVE-2026-1", security_severity="9.8")])
+        out = ss.summarise_rollup(self.tmp, "latest", "critical,high")
+        self.assertNotIn("object at 0x", out)
+        self.assertNotIn("STATUS_PLACEHOLDER", out)

--- a/tests/scan_images/test_summarise_scout.py
+++ b/tests/scan_images/test_summarise_scout.py
@@ -1,0 +1,213 @@
+import importlib.util
+import json
+import pathlib
+import tempfile
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "scan_images" / "summarise_scout.py"
+spec = importlib.util.spec_from_file_location("summarise_scout", MODULE_PATH)
+ss = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ss)
+
+
+def sarif(results, rules):
+    return {
+        "version": "2.1.0",
+        "runs": [{"tool": {"driver": {"name": "docker scout", "rules": rules}}, "results": results}],
+    }
+
+
+def rule(rule_id, security_severity=None, tags=None, level=None, help_text=""):
+    node = {"id": rule_id, "shortDescription": {"text": rule_id}, "properties": {}}
+    if security_severity is not None:
+        node["properties"]["security-severity"] = security_severity
+    if tags:
+        node["properties"]["tags"] = tags
+    if level:
+        node["defaultConfiguration"] = {"level": level}
+    if help_text:
+        node["help"] = {"text": help_text}
+    return node
+
+
+def result(rule_id, message="", uri="", level=None):
+    node = {"ruleId": rule_id, "message": {"text": message}}
+    if uri:
+        node["locations"] = [{"physicalLocation": {"artifactLocation": {"uri": uri}}}]
+    if level:
+        node["level"] = level
+    return node
+
+
+class SeverityTest(unittest.TestCase):
+    def test_cvss_score_bands_map_to_labels(self):
+        for score, expected in [
+            ("9.8", "critical"),
+            ("9.0", "critical"),
+            ("7.5", "high"),
+            ("7.0", "high"),
+            ("5.0", "medium"),
+            ("4.0", "medium"),
+            ("1.0", "low"),
+            ("0.1", "low"),
+        ]:
+            self.assertEqual(ss.severity_of(rule("x", security_severity=score), {}), expected, score)
+
+    def test_zero_score_is_unknown_not_low(self):
+        self.assertEqual(ss.severity_of(rule("x", security_severity="0.0"), {}), "unknown")
+
+    def test_falls_back_to_tags_when_no_score(self):
+        self.assertEqual(ss.severity_of(rule("x", tags=["CRITICAL"]), {}), "critical")
+
+    def test_falls_back_to_sarif_level_when_no_score_or_tag(self):
+        self.assertEqual(ss.severity_of(rule("x"), {"level": "error"}), "high")
+        self.assertEqual(ss.severity_of(rule("x"), {"level": "note"}), "low")
+
+    def test_unparseable_score_does_not_raise(self):
+        self.assertEqual(ss.severity_of(rule("x", security_severity="not-a-number"), {}), "unknown")
+
+    def test_missing_everything_is_unknown(self):
+        self.assertEqual(ss.severity_of({}, {}), "unknown")
+
+
+class ParseTest(unittest.TestCase):
+    def test_extracts_cve_severity_package_and_fix(self):
+        payload = sarif(
+            [result("CVE-2026-1234", message="Fixed in 1.2.3", uri="usr/lib/libfoo.so")],
+            [rule("CVE-2026-1234", security_severity="9.8")],
+        )
+        findings, problems = ss.parse_sarif(payload)
+        self.assertEqual(problems, [])
+        self.assertEqual(len(findings), 1)
+        self.assertEqual(findings[0]["id"], "CVE-2026-1234")
+        self.assertEqual(findings[0]["severity"], "critical")
+        self.assertEqual(findings[0]["package"], "usr/lib/libfoo.so")
+        self.assertEqual(findings[0]["fixed_in"], "1.2.3")
+
+    def test_finds_the_cve_in_help_text_when_the_rule_id_is_opaque(self):
+        payload = sarif(
+            [result("SNYK-123")],
+            [rule("SNYK-123", security_severity="7.5", help_text="See CVE-2026-9999 for detail")],
+        )
+        findings, _ = ss.parse_sarif(payload)
+        self.assertEqual(findings[0]["id"], "CVE-2026-9999")
+
+    def test_keeps_the_rule_id_when_no_cve_is_present(self):
+        payload = sarif([result("GHSA-abcd")], [rule("GHSA-abcd", security_severity="5.0")])
+        findings, _ = ss.parse_sarif(payload)
+        self.assertEqual(findings[0]["id"], "GHSA-abcd")
+
+    def test_missing_fix_version_is_empty_not_an_error(self):
+        payload = sarif([result("CVE-2026-1", message="no fix mentioned")], [rule("CVE-2026-1")])
+        findings, _ = ss.parse_sarif(payload)
+        self.assertEqual(findings[0]["fixed_in"], "")
+
+    def test_report_with_no_runs_is_reported(self):
+        findings, problems = ss.parse_sarif({"version": "2.1.0"})
+        self.assertEqual(findings, [])
+        self.assertEqual(len(problems), 1)
+
+    def test_empty_results_is_a_clean_report_not_a_problem(self):
+        findings, problems = ss.parse_sarif(sarif([], []))
+        self.assertEqual(findings, [])
+        self.assertEqual(problems, [])
+
+
+class CountsTest(unittest.TestCase):
+    def test_tallies_every_severity(self):
+        findings = [{"severity": s} for s in ["critical", "high", "high", "low"]]
+        tally = ss.counts(findings)
+        self.assertEqual(tally["critical"], 1)
+        self.assertEqual(tally["high"], 2)
+        self.assertEqual(tally["low"], 1)
+        self.assertEqual(tally["medium"], 0)
+
+
+class SummariseOneTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, name, payload):
+        path = self.tmp / name
+        path.write_text(json.dumps(payload))
+        return path
+
+    def test_clean_report_says_so(self):
+        path = self.write("scout-hub.sarif", sarif([], []))
+        out = ss.summarise_one(path, "selenium/hub:nightly")
+        self.assertIn("No CVEs with a fix available", out)
+
+    def test_lists_critical_and_high_with_the_fix_version(self):
+        payload = sarif(
+            [result("CVE-2026-1", message="Fixed in 2.0", uri="usr/bin/thing")],
+            [rule("CVE-2026-1", security_severity="9.8")],
+        )
+        out = ss.summarise_one(self.write("scout-base.sarif", payload), "selenium/base:nightly")
+        self.assertIn("CVE-2026-1", out)
+        self.assertIn("critical", out)
+        self.assertIn("2.0", out)
+        self.assertIn("usr/bin/thing", out)
+
+    def test_missing_file_is_reported_not_raised(self):
+        out = ss.summarise_one(self.tmp / "absent.sarif", "selenium/hub:nightly")
+        self.assertIn("Could not read", out)
+
+    def test_invalid_json_is_reported_not_raised(self):
+        path = self.tmp / "bad.sarif"
+        path.write_text("{not json")
+        self.assertIn("Could not read", ss.summarise_one(path, "selenium/hub:nightly"))
+
+
+class RollupTest(unittest.TestCase):
+    def setUp(self):
+        self._tmp = tempfile.TemporaryDirectory()
+        self.tmp = pathlib.Path(self._tmp.name)
+        self.addCleanup(self._tmp.cleanup)
+
+    def write(self, image, results, rules):
+        d = self.tmp / f"scout-{image}"
+        d.mkdir(parents=True)
+        (d / f"scout-{image}.sarif").write_text(json.dumps(sarif(results, rules)))
+
+    def test_no_reports_points_at_the_likeliest_cause(self):
+        out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
+        self.assertIn("not enabled", out)
+        self.assertIn("docker scout repo list", out)
+
+    def test_worst_image_is_listed_first(self):
+        self.write("quiet", [], [])
+        self.write(
+            "noisy",
+            [result("CVE-2026-1"), result("CVE-2026-2")],
+            [rule("CVE-2026-1", security_severity="9.8"), rule("CVE-2026-2", security_severity="9.8")],
+        )
+        out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
+        self.assertLess(out.index("`noisy`"), out.index("`quiet`"))
+
+    def test_totals_row_sums_every_image(self):
+        self.write("a", [result("CVE-2026-1")], [rule("CVE-2026-1", security_severity="9.8")])
+        self.write("b", [result("CVE-2026-2")], [rule("CVE-2026-2", security_severity="7.5")])
+        out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
+        self.assertIn("| **Total** | 1 | 1 | 0 | 0 | **2** |", out)
+
+    def test_clean_run_says_nothing_actionable(self):
+        self.write("a", [], [])
+        out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
+        self.assertIn("Nothing critical or high", out)
+
+    def test_points_maintainers_at_the_shared_base_layer(self):
+        self.write("a", [result("CVE-2026-1")], [rule("CVE-2026-1", security_severity="9.8")])
+        out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
+        self.assertIn("base", out)
+        self.assertIn("node-base", out)
+
+    def test_an_unreadable_report_does_not_lose_the_others(self):
+        self.write("good", [result("CVE-2026-1")], [rule("CVE-2026-1", security_severity="9.8")])
+        bad = self.tmp / "scout-bad"
+        bad.mkdir()
+        (bad / "scout-bad.sarif").write_text("{not json")
+        out = ss.summarise_rollup(self.tmp, "nightly", "critical,high")
+        self.assertIn("`good`", out)
+        self.assertIn("Could not read", out)


### PR DESCRIPTION
Replaces `scan-dockerfile.yml`.

## Why

That workflow ran Trivy with `scan-type: fs` over the working tree. It scanned what we **write**; nothing scanned what we **ship**. A CVE disclosed in a base image or an OS package after the last release was invisible to it — which is most of them. Meanwhile Docker Scout's results for the published `selenium/*` images sat on Docker Hub and never came back into the repo, so no one was alerted and there was no per-image status to act on.

## What replaces it

`scan-images.yml` scans the tag people actually pull:

- **Daily against `:latest`**, inheriting the old workflow's `0 0 * * *` cron.
- **Again from `nightly.yml` against `:nightly`**, once those images are pushed — the earliest point the alert is useful, while there is still time to bump a base image before it reaches a release.

The image list is read from whichever Makefile target publishes the tag being scanned (`tag_latest` or `tag_nightly`), so there is no second list to drift. Both currently resolve to the same 26 images.

Nothing is pulled: the images already carry `--sbom=true --attest type=provenance,mode=max`, which is exactly what Scout reads.

## Status and what's fixable

Every run leads with the answer, then the detail:

```
## Fixable CVEs in `:latest` images

Reporting severities: **critical,high**. Every CVE listed has a fix available upstream.

**Status: ACTION NEEDED** — 2 critical and 2 high with fixes available, across 2 of 26 images.

| Image | Critical | High | Medium | Low | Total fixable |
| --- | ---: | ---: | ---: | ---: | ---: |
| `base` | 1 | 1 | 1 | 0 | 3 |
| `node-chrome` | 1 | 1 | 0 | 0 | 2 |
| `hub` | 0 | 0 | 0 | 0 | 0 |
| **Total** | 2 | 2 | 1 | 0 | **5** |

Most of these will come from a shared base layer, so bumping the base image usually clears
the same CVE across every descendant at once - start with `base` and `node-base`.
```

Status is one of **ACTION NEEDED** (any critical or high), **OK** (only lower severities), or **CLEAN**. Per-image jobs add a severity breakdown and a table of each CVE with its **fixing version**. SARIF goes to the Security tab, one category per image, so findings get history and dismissal like any other code-scanning alert.

**Only fixable CVEs are reported** (`--only-fixed`). An unfixable CVE is not an action, and mixing the two is how a security report becomes noise.

## The replacement is not like-for-like — please read this bit

The old workflow ran `scanners: vuln,secret,misconfig`. Scout replaces **`vuln`**, and does it far better, against published images rather than source. It has **no equivalent for `secret` or `misconfig`** — it finds CVEs in image packages and does not read your source.

Deleting `scan-dockerfile.yml` outright would therefore have quietly removed **secret detection from a public repository**. I did not think that was mine to decide silently, so that half moves to `scan-source.yml` unchanged, minus the `vuln` scanning that Scout now owns. Pull requests still fail on a secret or a misconfiguration exactly as before. Git records it as a rename, so the diff shows precisely what changed.

If you would rather that went away too, `scan-source.yml` is a single file to delete.

## What I could not verify

**I could not confirm Docker Scout is enabled for the `selenium` org.** `docker scout repo list --org selenium` needs an interactive `docker login` and I did not authenticate as you. Scout's free tier covers a limited number of repositories; this scans 26.

If it is not enabled, or covers fewer repos, the affected jobs produce no SARIF. That is handled rather than silent — the step is `continue-on-error`, the upload is skipped, and the rollup says so:

> No Scout reports were produced. The most likely cause is that Docker Scout is not enabled for these repositories - check `docker scout repo list`.

**Run it once via `workflow_dispatch` before relying on it.** If the plan is the blocker, the same workflow shape works with `trivy image --ignore-unfixed`, which has no such limit.

Because I have no Scout account to test against, the SARIF parsing is written against the **SARIF specification** rather than Scout's exact output: `security-severity` (GitHub's convention, which the Security tab sorts on), falling back to `properties.tags`, then plain `level`. Unexpected output degrades to `unknown` rather than crashing, but the first real run is worth eyeballing.

## Design choices worth challenging

- **The scan never blocks a build.** A CVE in an upstream base image is not something a failed build can fix, and a red pipeline nobody can action is one everybody learns to ignore. Say the word if you would rather it gate.
- **The KEDA mirrors are excluded.** `selenium/keda`, `keda-metrics-apiserver` and `keda-admission-webhooks` are re-tags of upstream `kedacore` images made by `release_grid_scaler_nightly`; a CVE in them is fixed by bumping `KEDA_BASED_TAG`. Pass `images:` to scan them anyway.

## Verification

```
python3 -m unittest discover -s tests/scan_images   # Ran 30 tests ... OK
```

30 tests cover CVSS band mapping, all three severity fallbacks, CVE extraction from opaque rule ids, missing fix versions, malformed and missing reports, worst-first ordering, the totals row, and every status branch. The matrix-resolution shell was run locally for both tags and produces exactly 26 images each. All workflow files parse and `mbake validate` passes.

`make scan_image_scout IMAGE=base` reproduces one image locally.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGLHB3pjY3mGZBu4TyUsrm
