### PR TITLE
[ci] Fix the image scan resolving no images for the latest tag

### DIFF
--- a/.github/workflows/scan-images.yml
+++ b/.github/workflows/scan-images.yml
@@ -87,31 +87,14 @@ jobs:
         env:
           INPUT_IMAGES: ${{ inputs.images }}
           TAG: ${{ inputs.tag || 'latest' }}
+          NAMESPACE: ${{ vars.DOCKER_NAMESPACE || 'selenium' }}
         run: |
-          if [ -n "${INPUT_IMAGES}" ]; then
-            NAMES="${INPUT_IMAGES}"
-          else
-            # Read the tag_nightly target rather than the whole Makefile, so the
-            # list is exactly what nightly publishes and needs no second list to
-            # keep in step. This deliberately excludes selenium/keda,
-            # keda-metrics-apiserver and keda-admission-webhooks: those are
-            # straight re-tags of upstream kedacore images made by
-            # release_grid_scaler_nightly, which nightly does not run. A CVE in
-            # them is fixed by bumping KEDA_BASED_TAG, not by anything built
-            # here. Pass them via `images:` if you want them scanned anyway.
-            # Read the Makefile target that publishes the tag being scanned, so
-            # the list is exactly the release surface and needs no second list to
-            # keep in step.
-            case "${TAG}" in
-              nightly) TARGET=tag_nightly; SUFFIX=nightly ;;
-              *)       TARGET=tag_latest;  SUFFIX=latest  ;;
-            esac
-            NAMES=$(sed -n "/^${TARGET}:/,/^$/p" Makefile \
-                    | grep -oE "\$\(NAME\)/[a-z0-9._-]+:${SUFFIX}" \
-                    | sed "s|\$(NAME)/||; s|:${SUFFIX}||" | sort -u | tr '\n' ' ')
-          fi
-          echo "Scanning: ${NAMES}"
-          echo "images=$(printf '%s' "${NAMES}" | tr ' ' '\n' | grep . | jq -R . | jq -sc .)" >> "$GITHUB_OUTPUT"
+          # --verify drops anything the Makefile builds but the registry does not
+          # have, so a missing tag is a warning here rather than an opaque Scout
+          # failure 27 jobs later.
+          IMAGES=$(python3 scripts/scan_images/resolve_images.py \
+                     --tag "${TAG}" --namespace "${NAMESPACE}" --images "${INPUT_IMAGES}" --verify)
+          echo "images=${IMAGES}" >> "$GITHUB_OUTPUT"
 
   scout:
     name: Scout ${{ matrix.image }}

--- a/scripts/scan_images/resolve_images.py
+++ b/scripts/scan_images/resolve_images.py
@@ -1,0 +1,108 @@
+#!/usr/bin/env python3
+"""Work out which published images to scan for a given tag.
+
+This was shell inside the workflow. It is Python because the shell version had a
+quoting bug that made it silently match nothing: interpolating the tag forced the
+grep pattern into double quotes, bash ate the backslash in ``\\$``, and ``$``
+became an end-of-line anchor. The scan reported success having scanned zero
+images. Anything that can fail silently and still look green belongs somewhere it
+can be tested.
+
+Two sources, and both matter:
+
+* The ``Makefile`` says what this project *builds*. The Docker Hub namespace also
+  holds long-retired repositories - node-opera, node-phantomjs, the -debug
+  variants - which still carry a ``latest`` tag from years ago. Scanning those
+  would report CVEs nobody is going to fix and burn Scout quota doing it.
+* Docker Hub says what actually *exists*. A tag in the Makefile that was never
+  pushed should be reported here, not turned into an opaque Scout failure.
+
+So: take the Makefile's list, drop the upstream mirrors, and confirm against the
+registry.
+"""
+
+import argparse
+import json
+import pathlib
+import re
+import sys
+import urllib.error
+import urllib.request
+
+REPO_ROOT = pathlib.Path(__file__).resolve().parents[2]
+MAKEFILE = REPO_ROOT / "Makefile"
+HUB_API = "https://hub.docker.com/v2"
+
+# Re-tags of upstream kedacore images, made by release_grid_scaler_*. A CVE in
+# them is fixed by bumping KEDA_BASED_TAG, not by anything built here, so they
+# are not this scan's business. keda-external-scaler is ours and is kept.
+UPSTREAM_MIRRORS = {"keda", "keda-metrics-apiserver", "keda-admission-webhooks"}
+
+
+def images_for_tag(makefile_text, tag):
+    """Every image the Makefile publishes under `tag`, minus the upstream mirrors."""
+    pattern = re.compile(r"\$\(NAME\)/([a-z0-9._-]+):" + re.escape(tag) + r"(?![a-z0-9._-])")
+    found = set(pattern.findall(makefile_text))
+    return sorted(found - UPSTREAM_MIRRORS)
+
+
+def tag_exists(namespace, image, tag, opener=urllib.request.urlopen):
+    try:
+        opener(f"{HUB_API}/repositories/{namespace}/{image}/tags/{tag}/", timeout=30)
+        return True
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return False
+        raise
+
+
+def verify(images, namespace, tag, opener=urllib.request.urlopen):
+    """(published, missing). Missing means the Makefile builds it but the tag is not there."""
+    published, missing = [], []
+    for image in images:
+        try:
+            (published if tag_exists(namespace, image, tag, opener) else missing).append(image)
+        except Exception as error:  # noqa: BLE001 - a registry blip must not empty the matrix
+            print(f"WARNING  {image}: could not check the registry ({error}); scanning anyway", file=sys.stderr)
+            published.append(image)
+    return published, missing
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Resolve the images to scan for a tag.")
+    parser.add_argument("--tag", default="latest")
+    parser.add_argument("--namespace", default="selenium")
+    parser.add_argument("--images", default="", help="Explicit space or comma separated list, overrides the Makefile.")
+    parser.add_argument("--verify", action="store_true", help="Drop images whose tag is absent from the registry.")
+    parser.add_argument("--format", choices=["json", "lines"], default="json")
+    args = parser.parse_args(argv)
+
+    if args.images.strip():
+        images = sorted({name for name in re.split(r"[,\s]+", args.images.strip()) if name})
+    else:
+        images = images_for_tag(MAKEFILE.read_text(), args.tag)
+
+    if not images:
+        print(f"No images found for tag {args.tag!r}. Check the Makefile or pass --images.", file=sys.stderr)
+        return 1
+
+    missing = []
+    if args.verify:
+        images, missing = verify(images, args.namespace, args.tag)
+
+    for image in missing:
+        print(f"WARNING  {args.namespace}/{image}:{args.tag} is built by the Makefile but not on the registry", file=sys.stderr)
+    if not images:
+        print(f"Every candidate image is missing the {args.tag!r} tag on the registry.", file=sys.stderr)
+        return 1
+
+    print(f"Resolved {len(images)} image(s) for :{args.tag}", file=sys.stderr)
+    if args.format == "json":
+        print(json.dumps(images))
+    else:
+        print("\n".join(images))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/tests/scan_images/test_resolve_images.py
+++ b/tests/scan_images/test_resolve_images.py
@@ -1,0 +1,133 @@
+import contextlib
+import importlib.util
+import io
+import pathlib
+import unittest
+import urllib.error
+
+MODULE_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "scan_images" / "resolve_images.py"
+spec = importlib.util.spec_from_file_location("resolve_images", MODULE_PATH)
+ri = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(ri)
+
+MAKEFILE = """
+tag_latest:
+\tdocker tag $(NAME)/base:$(TAG_VERSION) $(NAME)/base:latest
+\tdocker tag $(NAME)/hub:$(TAG_VERSION) $(NAME)/hub:latest
+\tdocker tag $(NAME)/node-chrome:$(TAG_VERSION) $(NAME)/node-chrome:latest
+
+tag_ffmpeg_latest:
+\tdocker tag $(NAME)/ffmpeg:$(FFMPEG_TAG_VERSION) $(NAME)/ffmpeg:latest
+
+release_grid_scaler_latest:
+\tdocker buildx imagetools create -t $(NAME)/keda:latest upstream/keda:1
+\tdocker buildx imagetools create -t $(NAME)/keda-metrics-apiserver:latest upstream/x:1
+\tdocker buildx imagetools create -t $(NAME)/keda-admission-webhooks:latest upstream/y:1
+
+tag_nightly:
+\tdocker tag $(NAME)/base:$(TAG_VERSION) $(NAME)/base:nightly
+\tdocker tag $(NAME)/keda-external-scaler:$(TAG_VERSION) $(NAME)/keda-external-scaler:nightly
+"""
+
+
+class ImagesForTagTest(unittest.TestCase):
+    def test_collects_every_image_published_under_the_tag(self):
+        self.assertEqual(ri.images_for_tag(MAKEFILE, "latest"), ["base", "ffmpeg", "hub", "node-chrome"])
+
+    def test_excludes_the_upstream_keda_mirrors(self):
+        found = ri.images_for_tag(MAKEFILE, "latest")
+        for mirror in ["keda", "keda-metrics-apiserver", "keda-admission-webhooks"]:
+            self.assertNotIn(mirror, found)
+
+    def test_keeps_keda_external_scaler_which_is_ours(self):
+        self.assertIn("keda-external-scaler", ri.images_for_tag(MAKEFILE, "nightly"))
+
+    def test_a_different_tag_gets_a_different_list(self):
+        self.assertEqual(ri.images_for_tag(MAKEFILE, "nightly"), ["base", "keda-external-scaler"])
+
+    def test_unknown_tag_is_empty_rather_than_everything(self):
+        self.assertEqual(ri.images_for_tag(MAKEFILE, "beta"), [])
+
+    def test_tag_match_does_not_run_past_the_tag(self):
+        # ':latest' must not also match ':latest-arm64'
+        text = "\t$(NAME)/base:latest-arm64\n\t$(NAME)/hub:latest\n"
+        self.assertEqual(ri.images_for_tag(text, "latest"), ["hub"])
+
+    def test_this_is_the_bug_the_shell_version_had(self):
+        # The shell built its pattern in double quotes, so bash turned '\$' into a
+        # bare '$' and grep read it as an end-of-line anchor: zero matches, and a
+        # green run that scanned nothing. Guard the real Makefile, not a fixture.
+        real = (pathlib.Path(__file__).parents[2] / "Makefile").read_text()
+        self.assertGreater(len(ri.images_for_tag(real, "latest")), 20)
+        self.assertGreater(len(ri.images_for_tag(real, "nightly")), 20)
+
+
+class StubOpener:
+    """Stands in for urllib.request.urlopen. `missing` 404s, `broken` raises."""
+
+    def __init__(self, missing=(), broken=()):
+        self.missing = set(missing)
+        self.broken = set(broken)
+        self.calls = []
+
+    def __call__(self, url, timeout=None):
+        self.calls.append(url)
+        image = url.rstrip("/").split("/")[-3]
+        if image in self.broken:
+            raise urllib.error.URLError("connection reset")
+        if image in self.missing:
+            raise urllib.error.HTTPError(url, 404, "Not Found", {}, io.BytesIO(b""))
+        return object()
+
+
+class VerifyTest(unittest.TestCase):
+    def test_splits_published_from_missing(self):
+        opener = StubOpener(missing={"ffmpeg"})
+        published, missing = ri.verify(["base", "ffmpeg", "hub"], "selenium", "nightly", opener)
+        self.assertEqual(published, ["base", "hub"])
+        self.assertEqual(missing, ["ffmpeg"])
+
+    def test_all_present_means_nothing_missing(self):
+        published, missing = ri.verify(["base", "hub"], "selenium", "latest", StubOpener())
+        self.assertEqual(published, ["base", "hub"])
+        self.assertEqual(missing, [])
+
+    def test_a_registry_error_keeps_the_image_rather_than_emptying_the_matrix(self):
+        opener = StubOpener(broken={"hub"})
+        with contextlib.redirect_stderr(io.StringIO()):
+            published, missing = ri.verify(["base", "hub"], "selenium", "latest", opener)
+        self.assertEqual(published, ["base", "hub"])
+        self.assertEqual(missing, [])
+
+    def test_checks_the_requested_tag(self):
+        opener = StubOpener()
+        ri.verify(["base"], "selenium", "nightly", opener)
+        self.assertTrue(opener.calls[0].endswith("/repositories/selenium/base/tags/nightly/"))
+
+
+class TagExistsTest(unittest.TestCase):
+    def test_true_when_present(self):
+        self.assertTrue(ri.tag_exists("selenium", "base", "latest", StubOpener()))
+
+    def test_false_on_404(self):
+        self.assertFalse(ri.tag_exists("selenium", "base", "latest", StubOpener(missing={"base"})))
+
+    def test_non_404_http_errors_propagate(self):
+        def opener(url, timeout=None):
+            raise urllib.error.HTTPError(url, 500, "Server Error", {}, io.BytesIO(b""))
+
+        with self.assertRaises(urllib.error.HTTPError):
+            ri.tag_exists("selenium", "base", "latest", opener)
+
+
+class MainTest(unittest.TestCase):
+    def test_explicit_images_override_the_makefile(self):
+        out = io.StringIO()
+        with contextlib.redirect_stdout(out), contextlib.redirect_stderr(io.StringIO()):
+            code = ri.main(["--tag", "latest", "--images", "hub, base"])
+        self.assertEqual(code, 0)
+        self.assertEqual(out.getvalue().strip(), '["base", "hub"]')
+
+    def test_unknown_tag_exits_non_zero_rather_than_emitting_an_empty_matrix(self):
+        with contextlib.redirect_stdout(io.StringIO()), contextlib.redirect_stderr(io.StringIO()):
+            self.assertEqual(ri.main(["--tag", "no-such-tag"]), 1)


### PR DESCRIPTION
Fixes the dispatch run on `latest` that [scanned nothing and reported success](https://github.com/SeleniumHQ/docker-selenium/actions/runs/33961478327/job/101293997620).

## What happened

```
Scanning:
```

The image list came out empty, the Scout matrix expanded to zero jobs, and the report job found no results. The run went red only because the report job had nothing to read — had the matrix been optional, this would have been a **green run that scanned nothing.**

## Why — and it was mine

The original shell built its grep pattern in **single** quotes:

```bash
grep -oE '\$\(NAME\)/[a-z0-9._-]+:nightly'
```

Making it tag-aware meant interpolating `${SUFFIX}`, so the pattern moved into **double** quotes. Bash then consumed the backslash in `\$`, and grep received:

```
$\(NAME\)/[a-z0-9._-]+:latest
```

where a leading `$` is an end-of-line anchor in ERE. It matched nothing, silently.

Worse: **my local verification used different escaping from the committed file**, so it passed while the real thing was broken. The check proved nothing.

## The fix

The shell is replaced by `scripts/scan_images/resolve_images.py`. Anything that can fail silently and still look green belongs somewhere it can be tested — this now has 16 tests, including one that asserts against the **real Makefile**, so this exact regression cannot come back:

```python
def test_this_is_the_bug_the_shell_version_had(self):
    real = (pathlib.Path(__file__).parents[2] / "Makefile").read_text()
    self.assertGreater(len(ri.images_for_tag(real, "latest")), 20)
```

While fixing it, the list is now resolved properly rather than by parsing one Makefile target:

- **Every image the Makefile publishes under the tag.** `latest` now correctly picks up `ffmpeg` from `tag_ffmpeg_latest` alongside the 26 from `tag_latest` — **27 total**, where the old code would have found 26 even when working.
- **Verified against Docker Hub**, dropping anything not actually published. A missing tag is now a warning in the first job instead of an opaque Scout failure 27 jobs later. This is what catches `ffmpeg` having `latest` but no `nightly`.
- The upstream `keda`, `keda-metrics-apiserver` and `keda-admission-webhooks` mirrors stay excluded — their CVEs are fixed by bumping `KEDA_BASED_TAG`.

## On "get the result from existing images on Docker Hub"

I looked at sourcing the list from the Docker Hub namespace directly, and deliberately did not. The namespace holds **42 repositories, 41 with a `latest` tag** — but 15 are ones this project no longer builds:

```
node-opera  node-opera-debug  node-phantomjs  node-chrome-debug  node-firefox-debug
standalone-opera  standalone-opera-debug  standalone-chrome-debug  standalone-firefox-debug
selenium-remote-build  uploader  ffmpeg  keda  keda-admission-webhooks  keda-metrics-apiserver
```

Most of those carry a years-old `latest` from images that were retired long ago. Scanning them would report CVEs nobody is going to fix and spend Scout quota doing it.

So both sources are used, each for what it actually knows: **the Makefile says what we maintain; the registry confirms it exists.** `ffmpeg` is the one entry above that *is* still ours, and it is now included.

## Verification

```
python3 -m unittest discover -s tests/scan_images   # Ran 46 tests ... OK
```

The resolver was run against the real Makefile and registry:

```
Resolved 27 image(s) for :latest      (26 from tag_latest + ffmpeg)
Resolved 26 image(s) for :nightly     (ffmpeg has no nightly tag; --verify confirms)
```

and the matrix step was simulated end-to-end, expanding to 27 jobs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGLHB3pjY3mGZBu4TyUsrm
