### PR TITLE
[ci] Build images once per PR and promote by tag instead of rebuilding

### DIFF
--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -240,7 +240,7 @@ jobs:
 
       - name: Log in to GHCR
         if: inputs.push
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
 
       - name: Build images
         uses: nick-invision/retry@master
@@ -292,7 +292,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
       - name: Merge the architecture tags
         run: |
           CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -1,0 +1,215 @@
+name: Build images once
+
+# Builds the image set at most once per run and publishes it to GHCR, so the ~37
+# test matrix jobs can pull instead of each building the images it needs. Every
+# test target names image targets as Make prerequisites, so before this they all
+# built something; recent pull request runs took 75-88 minutes.
+#
+# Three modes, decided by the `decide` job and honoured by every test workflow:
+#
+#   reuse-main     the change cannot affect image content, so nothing is built
+#                  and the tests run against the last :main
+#   build-and-push build once, push :pr-<N>, every test job pulls it
+#   build-in-job   fork pull requests, which have no registry credentials, keep
+#                  today's behaviour and build in each job
+#
+# Fork detection compares the head repository against this one. A fork run never
+# receives credentials and never pushes. pull_request_target is deliberately not
+# used: it would run untrusted code with a registry write token.
+
+on:
+  workflow_call:
+    inputs:
+      ci-tag:
+        description: 'Tag to publish. Defaults to pr-<number> or main.'
+        required: false
+        type: string
+        default: ''
+      force-build:
+        description: 'Build even when the change looks image-neutral'
+        required: false
+        type: boolean
+        default: false
+      push:
+        description: 'Push the built images. False builds only, for verification.'
+        required: false
+        type: boolean
+        default: true
+    outputs:
+      mode:
+        description: 'reuse-main, build-and-push, or build-in-job'
+        value: ${{ jobs.decide.outputs.mode }}
+      ci-tag:
+        description: 'Tag the test jobs should pull'
+        value: ${{ jobs.decide.outputs.ci-tag }}
+      registry:
+        description: 'Registry holding that tag'
+        value: ${{ jobs.decide.outputs.registry }}
+
+env:
+  CI_REGISTRY: ghcr.io/${{ github.repository_owner }}
+
+jobs:
+  decide:
+    name: Decide whether to build
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: read
+    outputs:
+      mode: ${{ steps.decide.outputs.mode }}
+      ci-tag: ${{ steps.decide.outputs.ci-tag }}
+      registry: ${{ steps.decide.outputs.registry }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Decide
+        id: decide
+        env:
+          IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
+          INPUT_TAG: ${{ inputs.ci-tag }}
+          FORCE_BUILD: ${{ inputs.force-build }}
+          REGISTRY: ${{ env.CI_REGISTRY }}
+        run: |
+          set -euo pipefail
+          echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+
+          # A fork has no credentials for our registry, so it cannot use a
+          # prebuilt image and must not be handed one to push to.
+          if [ "${IS_FORK}" = "true" ]; then
+            echo "Fork pull request: building in each job, as before."
+            echo "mode=build-in-job" >> "$GITHUB_OUTPUT"
+            echo "ci-tag=" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          if [ -n "${INPUT_TAG}" ]; then
+            TAG="${INPUT_TAG}"
+          elif [ -n "${PR_NUMBER}" ]; then
+            TAG="pr-${PR_NUMBER}"
+          else
+            # Not a pull request, so this is trunk. Publish under a run-scoped tag
+            # and let build-test.yml move :main only after the suite passes, so
+            # :main never points at an untested tree.
+            TAG="trunk-${HEAD_SHA:0:7}"
+          fi
+          echo "ci-tag=${TAG}" >> "$GITHUB_OUTPUT"
+
+          if [ "${FORCE_BUILD}" = "true" ] || [ -z "${PR_NUMBER}" ]; then
+            echo "Building: ${FORCE_BUILD:+forced}${PR_NUMBER:+}${PR_NUMBER:-not a pull request}."
+            echo "mode=build-and-push" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Anything that can change what ends up inside an image. The Makefile
+          # is included because it carries the build arguments and pinned
+          # versions; that is deliberately coarse. An unnecessary build costs
+          # minutes, a missed one ships an untested image.
+          CHANGED=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
+          if echo "${CHANGED}" | grep -qE '^(Base|Hub|Distributor|Router|Sessions|SessionQueue|EventBus|NodeBase|NodeChrome|NodeChromium|NodeEdge|NodeFirefox|NodeDocker|NodeKubernetes|NodeAllBrowsers|Standalone|StandaloneDocker|StandaloneKubernetes|Video|\.ffmpeg|\.keda-external-scaler)/|^Makefile$'; then
+            echo "Image content changed; building once and pushing ${TAG}."
+            echo "${CHANGED}" | grep -E '^(Base|Hub|Distributor|Router|Sessions|SessionQueue|EventBus|Node|Standalone|Video|\.ffmpeg|\.keda-external-scaler)|^Makefile$' | head -20
+            echo "mode=build-and-push" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+
+          # Nothing image-affecting changed, so the last good trunk build will do
+          # - provided it exists. It will not on the first run after this lands.
+          if docker manifest inspect "${REGISTRY}/base:main" >/dev/null 2>&1; then
+            echo "No image content changed; reusing ${REGISTRY}/<image>:main."
+            echo "mode=reuse-main" >> "$GITHUB_OUTPUT"
+            echo "ci-tag=main" >> "$GITHUB_OUTPUT"
+          else
+            echo "No image content changed, but :main does not exist yet; building."
+            echo "mode=build-and-push" >> "$GITHUB_OUTPUT"
+          fi
+
+  build:
+    name: Build and push ${{ needs.decide.outputs.ci-tag }}
+    needs: decide
+    if: needs.decide.outputs.mode == 'build-and-push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Free Disk Space (Ubuntu)
+        uses: jlumbroso/free-disk-space@main
+        with:
+          tool-cache: true
+          android: true
+          dotnet: true
+          haskell: true
+          large-packages: true
+          docker-images: true
+          swap-storage: true
+
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+
+      - name: Set up environment
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 10
+          max_attempts: 3
+          command: make setup_dev_env
+
+      - name: Set Selenium base version
+        uses: ./.github/actions/get-latest-upstream
+        with:
+          release: 'false'
+          gh_cli_token: ${{ secrets.GITHUB_TOKEN }}
+          authors: ${{ vars.AUTHORS || github.repository_owner }}
+
+      # Multi-arch, so the arm64 half of the test matrix pulls rather than
+      # building. The build is slower once; it used to be paid in every job.
+      - name: Set build date and platforms
+        run: |
+          echo "BUILD_DATE=$(date '+%Y%m%d')" >> $GITHUB_ENV
+          make set_build_multiarch
+          cat .env | xargs -I {} echo {} >> $GITHUB_ENV
+
+      - name: Log in to GHCR
+        if: inputs.push
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+
+      - name: Build images
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: PLATFORMS="${PLATFORMS}" VERSION="${BASE_VERSION}" BUILD_DATE="${BUILD_DATE}" make build
+
+      - name: Push images
+        if: inputs.push
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: |
+            VERSION="${BASE_VERSION}" BUILD_DATE="${BUILD_DATE}" \
+              CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+              make push_ci_images
+
+      - name: Summary
+        if: always()
+        run: |
+          {
+            echo "### Images"
+            echo
+            echo "Mode: \`${{ needs.decide.outputs.mode }}\`"
+            echo "Tag: \`${{ env.CI_REGISTRY }}/<image>:${{ needs.decide.outputs.ci-tag }}\`"
+            echo
+            echo "Built once here; the test jobs pull instead of building."
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -48,8 +48,11 @@ on:
         description: 'Tag the test jobs should pull'
         value: ${{ jobs.decide.outputs.ci-tag }}
       base-version:
-        description: 'Selenium core the images were built against'
+        description: 'Selenium core version the images were built against'
         value: ${{ jobs.decide.outputs.base-version }}
+      base-release:
+        description: 'Upstream release tag that core came from'
+        value: ${{ jobs.decide.outputs.base-release }}
       src-hash:
         description: 'Content hash the tag is keyed on'
         value: ${{ jobs.decide.outputs.src-hash }}
@@ -72,6 +75,7 @@ jobs:
       ci-tag: ${{ steps.decide.outputs.ci-tag }}
       src-hash: ${{ steps.decide.outputs.src-hash }}
       base-version: ${{ steps.decide.outputs.base-version }}
+      base-release: ${{ steps.decide.outputs.base-release }}
       registry: ${{ steps.decide.outputs.registry }}
     steps:
       - name: Checkout code
@@ -135,11 +139,12 @@ jobs:
               | sha256sum | cut -c1-12
           )
           TAG="${INPUT_TAG:-src-${SRC_HASH}}"
-          echo "Selenium core: ${BASE_VERSION}"
+          echo "Selenium core: ${BASE_RELEASE} (${BASE_VERSION})"
           echo "Source hash: ${SRC_HASH}"
           echo "ci-tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "src-hash=${SRC_HASH}" >> "$GITHUB_OUTPUT"
           echo "base-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
+          echo "base-release=${BASE_RELEASE}" >> "$GITHUB_OUTPUT"
           {
             echo "### Images"
             echo
@@ -202,8 +207,16 @@ jobs:
           command: make setup_dev_env
 
       # Use exactly the core decide hashed on, so the tag and the image agree.
+      # All three matter: Base/Dockerfile builds its download URL from the
+      # release tag AND the version
+      #   .../releases/download/${RELEASE}/selenium-server-${VERSION}.jar
+      # so carrying only BASE_VERSION leaves BASE_RELEASE on the Makefile default
+      # and asks for a jar that does not exist.
       - name: Use the core decide resolved
-        run: echo "BASE_VERSION=${{ needs.decide.outputs.base-version }}" >> $GITHUB_ENV
+        run: |
+          echo "BASE_VERSION=${{ needs.decide.outputs.base-version }}" >> $GITHUB_ENV
+          echo "BASE_RELEASE=${{ needs.decide.outputs.base-release }}" >> $GITHUB_ENV
+          echo "VERSION=${{ needs.decide.outputs.base-version }}" >> $GITHUB_ENV
 
       # Multi-arch, so the arm64 half of the test matrix pulls rather than
       # building. The build is slower once; it used to be paid in every job.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -60,9 +60,6 @@ on:
         description: 'Registry holding that tag'
         value: ${{ jobs.decide.outputs.registry }}
 
-env:
-  CI_REGISTRY: ghcr.io/${{ github.repository_owner }}
-
 jobs:
   decide:
     name: Decide whether to build
@@ -103,9 +100,13 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           INPUT_TAG: ${{ inputs.ci-tag }}
           FORCE_BUILD: ${{ inputs.force-build }}
-          REGISTRY: ${{ env.CI_REGISTRY }}
+          OWNER: ${{ github.repository_owner }}
         run: |
           set -euo pipefail
+          # A registry reference must be lowercase and the owner is not
+          # (SeleniumHQ), so fold it here. GitHub expressions have no lower().
+          REGISTRY="ghcr.io/$(echo "${OWNER}" | tr '[:upper:]' '[:lower:]')"
+          echo "Registry: ${REGISTRY}"
           echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
 
           # A fork has no credentials for our registry, so it cannot use a
@@ -261,7 +262,7 @@ jobs:
           retry_wait_seconds: 60
           command: |
             VERSION="${BASE_VERSION}" BUILD_DATE="${BUILD_DATE}" \
-              CI_REGISTRY="${{ env.CI_REGISTRY }}" \
+              CI_REGISTRY="${{ needs.decide.outputs.registry }}" \
               CI_TAG="${{ needs.decide.outputs.ci-tag }}-${{ matrix.arch }}" \
               make push_ci_images
 
@@ -272,7 +273,7 @@ jobs:
             echo "### Images (${{ matrix.arch }})"
             echo
             echo "Mode: \`${{ needs.decide.outputs.mode }}\`"
-            echo "Tag: \`${{ env.CI_REGISTRY }}/<image>:${{ needs.decide.outputs.ci-tag }}\`"
+            echo "Tag: \`${{ needs.decide.outputs.registry }}/<image>:${{ needs.decide.outputs.ci-tag }}\`"
             echo
             echo "Built once here; the test jobs pull instead of building."
           } >> "$GITHUB_STEP_SUMMARY"
@@ -294,12 +295,12 @@ jobs:
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
       - name: Merge the architecture tags
         run: |
-          CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+          CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
             make merge_ci_images
       # Alias for cleanup: pr-<N> is what gets deleted when the pull request
       # closes. The src-* tag is shared and must outlive any single one.
       - name: Tag the manifest for this pull request
         if: github.event.pull_request.number
         run: |
-          CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+          CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
             PROMOTE_TO="pr-${{ github.event.pull_request.number }}" make promote_ci_images

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -175,10 +175,21 @@ jobs:
           fi
 
   build:
-    name: Build and push ${{ needs.decide.outputs.ci-tag }}
+    # One native runner per architecture, in parallel. Building both on a single
+    # runner means QEMU-emulating arm64, which ran past an hour; this costs about
+    # one amd64 build. The repo already uses ubuntu-24.04-arm for its arm64 tests.
+    name: Build ${{ matrix.arch }} ${{ needs.decide.outputs.ci-tag }}
     needs: decide
     if: needs.decide.outputs.mode == 'build-and-push'
-    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: true
+      matrix:
+        include:
+          - arch: amd64
+            os: ubuntu-24.04
+          - arch: arm64
+            os: ubuntu-24.04-arm
+    runs-on: ${{ matrix.os }}
     permissions:
       contents: read
       packages: write
@@ -218,13 +229,13 @@ jobs:
           echo "BASE_RELEASE=${{ needs.decide.outputs.base-release }}" >> $GITHUB_ENV
           echo "VERSION=${{ needs.decide.outputs.base-version }}" >> $GITHUB_ENV
 
-      # Multi-arch, so the arm64 half of the test matrix pulls rather than
-      # building. The build is slower once; it used to be paid in every job.
-      - name: Set build date and platforms
+      # Native, single platform. Edge and Chrome for Testing are amd64-only and
+      # the Makefile skips them when PLATFORMS has no linux/amd64, so the arm64
+      # job simply does not produce those two.
+      - name: Set build date and platform
         run: |
           echo "BUILD_DATE=$(date '+%Y%m%d')" >> $GITHUB_ENV
-          make set_build_multiarch
-          cat .env | xargs -I {} echo {} >> $GITHUB_ENV
+          echo "PLATFORMS=linux/${{ matrix.arch }}" >> $GITHUB_ENV
 
       - name: Log in to GHCR
         if: inputs.push
@@ -250,21 +261,45 @@ jobs:
           retry_wait_seconds: 60
           command: |
             VERSION="${BASE_VERSION}" BUILD_DATE="${BUILD_DATE}" \
-              CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+              CI_REGISTRY="${{ env.CI_REGISTRY }}" \
+              CI_TAG="${{ needs.decide.outputs.ci-tag }}-${{ matrix.arch }}" \
               make push_ci_images
-            if [ -n "${{ github.event.pull_request.number }}" ]; then
-              CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
-                PROMOTE_TO="pr-${{ github.event.pull_request.number }}" make promote_ci_images
-            fi
 
       - name: Summary
         if: always()
         run: |
           {
-            echo "### Images"
+            echo "### Images (${{ matrix.arch }})"
             echo
             echo "Mode: \`${{ needs.decide.outputs.mode }}\`"
             echo "Tag: \`${{ env.CI_REGISTRY }}/<image>:${{ needs.decide.outputs.ci-tag }}\`"
             echo
             echo "Built once here; the test jobs pull instead of building."
           } >> "$GITHUB_STEP_SUMMARY"
+
+  merge:
+    name: Merge into one manifest list
+    needs: [decide, build]
+    if: needs.decide.outputs.mode == 'build-and-push'
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Merge the architecture tags
+        run: |
+          CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+            make merge_ci_images
+      # Alias for cleanup: pr-<N> is what gets deleted when the pull request
+      # closes. The src-* tag is shared and must outlive any single one.
+      - name: Tag the manifest for this pull request
+        if: github.event.pull_request.number
+        run: |
+          CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+            PROMOTE_TO="pr-${{ github.event.pull_request.number }}" make promote_ci_images

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -42,6 +42,9 @@ on:
       ci-tag:
         description: 'Tag the test jobs should pull'
         value: ${{ jobs.decide.outputs.ci-tag }}
+      src-hash:
+        description: 'Content hash the tag is keyed on'
+        value: ${{ jobs.decide.outputs.src-hash }}
       registry:
         description: 'Registry holding that tag'
         value: ${{ jobs.decide.outputs.registry }}
@@ -59,6 +62,7 @@ jobs:
     outputs:
       mode: ${{ steps.decide.outputs.mode }}
       ci-tag: ${{ steps.decide.outputs.ci-tag }}
+      src-hash: ${{ steps.decide.outputs.src-hash }}
       registry: ${{ steps.decide.outputs.registry }}
     steps:
       - name: Checkout code
@@ -72,8 +76,6 @@ jobs:
         env:
           IS_FORK: ${{ github.event_name == 'pull_request' && github.event.pull_request.head.repo.full_name != github.repository }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
-          BASE_SHA: ${{ github.event.pull_request.base.sha }}
-          HEAD_SHA: ${{ github.event.pull_request.head.sha || github.sha }}
           INPUT_TAG: ${{ inputs.ci-tag }}
           FORCE_BUILD: ${{ inputs.force-build }}
           REGISTRY: ${{ env.CI_REGISTRY }}
@@ -90,44 +92,49 @@ jobs:
             exit 0
           fi
 
-          if [ -n "${INPUT_TAG}" ]; then
-            TAG="${INPUT_TAG}"
-          elif [ -n "${PR_NUMBER}" ]; then
-            TAG="pr-${PR_NUMBER}"
-          else
-            # Not a pull request, so this is trunk. Publish under a run-scoped tag
-            # and let build-test.yml move :main only after the suite passes, so
-            # :main never points at an untested tree.
-            TAG="trunk-${HEAD_SHA:0:7}"
-          fi
+          # Key the image set on its own content, not on the branch or the
+          # pull request. Every path that can change what ends up in an image,
+          # hashed by blob id, so the tag is identical whenever the content is.
+          #
+          # This is what lets a merge promote the pull request's images rather
+          # than rebuilding them: SeleniumHQ squash-merges, so the pull request
+          # commit is not an ancestor of trunk and cannot be matched by sha, but
+          # the content hash is the same on both sides. Verified against #3228:
+          # its head and its squash merge both hash to fd9b32eb0465.
+          PATHS="Base Hub Distributor Router Sessions SessionQueue EventBus NodeBase
+                 NodeChrome NodeChromium NodeEdge NodeFirefox NodeDocker NodeKubernetes
+                 NodeAllBrowsers Standalone StandaloneDocker StandaloneKubernetes Video
+                 .ffmpeg .keda-external-scaler Makefile"
+          SRC_HASH=$(git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort | sha256sum | cut -c1-12)
+          TAG="${INPUT_TAG:-src-${SRC_HASH}}"
+          echo "Source hash: ${SRC_HASH}"
           echo "ci-tag=${TAG}" >> "$GITHUB_OUTPUT"
+          echo "src-hash=${SRC_HASH}" >> "$GITHUB_OUTPUT"
+          {
+            echo "### Images"
+            echo
+            echo "Source hash: \`${SRC_HASH}\`"
+          } >> "$GITHUB_STEP_SUMMARY"
 
-          if [ "${FORCE_BUILD}" = "true" ] || [ -z "${PR_NUMBER}" ]; then
-            echo "Building: ${FORCE_BUILD:+forced}${PR_NUMBER:+}${PR_NUMBER:-not a pull request}."
+          if [ "${FORCE_BUILD}" = "true" ]; then
+            echo "Forced rebuild."
             echo "mode=build-and-push" >> "$GITHUB_OUTPUT"
+            echo "Forced rebuild." >> "$GITHUB_STEP_SUMMARY"
             exit 0
           fi
 
-          # Anything that can change what ends up inside an image. The Makefile
-          # is included because it carries the build arguments and pinned
-          # versions; that is deliberately coarse. An unnecessary build costs
-          # minutes, a missed one ships an untested image.
-          CHANGED=$(git diff --name-only "${BASE_SHA}" "${HEAD_SHA}")
-          if echo "${CHANGED}" | grep -qE '^(Base|Hub|Distributor|Router|Sessions|SessionQueue|EventBus|NodeBase|NodeChrome|NodeChromium|NodeEdge|NodeFirefox|NodeDocker|NodeKubernetes|NodeAllBrowsers|Standalone|StandaloneDocker|StandaloneKubernetes|Video|\.ffmpeg|\.keda-external-scaler)/|^Makefile$'; then
-            echo "Image content changed; building once and pushing ${TAG}."
-            echo "${CHANGED}" | grep -E '^(Base|Hub|Distributor|Router|Sessions|SessionQueue|EventBus|Node|Standalone|Video|\.ffmpeg|\.keda-external-scaler)|^Makefile$' | head -20
-            echo "mode=build-and-push" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Nothing image-affecting changed, so the last good trunk build will do
-          # - provided it exists. It will not on the first run after this lands.
-          if docker manifest inspect "${REGISTRY}/base:main" >/dev/null 2>&1; then
-            echo "No image content changed; reusing ${REGISTRY}/<image>:main."
-            echo "mode=reuse-main" >> "$GITHUB_OUTPUT"
-            echo "ci-tag=main" >> "$GITHUB_OUTPUT"
+          # Already built by an earlier run - the pull request that introduced
+          # this content, most often. Nothing to rebuild, on a pull request or on
+          # trunk. On trunk this is exactly the promotion case: the merge reuses
+          # the images its pull request built and tested, and promote-main then
+          # retags them.
+          if docker manifest inspect "${REGISTRY}/base:${TAG}" >/dev/null 2>&1; then
+            echo "Images for this content already exist; reusing ${TAG}."
+            echo "Reusing existing images - no rebuild." >> "$GITHUB_STEP_SUMMARY"
+            echo "mode=reuse" >> "$GITHUB_OUTPUT"
           else
-            echo "No image content changed, but :main does not exist yet; building."
+            echo "No images for this content; building ${TAG}."
+            echo "Image content is new - building once." >> "$GITHUB_STEP_SUMMARY"
             echo "mode=build-and-push" >> "$GITHUB_OUTPUT"
           fi
 
@@ -190,6 +197,9 @@ jobs:
           retry_wait_seconds: 60
           command: PLATFORMS="${PLATFORMS}" VERSION="${BASE_VERSION}" BUILD_DATE="${BUILD_DATE}" make build
 
+      # Also tag pr-<N>, so cleanup-pr-images.yml has something to delete when the
+      # pull request closes. The src-* tag is shared and must outlive any one
+      # pull request, so it is never the thing cleanup removes.
       - name: Push images
         if: inputs.push
         uses: nick-invision/retry@master
@@ -201,6 +211,10 @@ jobs:
             VERSION="${BASE_VERSION}" BUILD_DATE="${BUILD_DATE}" \
               CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
               make push_ci_images
+            if [ -n "${{ github.event.pull_request.number }}" ]; then
+              CI_REGISTRY="${{ env.CI_REGISTRY }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+                PROMOTE_TO="pr-${{ github.event.pull_request.number }}" make promote_ci_images
+            fi
 
       - name: Summary
         if: always()

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -25,6 +25,11 @@ on:
         required: false
         type: string
         default: ''
+      core:
+        description: "Selenium core to build against: 'nightly' or 'stable'. Empty derives it."
+        required: false
+        type: string
+        default: ''
       force-build:
         description: 'Build even when the change looks image-neutral'
         required: false
@@ -42,6 +47,9 @@ on:
       ci-tag:
         description: 'Tag the test jobs should pull'
         value: ${{ jobs.decide.outputs.ci-tag }}
+      base-version:
+        description: 'Selenium core the images were built against'
+        value: ${{ jobs.decide.outputs.base-version }}
       src-hash:
         description: 'Content hash the tag is keyed on'
         value: ${{ jobs.decide.outputs.src-hash }}
@@ -63,6 +71,7 @@ jobs:
       mode: ${{ steps.decide.outputs.mode }}
       ci-tag: ${{ steps.decide.outputs.ci-tag }}
       src-hash: ${{ steps.decide.outputs.src-hash }}
+      base-version: ${{ steps.decide.outputs.base-version }}
       registry: ${{ steps.decide.outputs.registry }}
     steps:
       - name: Checkout code
@@ -70,6 +79,18 @@ jobs:
         with:
           fetch-depth: 0
           persist-credentials: false
+
+      # Resolve the core first: the same source built against a different Selenium
+      # core produces different images, so the core has to be part of the key.
+      # Pull requests test against the upcoming nightly core, exactly as they did
+      # before this change; trunk and release build the stable one pinned in the
+      # Makefile. Those must never share a tag.
+      - name: Set Selenium base version
+        uses: ./.github/actions/get-latest-upstream
+        with:
+          release: ${{ (inputs.core == 'stable' || (inputs.core == '' && github.event_name != 'pull_request')) && 'true' || 'false' }}
+          gh_cli_token: ${{ secrets.GITHUB_TOKEN }}
+          authors: ${{ vars.AUTHORS || github.repository_owner }}
 
       - name: Decide
         id: decide
@@ -105,14 +126,24 @@ jobs:
                  NodeChrome NodeChromium NodeEdge NodeFirefox NodeDocker NodeKubernetes
                  NodeAllBrowsers Standalone StandaloneDocker StandaloneKubernetes Video
                  .ffmpeg .keda-external-scaler Makefile"
-          SRC_HASH=$(git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort | sha256sum | cut -c1-12)
+          # BASE_VERSION is part of the digest on purpose. Identical source built
+          # against a nightly core and against the stable core are different
+          # images; keying only on the files would let a pull request's
+          # nightly-core build be promoted to :main and released.
+          SRC_HASH=$(
+            { git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort; echo "core=${BASE_VERSION}"; } \
+              | sha256sum | cut -c1-12
+          )
           TAG="${INPUT_TAG:-src-${SRC_HASH}}"
+          echo "Selenium core: ${BASE_VERSION}"
           echo "Source hash: ${SRC_HASH}"
           echo "ci-tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "src-hash=${SRC_HASH}" >> "$GITHUB_OUTPUT"
+          echo "base-version=${BASE_VERSION}" >> "$GITHUB_OUTPUT"
           {
             echo "### Images"
             echo
+            echo "Selenium core: \`${BASE_VERSION}\`"
             echo "Source hash: \`${SRC_HASH}\`"
           } >> "$GITHUB_STEP_SUMMARY"
 
@@ -170,12 +201,9 @@ jobs:
           max_attempts: 3
           command: make setup_dev_env
 
-      - name: Set Selenium base version
-        uses: ./.github/actions/get-latest-upstream
-        with:
-          release: 'false'
-          gh_cli_token: ${{ secrets.GITHUB_TOKEN }}
-          authors: ${{ vars.AUTHORS || github.repository_owner }}
+      # Use exactly the core decide hashed on, so the tag and the image agree.
+      - name: Use the core decide resolved
+        run: echo "BASE_VERSION=${{ needs.decide.outputs.base-version }}" >> $GITHUB_ENV
 
       # Multi-arch, so the arm64 half of the test matrix pulls rather than
       # building. The build is slower once; it used to be paid in every job.

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -321,7 +321,25 @@ jobs:
           persist-credentials: false
       - name: Log in to GHCR
         run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
-      - name: Alias ${{ needs.decide.outputs.ci-tag }} as pr-${{ github.event.pull_request.number }}
+      # Two markers, deliberately:
+      #
+      #   pr-<N>          moves to the newest build, so a human can find "the
+      #                   current image for this pull request"
+      #   pr-<N>-<hash>   never moves, so every manifest this pull request ever
+      #                   used stays attributable to it
+      #
+      # The durable one is what makes close-time cleanup complete. The hash cannot
+      # be recomputed later: it covers BASE_VERSION, and for a pull request that is
+      # the nightly core, which moves - so replaying it after the fact would
+      # resolve a different nightly and a different hash.
+      - name: Mark ${{ needs.decide.outputs.ci-tag }} for pr-${{ github.event.pull_request.number }}
+        env:
+          REGISTRY: ${{ needs.decide.outputs.registry }}
+          CI_TAG: ${{ needs.decide.outputs.ci-tag }}
+          PR: ${{ github.event.pull_request.number }}
+          SRC_HASH: ${{ needs.decide.outputs.src-hash }}
         run: |
-          CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
-            PROMOTE_TO="pr-${{ github.event.pull_request.number }}" make promote_ci_images
+          set -euo pipefail
+          for marker in "pr-${PR}" "pr-${PR}-${SRC_HASH}"; do
+            CI_REGISTRY="${REGISTRY}" CI_TAG="${CI_TAG}" PROMOTE_TO="${marker}" make promote_ci_images
+          done

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -124,11 +124,14 @@ jobs:
           # pull request. Every path that can change what ends up in an image,
           # hashed by blob id, so the tag is identical whenever the content is.
           #
-          # This is what lets a merge promote the pull request's images rather
-          # than rebuilding them: SeleniumHQ squash-merges, so the pull request
-          # commit is not an ancestor of trunk and cannot be matched by sha, but
-          # the content hash is the same on both sides. Verified against #3228:
-          # its head and its squash merge both hash to fd9b32eb0465.
+          # This is what lets a merge reuse the pull request's images rather than
+          # rebuilding them: SeleniumHQ squash-merges, so the pull request commit
+          # is not an ancestor of trunk and cannot be matched by sha, but the
+          # content hash is the same on both sides. Checked against #3228, whose
+          # head and squash merge hash identically over these paths. The digest
+          # also covers BASE_VERSION, so the two sides match only while they
+          # resolve the same core - which is why `release` is threaded through
+          # from the calling workflow rather than resolved here.
           PATHS="Base Hub Distributor Router Sessions SessionQueue EventBus NodeBase
                  NodeChrome NodeChromium NodeEdge NodeFirefox NodeDocker NodeKubernetes
                  NodeAllBrowsers Standalone StandaloneDocker StandaloneKubernetes Video

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -297,10 +297,31 @@ jobs:
         run: |
           CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
             make merge_ci_images
-      # Alias for cleanup: pr-<N> is what gets deleted when the pull request
-      # closes. The src-* tag is shared and must outlive any single one.
-      - name: Tag the manifest for this pull request
-        if: github.event.pull_request.number
+
+  alias:
+    # The pr-<N> alias marks a manifest as in use by an open pull request, so the
+    # cleanup can tell "nobody needs this" from "somebody still does". It has to
+    # be applied on reuse too: a pull request that matched an existing manifest
+    # never enters the build job, and without an alias its images looked orphaned
+    # and were deletable while it was still open.
+    #
+    # Tagging is idempotent, and several pull requests can alias one manifest -
+    # that is exactly how the cleanup sees a manifest as shared.
+    name: Tag the manifest for this pull request
+    needs: [decide, merge]
+    if: always() && github.event.pull_request.number && needs.decide.outputs.mode != 'build-in-job' && !failure() && !cancelled()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+      - name: Log in to GHCR
+        run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
+      - name: Alias ${{ needs.decide.outputs.ci-tag }} as pr-${{ github.event.pull_request.number }}
         run: |
           CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
             PROMOTE_TO="pr-${{ github.event.pull_request.number }}" make promote_ci_images

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -7,9 +7,9 @@ name: Build images once
 #
 # Three modes, decided by the `decide` job and honoured by every test workflow:
 #
-#   reuse-main     the change cannot affect image content, so nothing is built
-#                  and the tests run against the last :main
-#   build-and-push build once, push :pr-<N>, every test job pulls it
+#   reuse          an identical image set is already published under this
+#                  content hash, so nothing is built and every test job pulls it
+#   build-and-push the content is new: build once, push, every test job pulls it
 #   build-in-job   fork pull requests, which have no registry credentials, keep
 #                  today's behaviour and build in each job
 #
@@ -25,11 +25,11 @@ on:
         required: false
         type: string
         default: ''
-      core:
-        description: "Selenium core to build against: 'nightly' or 'stable'. Empty derives it."
+      release:
+        description: "Build against the stable core ('true') or the nightly one ('false')"
         required: false
         type: string
-        default: ''
+        default: 'false'
       force-build:
         description: 'Build even when the change looks image-neutral'
         required: false
@@ -42,7 +42,7 @@ on:
         default: true
     outputs:
       mode:
-        description: 'reuse-main, build-and-push, or build-in-job'
+        description: 'reuse, build-and-push, or build-in-job'
         value: ${{ jobs.decide.outputs.mode }}
       ci-tag:
         description: 'Tag the test jobs should pull'
@@ -82,14 +82,16 @@ jobs:
           persist-credentials: false
 
       # Resolve the core first: the same source built against a different Selenium
-      # core produces different images, so the core has to be part of the key.
-      # Pull requests test against the upcoming nightly core, exactly as they did
-      # before this change; trunk and release build the stable one pinned in the
-      # Makefile. Those must never share a tag.
+      # core produces different images, so the core is part of the key.
+      #
+      # `release` comes from the caller and is the same value the test workflows
+      # feed their own get-latest-upstream, so the images and the tests can never
+      # disagree about which core is under test. Nightly runs pass false and get
+      # the nightly core, which is the whole point of nightly.
       - name: Set Selenium base version
         uses: ./.github/actions/get-latest-upstream
         with:
-          release: ${{ (inputs.core == 'stable' || (inputs.core == '' && github.event_name != 'pull_request')) && 'true' || 'false' }}
+          release: ${{ inputs.release || 'false' }}
           gh_cli_token: ${{ secrets.GITHUB_TOKEN }}
           authors: ${{ vars.AUTHORS || github.repository_owner }}
 
@@ -165,7 +167,18 @@ jobs:
           # trunk. On trunk this is exactly the promotion case: the merge reuses
           # the images its pull request built and tested, and promote-main then
           # retags them.
-          if docker manifest inspect "${REGISTRY}/base:${TAG}" >/dev/null 2>&1; then
+          #
+          # The probe is the completeness marker, NOT base:<tag>. base is the
+          # first image the merge writes, so if a merge dies partway - and
+          # cancel-in-progress makes that routine - base:<tag> exists while later
+          # images do not. Probing base would then choose reuse for ever and
+          # every run would hard-fail in pull_ci_images, with no way out but a
+          # hand-deleted tag. The marker is written only after every image has
+          # merged, so a half-finished set simply rebuilds.
+          #
+          # It is another tag on the manifest base:<tag> already is, so it costs
+          # no storage and cannot itself be left behind.
+          if docker manifest inspect "${REGISTRY}/base:${TAG}-complete" >/dev/null 2>&1; then
             echo "Images for this content already exist; reusing ${TAG}."
             echo "Reusing existing images - no rebuild." >> "$GITHUB_STEP_SUMMARY"
             echo "mode=reuse" >> "$GITHUB_OUTPUT"
@@ -293,10 +306,25 @@ jobs:
           persist-credentials: false
       - name: Log in to GHCR
         run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
+      # Retried: a registry blip here used to leave the set half-merged, which
+      # decide could not distinguish from a finished one.
       - name: Merge the architecture tags
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: |
+            CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
+              make merge_ci_images
+
+      # Only now is the set complete, and only now does decide consider it
+      # reusable. Deliberately a separate step after the retries: if the merge
+      # never succeeds, no marker is written and the next run rebuilds.
+      - name: Mark the set complete
         run: |
           CI_REGISTRY="${{ needs.decide.outputs.registry }}" CI_TAG="${{ needs.decide.outputs.ci-tag }}" \
-            make merge_ci_images
+            make mark_ci_images_complete
 
   alias:
     # The pr-<N> alias marks a manifest as in use by an open pull request, so the

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -129,7 +129,7 @@ jobs:
         with:
           persist-credentials: false
       - name: Log in to GHCR
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
       - name: Retag ${{ needs.build-images.outputs.ci-tag }} as main
         run: |
           CI_REGISTRY="${{ needs.build-images.outputs.registry }}" \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -80,6 +80,7 @@ jobs:
     if: contains(toJson(github.event.commits), '[skip test]') == false
     name: Test Selenium Grid on Docker
     uses: ./.github/workflows/docker-test.yml
+    secrets: inherit
     with:
       ci-mode: ${{ needs.build-images.outputs.mode }}
       ci-tag: ${{ needs.build-images.outputs.ci-tag }}
@@ -91,12 +92,11 @@ jobs:
     if: contains(toJson(github.event.commits), '[skip test]') == false
     name: Test Selenium Grid on Kubernetes
     uses: ./.github/workflows/helm-chart-test.yml
+    secrets: inherit
     with:
       ci-mode: ${{ needs.build-images.outputs.mode }}
       ci-tag: ${{ needs.build-images.outputs.ci-tag }}
       ci-registry: ${{ needs.build-images.outputs.registry }}
-    secrets: inherit
-    with:
       release: ${{ inputs.release == 'true' }}
       test-patched-keda: ${{ github.event.inputs.test-patched-keda }}
 
@@ -105,12 +105,11 @@ jobs:
     if: contains(toJson(github.event.commits), '[skip test]') == false
     name: Test Dynamic Grid on Kubernetes
     uses: ./.github/workflows/k8s-dynamic-grid-test.yml
+    secrets: inherit
     with:
       ci-mode: ${{ needs.build-images.outputs.mode }}
       ci-tag: ${{ needs.build-images.outputs.ci-tag }}
       ci-registry: ${{ needs.build-images.outputs.registry }}
-    secrets: inherit
-    with:
       release: ${{ inputs.release == 'true' }}
 
   promote-main:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -117,7 +117,7 @@ jobs:
     # rather than by the build job. The build published trunk-<sha>; this retags
     # that exact manifest, so no rebuild happens and the digest is identical.
     needs: [build-images, docker-test, helm-chart-test, k8s-dynamic-grid-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !failure() && !cancelled() && needs.build-images.outputs.mode == 'build-and-push'
+    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !failure() && !cancelled() && needs.build-images.outputs.mode != 'build-in-job'
     name: Promote tested images to main
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -69,32 +69,81 @@ jobs:
       - name: Lint format
         run: make lint_format_scripts
 
-  docker-test:
+  build-images:
     needs: [lint-format]
+    name: Build images once
+    uses: ./.github/workflows/build-images.yml
+    secrets: inherit
+
+  docker-test:
+    needs: [lint-format, build-images]
     if: contains(toJson(github.event.commits), '[skip test]') == false
     name: Test Selenium Grid on Docker
     uses: ./.github/workflows/docker-test.yml
     with:
+      ci-mode: ${{ needs.build-images.outputs.mode }}
+      ci-tag: ${{ needs.build-images.outputs.ci-tag }}
+      ci-registry: ${{ needs.build-images.outputs.registry }}
       release: ${{ inputs.release == 'true' }}
 
   helm-chart-test:
-    needs: [lint-format]
+    needs: [lint-format, build-images]
     if: contains(toJson(github.event.commits), '[skip test]') == false
     name: Test Selenium Grid on Kubernetes
     uses: ./.github/workflows/helm-chart-test.yml
+    with:
+      ci-mode: ${{ needs.build-images.outputs.mode }}
+      ci-tag: ${{ needs.build-images.outputs.ci-tag }}
+      ci-registry: ${{ needs.build-images.outputs.registry }}
     secrets: inherit
     with:
       release: ${{ inputs.release == 'true' }}
       test-patched-keda: ${{ github.event.inputs.test-patched-keda }}
 
   k8s-dynamic-grid-test:
-    needs: [lint-format]
+    needs: [lint-format, build-images]
     if: contains(toJson(github.event.commits), '[skip test]') == false
     name: Test Dynamic Grid on Kubernetes
     uses: ./.github/workflows/k8s-dynamic-grid-test.yml
+    with:
+      ci-mode: ${{ needs.build-images.outputs.mode }}
+      ci-tag: ${{ needs.build-images.outputs.ci-tag }}
+      ci-registry: ${{ needs.build-images.outputs.registry }}
     secrets: inherit
     with:
       release: ${{ inputs.release == 'true' }}
+
+  promote-main:
+    # :main must only ever denote a tree whose tests passed, so it is moved here
+    # rather than by the build job. The build published trunk-<sha>; this retags
+    # that exact manifest, so no rebuild happens and the digest is identical.
+    needs: [build-images, docker-test, helm-chart-test, k8s-dynamic-grid-test]
+    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !failure() && !cancelled() && needs.build-images.outputs.mode == 'build-and-push'
+    name: Promote tested images to main
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+      - name: Log in to GHCR
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Retag ${{ needs.build-images.outputs.ci-tag }} as main
+        run: |
+          CI_REGISTRY="${{ needs.build-images.outputs.registry }}" \
+            CI_TAG="${{ needs.build-images.outputs.ci-tag }}" PROMOTE_TO=main \
+            make promote_ci_images
+      - name: Summary
+        run: |
+          {
+            echo "### Promoted to \`:main\`"
+            echo
+            echo "\`${{ needs.build-images.outputs.ci-tag }}\` passed the full suite and is now \`:main\`."
+            echo "Retagged, not rebuilt, so the digest is unchanged."
+          } >> "$GITHUB_STEP_SUMMARY"
 
   rerun-workflow-when-failure:
     name: Rerun workflow when failure

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -18,6 +18,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild the images even when an identical set already exists'
+        required: false
+        default: false
+        type: boolean
   workflow_dispatch:
     inputs:
       rerunFailedOnly:
@@ -30,6 +35,11 @@ on:
         required: false
         default: ''
         type: string
+      force-build:
+        description: 'Rebuild the images even when an identical set already exists'
+        required: false
+        default: false
+        type: boolean
   push:
     branches:
       - trunk
@@ -74,6 +84,12 @@ jobs:
     name: Build images once
     uses: ./.github/workflows/build-images.yml
     secrets: inherit
+    with:
+      release: ${{ inputs.release || 'false' }}
+      # The manual way out of any bad image set: re-run this workflow from the
+      # Actions tab with force-build ticked and the tag is rebuilt from source,
+      # whatever is in the registry under it.
+      force-build: ${{ inputs.force-build || false }}
 
   docker-test:
     needs: [lint-format, build-images]
@@ -114,10 +130,22 @@ jobs:
 
   promote-main:
     # :main must only ever denote a tree whose tests passed, so it is moved here
-    # rather than by the build job. The build published trunk-<sha>; this retags
-    # that exact manifest, so no rebuild happens and the digest is identical.
+    # rather than by the build job. It retags the exact src-<hash> manifest the
+    # tests ran against, so no rebuild happens and the digest is identical.
+    # :main is a cache for later trunk runs, not a release source - deploy.yml
+    # builds its own images.
     needs: [build-images, docker-test, helm-chart-test, k8s-dynamic-grid-test]
-    if: github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !failure() && !cancelled() && needs.build-images.outputs.mode != 'build-in-job'
+    # Every test job must have SUCCEEDED, not merely not-failed. The three of
+    # them skip on '[skip test]', a skipped job is not a failure, and the
+    # release bot pushes exactly such a commit after every release - one that
+    # rewrites Base/, NodeChrome/, Video/ and the Makefile, so the hash changes
+    # and a fresh, wholly untested manifest would have become :main.
+    if: >-
+      github.event_name == 'push' && github.ref == 'refs/heads/trunk' && !cancelled()
+      && needs.build-images.outputs.mode != 'build-in-job'
+      && needs.docker-test.result == 'success'
+      && needs.helm-chart-test.result == 'success'
+      && needs.k8s-dynamic-grid-test.result == 'success'
     name: Promote tested images to main
     runs-on: ubuntu-24.04
     permissions:

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -169,9 +169,10 @@ jobs:
       - name: Remove trunk images that main has superseded
         continue-on-error: true
         env:
-          # The packages are org-level, so deleting a version needs the CI token;
-          # GITHUB_TOKEN 403s, and continue-on-error would have hidden that.
-          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          # The CI token, with no fallback. The packages are org-level, so
+          # GITHUB_TOKEN 403s on a version delete - falling back to it would only
+          # turn a missing secret into a sweep that quietly deletes nothing.
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
         run: |
           python3 scripts/ci/cleanup_pr_images.py \
             --owner "${{ github.repository_owner }}" --prune-superseded --no-pr-sweep \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -169,7 +169,9 @@ jobs:
       - name: Remove trunk images that main has superseded
         continue-on-error: true
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # The packages are org-level, so deleting a version needs the CI token;
+          # GITHUB_TOKEN 403s, and continue-on-error would have hidden that.
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}
         run: |
           python3 scripts/ci/cleanup_pr_images.py \
             --owner "${{ github.repository_owner }}" --prune-superseded --no-pr-sweep \

--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -135,6 +135,18 @@ jobs:
           CI_REGISTRY="${{ needs.build-images.outputs.registry }}" \
             CI_TAG="${{ needs.build-images.outputs.ci-tag }}" PROMOTE_TO=main \
             make promote_ci_images
+      # :main has just moved, so every older trunk manifest is now superseded.
+      # They carry no pr-* alias - only a pull request build creates one - so the
+      # closed-pull-request sweep can never reach them.
+      - name: Remove trunk images that main has superseded
+        continue-on-error: true
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          python3 scripts/ci/cleanup_pr_images.py \
+            --owner "${{ github.repository_owner }}" --prune-superseded --no-pr-sweep \
+            >> "$GITHUB_STEP_SUMMARY"
+
       - name: Summary
         run: |
           {

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -1,0 +1,59 @@
+name: Clean up PR images
+
+# build-images.yml publishes one image set per pull request, tagged pr-<number>.
+# Without this they accumulate forever: 27 images per open pull request, none of
+# them useful once the pull request closes.
+#
+# Runs on close, whether merged or not - a rejected pull request leaves exactly
+# the same rubbish behind as a merged one. Also runs on a schedule to sweep tags
+# belonging to pull requests that closed while this workflow was failing, or
+# before it existed.
+
+on:
+  pull_request_target:
+    types: [closed]
+  schedule:
+    # Weekly sweep for anything the close event missed.
+    - cron: '0 3 * * 0'
+  workflow_dispatch:
+    inputs:
+      pr-number:
+        description: 'Delete images for this PR number. Empty means sweep all closed PRs.'
+        required: false
+        type: string
+        default: ''
+
+# pull_request_target is safe here only because this workflow never checks out or
+# runs any code from the pull request. It reads a number and calls an API.
+permissions:
+  contents: read
+  packages: write
+  pull-requests: read
+
+concurrency:
+  group: ${{ github.workflow }}
+  cancel-in-progress: false
+
+jobs:
+  cleanup:
+    name: Delete pr-* image tags
+    runs-on: ubuntu-24.04
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@main
+        with:
+          persist-credentials: false
+
+      - name: Delete the tags
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          OWNER: ${{ github.repository_owner }}
+          EVENT_PR: ${{ github.event.pull_request.number }}
+          INPUT_PR: ${{ inputs.pr-number }}
+        run: |
+          set -euo pipefail
+          python3 scripts/ci/cleanup_pr_images.py \
+            --owner "${OWNER}" \
+            ${EVENT_PR:+--pr "${EVENT_PR}"} \
+            ${INPUT_PR:+--pr "${INPUT_PR}"} \
+            >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -52,8 +52,18 @@ jobs:
           INPUT_PR: ${{ inputs.pr-number }}
         run: |
           set -euo pipefail
+          # On the weekly sweep also collect orphans: src-* manifests with no
+          # pr-* alias. A pull request retags pr-<N> onto each new build, so its
+          # earlier manifests keep only src-* and no other sweep can see them.
+          # Safe because every manifest an open pull request depends on is
+          # aliased, including one it merely reused - the age guard just covers
+          # the minutes between a push and its alias landing.
+          ORPHANS=""
+          if [ -z "${EVENT_PR}${INPUT_PR}" ]; then
+            ORPHANS="--prune-orphans 7"
+          fi
           python3 scripts/ci/cleanup_pr_images.py \
-            --owner "${OWNER}" \
+            --owner "${OWNER}" ${ORPHANS} \
             ${EVENT_PR:+--pr "${EVENT_PR}"} \
             ${INPUT_PR:+--pr "${INPUT_PR}"} \
             >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -4,10 +4,20 @@ name: Clean up PR images
 # Without this they accumulate forever: 27 images per open pull request, none of
 # them useful once the pull request closes.
 #
-# Runs on close, whether merged or not - a rejected pull request leaves exactly
-# the same rubbish behind as a merged one. Also runs on a schedule to sweep tags
-# belonging to pull requests that closed while this workflow was failing, or
-# before it existed.
+# Runs when a pull request is closed WITHOUT being merged - it leaves the same
+# rubbish behind and nothing else will ever want those images.
+#
+# A merged pull request is deliberately left alone here. Its manifests are the
+# ones the trunk run started seconds earlier is about to reuse: the merge commit
+# hashes to the same content, so decide chooses reuse and every test job pulls
+# that exact manifest. Deleting on merge either hard-fails those pulls or, at
+# best, forces the rebuild this whole design exists to avoid. They are collected
+# later instead - the weekly sweep sees a closed pull request, and by then either
+# promote-main has claimed them as :main (protected) or a later trunk build has
+# superseded them.
+#
+# The schedule also sweeps tags belonging to pull requests that closed while this
+# workflow was failing, or before it existed.
 
 on:
   pull_request_target:
@@ -37,6 +47,9 @@ concurrency:
 jobs:
   cleanup:
     name: Delete pr-* image tags
+    # Merged pull requests are skipped here; see the note above. A maintainer can
+    # still force one with workflow_dispatch and a pr-number.
+    if: github.event_name != 'pull_request_target' || github.event.pull_request.merged == false
     runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
@@ -46,7 +59,7 @@ jobs:
 
       - name: Delete the tags
         env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           EVENT_PR: ${{ github.event.pull_request.number }}
           INPUT_PR: ${{ inputs.pr-number }}

--- a/.github/workflows/cleanup-pr-images.yml
+++ b/.github/workflows/cleanup-pr-images.yml
@@ -59,7 +59,11 @@ jobs:
 
       - name: Delete the tags
         env:
-          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}
+          # The CI token, with no fallback. The packages are org-level, so
+          # GITHUB_TOKEN 403s on a version delete; without the secret the script
+          # stops with "GH_TOKEN is required" rather than reporting a clean sweep
+          # that removed nothing.
+          GH_TOKEN: ${{ secrets.SELENIUM_CI_TOKEN }}
           OWNER: ${{ github.repository_owner }}
           EVENT_PR: ${{ github.event.pull_request.number }}
           INPUT_PR: ${{ inputs.pr-number }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -145,9 +145,38 @@ jobs:
       - name: Log in to GHCR
         if: github.event.inputs.skip-build-push-image != 'true'
         run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      # Only reuse :main when it was built from this source and this core. The
+      # hash covers both, so a stale :main - trunk moved on, or the core changed
+      # under us - falls through to a rebuild instead of releasing the wrong bits.
+      - name: Is :main up to date for this release?
+        id: main-current
+        if: github.event.inputs.skip-build-push-image != 'true'
+        run: |
+          set -euo pipefail
+          REGISTRY="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
+          PATHS="Base Hub Distributor Router Sessions SessionQueue EventBus NodeBase
+                 NodeChrome NodeChromium NodeEdge NodeFirefox NodeDocker NodeKubernetes
+                 NodeAllBrowsers Standalone StandaloneDocker StandaloneKubernetes Video
+                 .ffmpeg .keda-external-scaler Makefile"
+          SRC_HASH=$(
+            { git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort; echo "core=${BASE_VERSION}"; } \
+              | sha256sum | cut -c1-12
+          )
+          echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
+          echo "src-hash=${SRC_HASH}" >> "$GITHUB_OUTPUT"
+          MAIN=$(docker manifest inspect "${REGISTRY}/base:main" 2>/dev/null | sha256sum | cut -c1-12 || echo none)
+          SRC=$(docker manifest inspect "${REGISTRY}/base:src-${SRC_HASH}" 2>/dev/null | sha256sum | cut -c1-12 || echo missing)
+          if [ "${SRC}" != "missing" ] && [ "${SRC}" = "${MAIN}" ]; then
+            echo "current=true" >> "$GITHUB_OUTPUT"
+            echo ":main matches src-${SRC_HASH} (core ${BASE_VERSION}); promoting it." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "current=false" >> "$GITHUB_OUTPUT"
+            echo ":main does not match src-${SRC_HASH} (core ${BASE_VERSION}); rebuilding." >> "$GITHUB_STEP_SUMMARY"
+          fi
+
       - name: Pull the tested main images
         id: pull-main
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.main-current.outputs.current == 'true'
         continue-on-error: true
         uses: nick-invision/retry@master
         with:
@@ -156,7 +185,7 @@ jobs:
           retry_wait_seconds: 60
           command: |
             VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
-              CI_REGISTRY="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              CI_REGISTRY="${{ steps.main-current.outputs.registry }}" \
               CI_TAG=main make pull_ci_images
       # :main will not exist on the first release after this lands, and a release
       # must not be blocked on that. Fall back to building exactly as before.
@@ -172,9 +201,9 @@ jobs:
         if: github.event.inputs.skip-build-push-image != 'true'
         run: |
           if [ "${{ steps.pull-main.outcome }}" = "success" ]; then
-            echo "Promoting the tested :main images to ${GRID_VERSION}-${BUILD_DATE}." >> "$GITHUB_STEP_SUMMARY"
+            echo "Released ${GRID_VERSION}-${BUILD_DATE} by promoting the tested :main images." >> "$GITHUB_STEP_SUMMARY"
           else
-            echo "No usable :main image; built from source for ${GRID_VERSION}-${BUILD_DATE}." >> "$GITHUB_STEP_SUMMARY"
+            echo "Built ${GRID_VERSION}-${BUILD_DATE} from source; :main was not usable." >> "$GITHUB_STEP_SUMMARY"
           fi
       - name: Login Docker Hub
         run: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -144,7 +144,7 @@ jobs:
       # The build-test job above has already re-run the suite against it.
       - name: Log in to GHCR
         if: github.event.inputs.skip-build-push-image != 'true'
-        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+        run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
       # Only reuse :main when it was built from this source and this core. The
       # hash covers both, so a stale :main - trunk moved on, or the core changed
       # under us - falls through to a rebuild instead of releasing the wrong bits.

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,14 +138,44 @@ jobs:
         run: |
           make chart_render_template
           echo "PUBLISH_YAML_MANIFESTS=$(find ./tests/tests -name "k8s_*.yaml" | tr '\n' ',')" >> $GITHUB_ENV
-      - name: Build images
+      # Promote rather than rebuild. :main is the last trunk build whose full
+      # test suite passed, so pulling it means the digest released is the digest
+      # tested - a rebuild from the same source is close, but not the same thing.
+      # The build-test job above has already re-run the suite against it.
+      - name: Log in to GHCR
         if: github.event.inputs.skip-build-push-image != 'true'
+        run: echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+      - name: Pull the tested main images
+        id: pull-main
+        if: github.event.inputs.skip-build-push-image != 'true'
+        continue-on-error: true
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: |
+            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              CI_REGISTRY="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              CI_TAG=main make pull_ci_images
+      # :main will not exist on the first release after this lands, and a release
+      # must not be blocked on that. Fall back to building exactly as before.
+      - name: Build images
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.pull-main.outcome != 'success'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 180
           max_attempts: 3
           retry_wait_seconds: 60
           command: PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make build
+      - name: Record how the images were obtained
+        if: github.event.inputs.skip-build-push-image != 'true'
+        run: |
+          if [ "${{ steps.pull-main.outcome }}" = "success" ]; then
+            echo "Promoting the tested :main images to ${GRID_VERSION}-${BUILD_DATE}." >> "$GITHUB_STEP_SUMMARY"
+          else
+            echo "No usable :main image; built from source for ${GRID_VERSION}-${BUILD_DATE}." >> "$GITHUB_STEP_SUMMARY"
+          fi
       - name: Login Docker Hub
         run: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
         env:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,73 +138,14 @@ jobs:
         run: |
           make chart_render_template
           echo "PUBLISH_YAML_MANIFESTS=$(find ./tests/tests -name "k8s_*.yaml" | tr '\n' ',')" >> $GITHUB_ENV
-      # Promote rather than rebuild. :main is the last trunk build whose full
-      # test suite passed, so pulling it means the digest released is the digest
-      # tested - a rebuild from the same source is close, but not the same thing.
-      # The build-test job above has already re-run the suite against it.
-      - name: Log in to GHCR
-        if: github.event.inputs.skip-build-push-image != 'true'
-        run: echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
-      # Only reuse :main when it was built from this source and this core. The
-      # hash covers both, so a stale :main - trunk moved on, or the core changed
-      # under us - falls through to a rebuild instead of releasing the wrong bits.
-      - name: Is :main up to date for this release?
-        id: main-current
-        if: github.event.inputs.skip-build-push-image != 'true'
-        run: |
-          set -euo pipefail
-          REGISTRY="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')"
-          PATHS="Base Hub Distributor Router Sessions SessionQueue EventBus NodeBase
-                 NodeChrome NodeChromium NodeEdge NodeFirefox NodeDocker NodeKubernetes
-                 NodeAllBrowsers Standalone StandaloneDocker StandaloneKubernetes Video
-                 .ffmpeg .keda-external-scaler Makefile"
-          SRC_HASH=$(
-            { git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort; echo "core=${BASE_VERSION}"; } \
-              | sha256sum | cut -c1-12
-          )
-          echo "registry=${REGISTRY}" >> "$GITHUB_OUTPUT"
-          echo "src-hash=${SRC_HASH}" >> "$GITHUB_OUTPUT"
-          MAIN=$(docker manifest inspect "${REGISTRY}/base:main" 2>/dev/null | sha256sum | cut -c1-12 || echo none)
-          SRC=$(docker manifest inspect "${REGISTRY}/base:src-${SRC_HASH}" 2>/dev/null | sha256sum | cut -c1-12 || echo missing)
-          if [ "${SRC}" != "missing" ] && [ "${SRC}" = "${MAIN}" ]; then
-            echo "current=true" >> "$GITHUB_OUTPUT"
-            echo ":main matches src-${SRC_HASH} (core ${BASE_VERSION}); promoting it." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "current=false" >> "$GITHUB_OUTPUT"
-            echo ":main does not match src-${SRC_HASH} (core ${BASE_VERSION}); rebuilding." >> "$GITHUB_STEP_SUMMARY"
-          fi
-
-      - name: Pull the tested main images
-        id: pull-main
-        if: github.event.inputs.skip-build-push-image != 'true' && steps.main-current.outputs.current == 'true'
-        continue-on-error: true
-        uses: nick-invision/retry@master
-        with:
-          timeout_minutes: 45
-          max_attempts: 3
-          retry_wait_seconds: 60
-          command: |
-            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
-              CI_REGISTRY="${{ steps.main-current.outputs.registry }}" \
-              CI_TAG=main make pull_ci_images
-      # :main will not exist on the first release after this lands, and a release
-      # must not be blocked on that. Fall back to building exactly as before.
       - name: Build images
-        if: github.event.inputs.skip-build-push-image != 'true' && steps.pull-main.outcome != 'success'
+        if: github.event.inputs.skip-build-push-image != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 180
           max_attempts: 3
           retry_wait_seconds: 60
           command: PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make build
-      - name: Record how the images were obtained
-        if: github.event.inputs.skip-build-push-image != 'true'
-        run: |
-          if [ "${{ steps.pull-main.outcome }}" = "success" ]; then
-            echo "Released ${GRID_VERSION}-${BUILD_DATE} by promoting the tested :main images." >> "$GITHUB_STEP_SUMMARY"
-          else
-            echo "Built ${GRID_VERSION}-${BUILD_DATE} from source; :main was not usable." >> "$GITHUB_STEP_SUMMARY"
-          fi
       - name: Login Docker Hub
         run: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
         env:

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -3,6 +3,21 @@ name: Test Docker Selenium
 on:
   workflow_call:
     inputs:
+      ci-mode:
+        description: 'reuse-main, build-and-push, or build-in-job'
+        required: false
+        type: string
+        default: 'build-in-job'
+      ci-tag:
+        description: 'Registry tag holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
+      ci-registry:
+        description: 'Registry holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
       release:
         description: 'Test a new release process'
         required: false
@@ -229,9 +244,25 @@ jobs:
           echo "AUTHORS=${AUTHORS}" >> $GITHUB_ENV
         env:
           AUTHORS: ${{ vars.AUTHORS || github.repository_owner }}
+      # Built once by build-images.yml. Pull and retag to the local names the
+      # compose files already expect, so the test targets need no changes;
+      # SKIP_BUILD then stops their Make prerequisites rebuilding them.
+      - name: Use prebuilt images
+        if: inputs.ci-mode != 'build-in-job'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
+      - name: Skip in-job builds when images were pulled
+        if: inputs.ci-mode != 'build-in-job'
+        run: echo "SKIP_BUILD=true" >> $GITHUB_ENV
       - name: Build Docker images
         uses: nick-invision/retry@master
-        if: matrix.build-all == true
+        if: inputs.ci-mode == 'build-in-job' && matrix.build-all == true
         with:
           timeout_minutes: 90
           max_attempts: 3

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -255,7 +255,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
             VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
       - name: Skip in-job builds when images were pulled
         if: inputs.ci-mode != 'build-in-job'

--- a/.github/workflows/docker-test.yml
+++ b/.github/workflows/docker-test.yml
@@ -4,7 +4,7 @@ on:
   workflow_call:
     inputs:
       ci-mode:
-        description: 'reuse-main, build-and-push, or build-in-job'
+        description: 'reuse, build-and-push, or build-in-job'
         required: false
         type: string
         default: 'build-in-job'

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -8,6 +8,21 @@ on:
       DOCKER_PASSWORD:
         required: false
     inputs:
+      ci-mode:
+        description: 'reuse-main, build-and-push, or build-in-job'
+        required: false
+        type: string
+        default: 'build-in-job'
+      ci-tag:
+        description: 'Registry tag holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
+      ci-registry:
+        description: 'Registry holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
       release:
         description: 'Test a new release process'
         required: false
@@ -195,7 +210,24 @@ jobs:
           BUILD_DATE=${BUILD_DATE} make chart_build
           echo "CHART_PACKAGE_PATH=$(cat /tmp/selenium_chart_version)" >> $GITHUB_ENV
           echo "CHART_FILE_NAME=$(basename $(cat /tmp/selenium_chart_version))" >> $GITHUB_ENV
+      # Built once by build-images.yml. Pull and retag to the local names the
+      # compose files already expect, so the test targets need no changes;
+      # SKIP_BUILD then stops their Make prerequisites rebuilding them.
+      - name: Use prebuilt images
+        if: inputs.ci-mode != 'build-in-job'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
+      - name: Skip in-job builds when images were pulled
+        if: inputs.ci-mode != 'build-in-job'
+        run: echo "SKIP_BUILD=true" >> $GITHUB_ENV
       - name: Build Docker images
+        if: inputs.ci-mode == 'build-in-job'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 90

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -221,7 +221,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
             VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
       - name: Skip in-job builds when images were pulled
         if: inputs.ci-mode != 'build-in-job'

--- a/.github/workflows/helm-chart-test.yml
+++ b/.github/workflows/helm-chart-test.yml
@@ -9,7 +9,7 @@ on:
         required: false
     inputs:
       ci-mode:
-        description: 'reuse-main, build-and-push, or build-in-job'
+        description: 'reuse, build-and-push, or build-in-job'
         required: false
         type: string
         default: 'build-in-job'

--- a/.github/workflows/k8s-dynamic-grid-test.yml
+++ b/.github/workflows/k8s-dynamic-grid-test.yml
@@ -8,6 +8,21 @@ on:
       DOCKER_PASSWORD:
         required: false
     inputs:
+      ci-mode:
+        description: 'reuse-main, build-and-push, or build-in-job'
+        required: false
+        type: string
+        default: 'build-in-job'
+      ci-tag:
+        description: 'Registry tag holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
+      ci-registry:
+        description: 'Registry holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
       release:
         description: 'Test a new release process'
         required: false
@@ -89,7 +104,24 @@ jobs:
           echo "AUTHORS=${AUTHORS}" >> $GITHUB_ENV
         env:
           AUTHORS: ${{ vars.AUTHORS || github.repository_owner }}
+      # Built once by build-images.yml. Pull and retag to the local names the
+      # compose files already expect, so the test targets need no changes;
+      # SKIP_BUILD then stops their Make prerequisites rebuilding them.
+      - name: Use prebuilt images
+        if: inputs.ci-mode != 'build-in-job'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
+      - name: Skip in-job builds when images were pulled
+        if: inputs.ci-mode != 'build-in-job'
+        run: echo "SKIP_BUILD=true" >> $GITHUB_ENV
       - name: Build Docker images
+        if: inputs.ci-mode == 'build-in-job'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 90

--- a/.github/workflows/k8s-dynamic-grid-test.yml
+++ b/.github/workflows/k8s-dynamic-grid-test.yml
@@ -115,7 +115,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
             VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
       - name: Skip in-job builds when images were pulled
         if: inputs.ci-mode != 'build-in-job'

--- a/.github/workflows/k8s-dynamic-grid-test.yml
+++ b/.github/workflows/k8s-dynamic-grid-test.yml
@@ -9,7 +9,7 @@ on:
         required: false
     inputs:
       ci-mode:
-        description: 'reuse-main, build-and-push, or build-in-job'
+        description: 'reuse, build-and-push, or build-in-job'
         required: false
         type: string
         default: 'build-in-job'

--- a/.github/workflows/k8s-scaling-test.yml
+++ b/.github/workflows/k8s-scaling-test.yml
@@ -8,6 +8,21 @@ on:
       DOCKER_PASSWORD:
         required: false
     inputs:
+      ci-mode:
+        description: 'reuse-main, build-and-push, or build-in-job'
+        required: false
+        type: string
+        default: 'build-in-job'
+      ci-tag:
+        description: 'Registry tag holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
+      ci-registry:
+        description: 'Registry holding the prebuilt images'
+        required: false
+        type: string
+        default: ''
       release:
         description: 'Test a new release process'
         required: false
@@ -197,7 +212,24 @@ jobs:
           timeout_minutes: 10
           max_attempts: 3
           command: CLUSTER=${CLUSTER} SERVICE_MESH=${SERVICE_MESH} KUBERNETES_VERSION=${KUBERNETES_VERSION} NAME=${IMAGE_REGISTRY} VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} make chart_cluster_setup
+      # Built once by build-images.yml. Pull and retag to the local names the
+      # compose files already expect, so the test targets need no changes;
+      # SKIP_BUILD then stops their Make prerequisites rebuilding them.
+      - name: Use prebuilt images
+        if: inputs.ci-mode != 'build-in-job'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 45
+          max_attempts: 3
+          retry_wait_seconds: 30
+          command: |
+            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
+      - name: Skip in-job builds when images were pulled
+        if: inputs.ci-mode != 'build-in-job'
+        run: echo "SKIP_BUILD=true" >> $GITHUB_ENV
       - name: Build Docker images
+        if: inputs.ci-mode == 'build-in-job'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 30

--- a/.github/workflows/k8s-scaling-test.yml
+++ b/.github/workflows/k8s-scaling-test.yml
@@ -223,7 +223,7 @@ jobs:
           max_attempts: 3
           retry_wait_seconds: 30
           command: |
-            echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
+            echo "${{ secrets.SELENIUM_CI_TOKEN || secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME || github.actor }}" --password-stdin
             VERSION=${BRANCH} BUILD_DATE=${BUILD_DATE} CI_REGISTRY="${{ inputs.ci-registry }}" CI_TAG="${{ inputs.ci-tag }}" make pull_ci_images
       - name: Skip in-job builds when images were pulled
         if: inputs.ci-mode != 'build-in-job'

--- a/.github/workflows/k8s-scaling-test.yml
+++ b/.github/workflows/k8s-scaling-test.yml
@@ -9,7 +9,7 @@ on:
         required: false
     inputs:
       ci-mode:
-        description: 'reuse-main, build-and-push, or build-in-job'
+        description: 'reuse, build-and-push, or build-in-job'
         required: false
         type: string
         default: 'build-in-job'

--- a/Makefile
+++ b/Makefile
@@ -39,6 +39,75 @@ TEST_PATCHED_KEDA := $(or $(TEST_PATCHED_KEDA),$(TEST_PATCHED_KEDA),false)
 TRACING_EXPORTER_ENDPOINT := $(or $(TRACING_EXPORTER_ENDPOINT),$(TRACING_EXPORTER_ENDPOINT),http://\$$KUBERNETES_NODE_HOST_IP:4317)
 GHCR_NAMESPACE := $(or $(GHCR_NAMESPACE),$(GHCR_NAMESPACE),ghcr.io/seleniumhq)
 
+# --- CI image reuse -----------------------------------------------------------
+#
+# The PR test suite spans 37 matrix jobs and every one of them used to build the
+# images it needed, because each test target names image targets as prerequisites
+# (`test_video: video hub chrome firefox edge chromium`). Building once and
+# reusing the result is worth ~36 redundant builds per pull request.
+#
+#   SKIP_BUILD=true   every image-build target becomes a no-op, so the test
+#                     targets keep their prerequisites and need no edits. Use it
+#                     only when the images are already present locally.
+#   make push_ci_images / pull_ci_images   move that set through a registry.
+#
+# With SKIP_BUILD unset nothing below changes: `make build`, `make test` and every
+# other local workflow behave exactly as before.
+
+CI_REGISTRY := $(or $(CI_REGISTRY),ghcr.io/seleniumhq)
+CI_TAG := $(or $(CI_TAG),main)
+
+# The images a test run can need. Kept as one list so push and pull cannot drift.
+CI_IMAGES := base hub distributor router sessions session-queue event-bus \
+	node-base node-chrome node-chrome-for-testing node-chromium node-edge node-firefox \
+	node-all-browsers node-docker node-kubernetes \
+	standalone-chrome standalone-chrome-for-testing standalone-chromium standalone-edge \
+	standalone-firefox standalone-all-browsers standalone-docker standalone-kubernetes \
+	video keda-external-scaler
+
+# Image-build targets only. gen_certs, prepare_resources and update_go are
+# deliberately absent: they produce working-tree files the tests read, not images,
+# and must still run when the images come from a registry.
+SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bus \
+	node_base chrome chrome_only chrome-for-testing chrome-for-testing_only chromium \
+	edge edge_only firefox firefox_only all_browsers docker kubernetes \
+	standalone_chrome standalone_chrome_only standalone_chrome-for-testing \
+	standalone_chrome-for-testing_only standalone_chromium standalone_edge \
+	standalone_edge_only standalone_firefox standalone_firefox_only \
+	standalone_all_browsers standalone_docker standalone_kubernetes \
+	video ffmpeg keda_external_scaler
+
+
+# Push what was just built, so the rest of the run can reuse it.
+push_ci_images:
+	@set -e; for image in $(CI_IMAGES); do \
+		echo "push $(CI_REGISTRY)/$$image:$(CI_TAG)"; \
+		docker tag $(NAME)/$$image:$(TAG_VERSION) $(CI_REGISTRY)/$$image:$(CI_TAG); \
+		docker push $(CI_REGISTRY)/$$image:$(CI_TAG); \
+	done
+
+# Pull the prebuilt set and give it the local names the compose files expect.
+# Fails on the first missing image: a clear error here beats a compose failure
+# fifteen minutes into a test job.
+pull_ci_images:
+	@set -e; for image in $(CI_IMAGES); do \
+		echo "pull $(CI_REGISTRY)/$$image:$(CI_TAG)"; \
+		docker pull --quiet $(CI_REGISTRY)/$$image:$(CI_TAG); \
+		docker tag $(CI_REGISTRY)/$$image:$(CI_TAG) $(NAME)/$$image:$(TAG_VERSION); \
+	done
+	@echo "Retagged $(words $(CI_IMAGES)) images to $(NAME)/<image>:$(TAG_VERSION)"
+
+# Promote a tested tag to another tag without rebuilding, so the digest released
+# is the digest tested. Used by deploy.yml to turn :main into the release tag.
+promote_ci_images:
+	@set -e; \
+	if [ -z "$(PROMOTE_TO)" ]; then echo "PROMOTE_TO is required"; exit 1; fi; \
+	for image in $(CI_IMAGES); do \
+		echo "promote $$image: $(CI_TAG) -> $(PROMOTE_TO)"; \
+		docker buildx imagetools create \
+			-t $(CI_REGISTRY)/$$image:$(PROMOTE_TO) $(CI_REGISTRY)/$$image:$(CI_TAG); \
+	done
+
 all: hub \
 	distributor \
 	router \
@@ -1572,3 +1641,13 @@ test_k8s_dynamic_grid_hub_node:
 	tag_and_push_browser_images \
 	test \
 	video
+
+# Placed last on purpose: GNU Make lets the last definition of a target win, so
+# these no-ops must come after the real build recipes above. Defining them at all
+# only happens when SKIP_BUILD=true, so an ordinary `make build` never sees them
+# and never prints an override warning.
+ifeq ($(strip $(SKIP_BUILD)),true)
+$(SKIP_BUILD_TARGETS):
+	@echo "SKIP_BUILD=true: using the prebuilt image for '$@'"
+endif
+

--- a/Makefile
+++ b/Makefile
@@ -78,12 +78,23 @@ SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bu
 	video ffmpeg keda_external_scaler
 
 # Push what was just built, so the rest of the run can reuse it.
+# Skips images this build did not produce. On an arm64 runner that is Edge and
+# Chrome for Testing, which are amd64-only; without the check the loop would fail
+# tagging an image that was correctly never built.
 push_ci_images:
-	@set -e; for image in $(CI_IMAGES); do \
+	@set -e; pushed=0; skipped=""; \
+	for image in $(CI_IMAGES); do \
+		if ! docker image inspect $(NAME)/$$image:$(TAG_VERSION) >/dev/null 2>&1; then \
+			skipped="$$skipped $$image"; continue; \
+		fi; \
 		echo "push $(CI_REGISTRY)/$$image:$(CI_TAG)"; \
 		docker tag $(NAME)/$$image:$(TAG_VERSION) $(CI_REGISTRY)/$$image:$(CI_TAG); \
-		docker push $(CI_REGISTRY)/$$image:$(CI_TAG); \
-	done
+		docker push --quiet $(CI_REGISTRY)/$$image:$(CI_TAG); \
+		pushed=$$((pushed+1)); \
+	done; \
+	echo "pushed $$pushed image(s) as $(CI_TAG)"; \
+	if [ -n "$$skipped" ]; then echo "not built here, skipped:$$skipped"; fi; \
+		if [ "$$pushed" -eq 0 ]; then echo "nothing was pushed" >&2; exit 1; fi
 
 # Pull the prebuilt set and give it the local names the compose files expect.
 # Fails on the first missing image: a clear error here beats a compose failure
@@ -95,6 +106,26 @@ pull_ci_images:
 		docker tag $(CI_REGISTRY)/$$image:$(CI_TAG) $(NAME)/$$image:$(TAG_VERSION); \
 	done
 	@echo "Retagged $(words $(CI_IMAGES)) images to $(NAME)/<image>:$(TAG_VERSION)"
+
+# Merge the per-architecture tags pushed by native runners into one manifest
+# list. Building multi-arch on a single runner means QEMU-emulating arm64, which
+# took over an hour; two native runners in parallel cost about one amd64 build.
+#
+# Edge and Chrome for Testing are amd64-only - the Makefile skips them when
+# PLATFORMS has no linux/amd64 - so their arm64 tag never exists and the list is
+# built from amd64 alone rather than failing.
+merge_ci_images:
+	@set -e; for image in $(CI_IMAGES); do \
+		refs="" ; \
+		for arch in amd64 arm64; do \
+			if docker manifest inspect $(CI_REGISTRY)/$$image:$(CI_TAG)-$$arch >/dev/null 2>&1; then \
+				refs="$$refs $(CI_REGISTRY)/$$image:$(CI_TAG)-$$arch" ; \
+			fi ; \
+		done ; \
+		if [ -z "$$refs" ]; then echo "no architecture tags for $$image:$(CI_TAG)" ; exit 1 ; fi ; \
+			echo "merge $$image:$(CI_TAG) <-$$refs" ; \
+			docker buildx imagetools create -t $(CI_REGISTRY)/$$image:$(CI_TAG) $$refs ; \
+		done
 
 # Promote a tested tag to another tag without rebuilding, so the digest released
 # is the digest tested. Used to turn trunk-<sha> into :main, and :main into a

--- a/Makefile
+++ b/Makefile
@@ -107,19 +107,38 @@ push_ci_images:
 		if [ "$$pushed" -eq 0 ]; then echo "nothing was pushed" >&2; exit 1; fi
 
 # Pull the prebuilt set and give it the local names the compose files expect.
-# Fails on the first missing image: a clear error here beats a compose failure
-# fifteen minutes into a test job.
+#
+# Edge and Chrome for Testing are amd64-only, so on arm64 their manifest list has
+# no matching entry and `docker pull` fails with "no matching manifest for
+# linux/arm64/v8". Skip those deliberately, by inspecting the manifest first -
+# and only those. An image missing from the registry entirely is still a hard
+# error, because that means the build or the merge went wrong, and a clear
+# failure here beats a compose failure fifteen minutes into a test job.
 pull_ci_images:
-	@set -e; for image in $(CI_IMAGES); do \
+	@set -e; arch=$$(docker version --format '{{.Server.Arch}}'); \
+	echo "pulling for linux/$$arch"; \
+	pulled=0; other_arch=""; \
+	for image in $(CI_IMAGES); do \
 		case "$$image" in \
 			video)  local_tag="$(FFMPEG_TAG_VERSION)-$(BUILD_DATE)" ;; \
 			ffmpeg) local_tag="$(FFMPEG_VERSION)-$(BUILD_DATE)" ;; \
 			*)      local_tag="$(TAG_VERSION)" ;; \
 		esac; \
-		echo "pull $(CI_REGISTRY)/$$image:$(CI_TAG) -> $(NAME)/$$image:$$local_tag"; \
-		docker pull --quiet $(CI_REGISTRY)/$$image:$(CI_TAG); \
-		docker tag $(CI_REGISTRY)/$$image:$(CI_TAG) $(NAME)/$$image:$$local_tag; \
-	done
+		ref="$(CI_REGISTRY)/$$image:$(CI_TAG)"; \
+		if ! manifest=$$(docker manifest inspect $$ref 2>/dev/null); then \
+			echo "$$ref is not in the registry" >&2; exit 1; \
+		fi; \
+		if ! echo "$$manifest" | tr -d ' ' | grep -q "\"architecture\":\"$$arch\""; then \
+			other_arch="$$other_arch $$image"; continue; \
+		fi; \
+		echo "pull $$ref -> $(NAME)/$$image:$$local_tag"; \
+		docker pull --quiet --platform linux/$$arch $$ref; \
+		docker tag $$ref $(NAME)/$$image:$$local_tag; \
+		pulled=$$((pulled+1)); \
+	done; \
+	echo "pulled $$pulled image(s) for linux/$$arch"; \
+	if [ -n "$$other_arch" ]; then echo "not built for linux/$$arch:$$other_arch"; fi; \
+		if [ "$$pulled" -eq 0 ]; then echo "nothing was pulled" >&2; exit 1; fi
 	@echo "Retagged $(words $(CI_IMAGES)) images to $(NAME)/<image>:$(TAG_VERSION)"
 
 # Merge the per-architecture tags pushed by native runners into one manifest

--- a/Makefile
+++ b/Makefile
@@ -78,17 +78,27 @@ SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bu
 	video ffmpeg keda_external_scaler
 
 # Push what was just built, so the rest of the run can reuse it.
+# video does not carry the grid tag: it is built as
+# $(NAME)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE), and the compose files read it
+# from VIDEO_TAG. Assuming $(TAG_VERSION) for every image meant video was never
+# found locally, silently skipped on push, and then missing at merge.
+#
 # Skips images this build did not produce. On an arm64 runner that is Edge and
 # Chrome for Testing, which are amd64-only; without the check the loop would fail
 # tagging an image that was correctly never built.
 push_ci_images:
 	@set -e; pushed=0; skipped=""; \
 	for image in $(CI_IMAGES); do \
-		if ! docker image inspect $(NAME)/$$image:$(TAG_VERSION) >/dev/null 2>&1; then \
+		case "$$image" in \
+			video)  local_tag="$(FFMPEG_TAG_VERSION)-$(BUILD_DATE)" ;; \
+			ffmpeg) local_tag="$(FFMPEG_VERSION)-$(BUILD_DATE)" ;; \
+			*)      local_tag="$(TAG_VERSION)" ;; \
+		esac; \
+		if ! docker image inspect $(NAME)/$$image:$$local_tag >/dev/null 2>&1; then \
 			skipped="$$skipped $$image"; continue; \
 		fi; \
 		echo "push $(CI_REGISTRY)/$$image:$(CI_TAG)"; \
-		docker tag $(NAME)/$$image:$(TAG_VERSION) $(CI_REGISTRY)/$$image:$(CI_TAG); \
+		docker tag $(NAME)/$$image:$$local_tag $(CI_REGISTRY)/$$image:$(CI_TAG); \
 		docker push --quiet $(CI_REGISTRY)/$$image:$(CI_TAG); \
 		pushed=$$((pushed+1)); \
 	done; \
@@ -101,9 +111,14 @@ push_ci_images:
 # fifteen minutes into a test job.
 pull_ci_images:
 	@set -e; for image in $(CI_IMAGES); do \
-		echo "pull $(CI_REGISTRY)/$$image:$(CI_TAG)"; \
+		case "$$image" in \
+			video)  local_tag="$(FFMPEG_TAG_VERSION)-$(BUILD_DATE)" ;; \
+			ffmpeg) local_tag="$(FFMPEG_VERSION)-$(BUILD_DATE)" ;; \
+			*)      local_tag="$(TAG_VERSION)" ;; \
+		esac; \
+		echo "pull $(CI_REGISTRY)/$$image:$(CI_TAG) -> $(NAME)/$$image:$$local_tag"; \
 		docker pull --quiet $(CI_REGISTRY)/$$image:$(CI_TAG); \
-		docker tag $(CI_REGISTRY)/$$image:$(CI_TAG) $(NAME)/$$image:$(TAG_VERSION); \
+		docker tag $(CI_REGISTRY)/$$image:$(CI_TAG) $(NAME)/$$image:$$local_tag; \
 	done
 	@echo "Retagged $(words $(CI_IMAGES)) images to $(NAME)/<image>:$(TAG_VERSION)"
 

--- a/Makefile
+++ b/Makefile
@@ -77,7 +77,6 @@ SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bu
 	standalone_all_browsers standalone_docker standalone_kubernetes \
 	video ffmpeg keda_external_scaler
 
-
 # Push what was just built, so the rest of the run can reuse it.
 push_ci_images:
 	@set -e; for image in $(CI_IMAGES); do \
@@ -98,14 +97,13 @@ pull_ci_images:
 	@echo "Retagged $(words $(CI_IMAGES)) images to $(NAME)/<image>:$(TAG_VERSION)"
 
 # Promote a tested tag to another tag without rebuilding, so the digest released
-# is the digest tested. Used by deploy.yml to turn :main into the release tag.
+# is the digest tested. Used to turn trunk-<sha> into :main, and :main into a
+# release tag.
 promote_ci_images:
-	@set -e; \
-	if [ -z "$(PROMOTE_TO)" ]; then echo "PROMOTE_TO is required"; exit 1; fi; \
-	for image in $(CI_IMAGES); do \
-		echo "promote $$image: $(CI_TAG) -> $(PROMOTE_TO)"; \
-		docker buildx imagetools create \
-			-t $(CI_REGISTRY)/$$image:$(PROMOTE_TO) $(CI_REGISTRY)/$$image:$(CI_TAG); \
+	@test -n "$(PROMOTE_TO)" || (echo "PROMOTE_TO is required" && exit 1)
+	@for image in $(CI_IMAGES); do \
+		echo "promote $$image: $(CI_TAG) -> $(PROMOTE_TO)" ; \
+		docker buildx imagetools create -t $(CI_REGISTRY)/$$image:$(PROMOTE_TO) $(CI_REGISTRY)/$$image:$(CI_TAG) || exit 1 ; \
 	done
 
 all: hub \
@@ -1650,4 +1648,3 @@ ifeq ($(strip $(SKIP_BUILD)),true)
 $(SKIP_BUILD_TARGETS):
 	@echo "SKIP_BUILD=true: using the prebuilt image for '$@'"
 endif
-

--- a/Makefile
+++ b/Makefile
@@ -65,9 +65,18 @@ CI_IMAGES := base hub distributor router sessions session-queue event-bus \
 	standalone-firefox standalone-all-browsers standalone-docker standalone-kubernetes \
 	video keda-external-scaler
 
-# Image-build targets only. gen_certs, prepare_resources and update_go are
+# Image-build targets, plus update_go. gen_certs and prepare_resources are
 # deliberately absent: they produce working-tree files the tests read, not images,
 # and must still run when the images come from a registry.
+#
+# update_go is here because it is a prerequisite of `base`, so it ran in every
+# test job on the reuse path - a `docker pull golang:latest` plus `go get -u` and
+# `go mod tidy` for two modules, over the network, in each of ~37 jobs. Nothing
+# read at test time comes out of it: it edits go.mod/go.sum and rewrites the
+# golang base image in .keda-external-scaler/, Hub/ and Router/ Dockerfiles, all
+# of which matter only to a build. Leaving it in cost minutes per job, added a
+# live-network flake to each one, and mutated hashed sources after the tag had
+# already been decided.
 SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bus \
 	node_base chrome chrome_only chrome-for-testing chrome-for-testing_only chromium \
 	edge edge_only firefox firefox_only all_browsers docker kubernetes \
@@ -75,7 +84,7 @@ SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bu
 	standalone_chrome-for-testing_only standalone_chromium standalone_edge \
 	standalone_edge_only standalone_firefox standalone_firefox_only \
 	standalone_all_browsers standalone_docker standalone_kubernetes \
-	video ffmpeg keda_external_scaler
+	video ffmpeg keda_external_scaler update_go
 
 # Push what was just built, so the rest of the run can reuse it.
 # video does not carry the grid tag: it is built as
@@ -139,7 +148,6 @@ pull_ci_images:
 	echo "pulled $$pulled image(s) for linux/$$arch"; \
 	if [ -n "$$other_arch" ]; then echo "not built for linux/$$arch:$$other_arch"; fi; \
 		if [ "$$pulled" -eq 0 ]; then echo "nothing was pulled" >&2; exit 1; fi
-	@echo "Retagged $(words $(CI_IMAGES)) images to $(NAME)/<image>:$(TAG_VERSION)"
 
 # Merge the per-architecture tags pushed by native runners into one manifest
 # list. Building multi-arch on a single runner means QEMU-emulating arm64, which

--- a/Makefile
+++ b/Makefile
@@ -161,9 +161,16 @@ merge_ci_images:
 			docker buildx imagetools create -t $(CI_REGISTRY)/$$image:$(CI_TAG) $$refs ; \
 		done
 
-# Promote a tested tag to another tag without rebuilding, so the digest released
-# is the digest tested. Used to turn trunk-<sha> into :main, and :main into a
-# release tag.
+# The marker decide reuses on. Written only once merge_ci_images has finished
+# every image, so "base:<tag> exists" can never be mistaken for "the whole set
+# exists". It is a second tag on the manifest base:<tag> already is - no extra
+# storage, and nothing for the cleanup to leak.
+mark_ci_images_complete:
+	docker buildx imagetools create -t $(CI_REGISTRY)/base:$(CI_TAG)-complete $(CI_REGISTRY)/base:$(CI_TAG)
+
+# Point another tag at an already-tested manifest, without rebuilding. Used for
+# the pr-<N> markers the cleanup keys on, and to retag a passing trunk set as
+# :main.
 promote_ci_images:
 	@test -n "$(PROMOTE_TO)" || (echo "PROMOTE_TO is required" && exit 1)
 	@for image in $(CI_IMAGES); do \

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -1,0 +1,157 @@
+#!/usr/bin/env python3
+"""Delete the GHCR image tags a pull request left behind.
+
+build-images.yml publishes one image set per pull request, tagged ``pr-<number>``.
+That is 27 images per pull request, useless the moment it closes, and nothing
+else removes them.
+
+Two modes:
+
+* ``--pr N`` deletes the tags for one pull request, run when it closes.
+* no ``--pr`` sweeps every ``pr-*`` tag whose pull request is closed, run weekly
+  to catch anything the close event missed - a failed run, or a pull request that
+  closed before this existed.
+
+Only ever deletes tags matching ``pr-<digits>``. A version tag, ``main``, or
+anything else is not something this touches, whatever the API returns.
+"""
+
+import argparse
+import json
+import os
+import re
+import sys
+import urllib.error
+import urllib.parse
+import urllib.request
+
+API = "https://api.github.com"
+PR_TAG = re.compile(r"\Apr-(\d+)\Z")
+
+# Kept in step with CI_IMAGES in the Makefile.
+IMAGES = [
+    "base", "hub", "distributor", "router", "sessions", "session-queue", "event-bus",
+    "node-base", "node-chrome", "node-chrome-for-testing", "node-chromium", "node-edge",
+    "node-firefox", "node-all-browsers", "node-docker", "node-kubernetes",
+    "standalone-chrome", "standalone-chrome-for-testing", "standalone-chromium",
+    "standalone-edge", "standalone-firefox", "standalone-all-browsers",
+    "standalone-docker", "standalone-kubernetes", "video", "keda-external-scaler",
+]
+
+
+def _request(url, token, method="GET"):
+    request = urllib.request.Request(
+        url,
+        headers={
+            "Authorization": f"Bearer {token}",
+            "Accept": "application/vnd.github+json",
+            "X-GitHub-Api-Version": "2022-11-28",
+        },
+        method=method,
+    )
+    with urllib.request.urlopen(request, timeout=60) as response:
+        body = response.read().decode()
+    return json.loads(body) if body else None
+
+
+def versions(owner, image, token):
+    """Every published version of one package, with its tags."""
+    out, page = [], 1
+    while True:
+        url = (
+            f"{API}/orgs/{owner}/packages/container/{urllib.parse.quote(image, safe='')}"
+            f"/versions?per_page=100&page={page}"
+        )
+        try:
+            batch = _request(url, token)
+        except urllib.error.HTTPError as error:
+            if error.code == 404:
+                return []  # package does not exist; nothing to clean
+            raise
+        if not batch:
+            return out
+        out += batch
+        page += 1
+
+
+def pr_is_open(owner, repo, number, token):
+    try:
+        return _request(f"{API}/repos/{owner}/{repo}/pulls/{number}", token)["state"] == "open"
+    except urllib.error.HTTPError as error:
+        if error.code == 404:
+            return False
+        raise
+
+
+def main(argv=None):
+    parser = argparse.ArgumentParser(description="Delete pr-* image tags from GHCR.")
+    parser.add_argument("--owner", required=True)
+    parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "").split("/")[-1] or "docker-selenium")
+    parser.add_argument("--pr", type=int, default=None, help="Only this pull request.")
+    parser.add_argument("--dry-run", action="store_true")
+    args = parser.parse_args(argv)
+
+    token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
+    if not token:
+        print("GH_TOKEN is required.", file=sys.stderr)
+        return 2
+
+    deleted, kept, failed = 0, 0, []
+    open_cache = {}
+
+    print("## Pull request image cleanup\n")
+    for image in IMAGES:
+        try:
+            for version in versions(args.owner, image, token):
+                tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+                targets = [t for t in tags if PR_TAG.match(t)]
+                if not targets:
+                    continue
+                number = int(PR_TAG.match(targets[0]).group(1))
+
+                if args.pr is not None and number != args.pr:
+                    continue
+                if args.pr is None:
+                    if number not in open_cache:
+                        open_cache[number] = pr_is_open(args.owner, args.repo, number, token)
+                    if open_cache[number]:
+                        kept += 1
+                        continue
+
+                # A version can carry several tags; only delete when every tag on
+                # it is a pr-* tag, so a shared manifest is never removed.
+                if set(tags) != set(targets):
+                    kept += 1
+                    continue
+
+                if args.dry_run:
+                    print(f"- would delete `{image}:{','.join(targets)}`")
+                    deleted += 1
+                    continue
+                try:
+                    _request(
+                        f"{API}/orgs/{args.owner}/packages/container/"
+                        f"{urllib.parse.quote(image, safe='')}/versions/{version['id']}",
+                        token,
+                        method="DELETE",
+                    )
+                    deleted += 1
+                except urllib.error.HTTPError as error:
+                    failed.append(f"{image}:{','.join(targets)} ({error.code})")
+        except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
+            failed.append(f"{image} ({error})")
+
+    scope = f"PR #{args.pr}" if args.pr is not None else "all closed pull requests"
+    print(f"Scope: {scope}\n")
+    print(f"- Deleted: **{deleted}**")
+    if kept:
+        print(f"- Kept (pull request still open, or tag shared): {kept}")
+    if failed:
+        print(f"- Failed: {len(failed)}")
+        for item in failed[:20]:
+            print(f"  - {item}")
+    return 1 if failed else 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -12,8 +12,19 @@ Two modes:
   to catch anything the close event missed - a failed run, or a pull request that
   closed before this existed.
 
-Only ever deletes tags matching ``pr-<digits>``. A version tag, ``main``, or
-anything else is not something this touches, whatever the API returns.
+GHCR deletes *versions* - manifests - not individual tags, and one manifest
+carries both its ``src-<hash>`` tag and the ``pr-<N>`` alias for the pull request
+that built it. So ``pr-<N>`` cannot be removed while keeping ``src-<hash>``: they
+are the same object. The alias is therefore used as the handle for finding what a
+closed pull request left behind, and a version is removed only when every one of
+these holds:
+
+* it carries a ``pr-<N>`` tag whose pull request is closed
+* it carries no ``pr-<M>`` tag for a pull request that is still open, since two
+  pull requests with identical image content share one manifest
+* it is not the manifest ``main`` points at, which is the release promotion source
+* every tag on it is ``pr-*`` or ``src-*``, so a release tag, ``latest`` or
+  ``nightly`` can never be caught by this even if the API returns one
 """
 
 import argparse
@@ -27,6 +38,8 @@ import urllib.request
 
 API = "https://api.github.com"
 PR_TAG = re.compile(r"\Apr-(\d+)\Z")
+SRC_TAG = re.compile(r"\Asrc-[0-9a-f]{6,}\Z")
+MAIN_TAG = "main"
 
 # Kept in step with CI_IMAGES in the Makefile.
 IMAGES = [
@@ -98,34 +111,53 @@ def main(argv=None):
 
     deleted, kept, failed = 0, 0, []
     open_cache = {}
+    protected = 0
 
     print("## Pull request image cleanup\n")
     for image in IMAGES:
         try:
-            for version in versions(args.owner, image, token):
-                tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
-                targets = [t for t in tags if PR_TAG.match(t)]
-                if not targets:
-                    continue
-                number = int(PR_TAG.match(targets[0]).group(1))
+            all_versions = versions(args.owner, image, token)
+            # Whatever main points at is the promotion source for a release and is
+            # never removed, however old the pull request that first built it.
+            main_ids = {
+                v["id"]
+                for v in all_versions
+                if MAIN_TAG in (v.get("metadata", {}).get("container", {}).get("tags", []) or [])
+            }
 
-                if args.pr is not None and number != args.pr:
+            for version in all_versions:
+                tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+                pr_tags = [t for t in tags if PR_TAG.match(t)]
+                if not pr_tags:
                     continue
-                if args.pr is None:
+
+                numbers = sorted(int(PR_TAG.match(t).group(1)) for t in pr_tags)
+                if args.pr is not None and args.pr not in numbers:
+                    continue
+
+                # Never touch anything carrying a tag outside the two CI families.
+                if any(not (PR_TAG.match(t) or SRC_TAG.match(t)) for t in tags):
+                    protected += 1
+                    continue
+
+                if version["id"] in main_ids:
+                    protected += 1
+                    continue
+
+                # Identical image content is one manifest, so a second pull request
+                # can be sharing it. Keep it while any of them is still open.
+                still_open = False
+                for number in numbers:
                     if number not in open_cache:
                         open_cache[number] = pr_is_open(args.owner, args.repo, number, token)
                     if open_cache[number]:
-                        kept += 1
-                        continue
-
-                # A version can carry several tags; only delete when every tag on
-                # it is a pr-* tag, so a shared manifest is never removed.
-                if set(tags) != set(targets):
+                        still_open = True
+                if still_open:
                     kept += 1
                     continue
 
                 if args.dry_run:
-                    print(f"- would delete `{image}:{','.join(targets)}`")
+                    print(f"- would delete `{image}:{','.join(sorted(tags))}`")
                     deleted += 1
                     continue
                 try:
@@ -137,7 +169,7 @@ def main(argv=None):
                     )
                     deleted += 1
                 except urllib.error.HTTPError as error:
-                    failed.append(f"{image}:{','.join(targets)} ({error.code})")
+                    failed.append(f"{image}:{','.join(sorted(tags))} ({error.code})")
         except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
             failed.append(f"{image} ({error})")
 
@@ -145,7 +177,9 @@ def main(argv=None):
     print(f"Scope: {scope}\n")
     print(f"- Deleted: **{deleted}**")
     if kept:
-        print(f"- Kept (pull request still open, or tag shared): {kept}")
+        print(f"- Kept (a sharing pull request is still open): {kept}")
+    if protected:
+        print(f"- Protected (points at `main`, or carries a non-CI tag): {protected}")
     if failed:
         print(f"- Failed: {len(failed)}")
         for item in failed[:20]:

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -38,7 +38,10 @@ import urllib.request
 from datetime import datetime, timedelta, timezone
 
 API = "https://api.github.com"
-PR_TAG = re.compile(r"\Apr-(\d+)\Z")
+# pr-<N> moves to a pull request's newest build; pr-<N>-<hash> is written once
+# per build and never moves, so every manifest a pull request used stays
+# attributable to it after the branch is gone.
+PR_TAG = re.compile(r"\Apr-(\d+)(?:-[0-9a-f]{6,})?\Z")
 SRC_TAG = re.compile(r"\Asrc-[0-9a-f]{6,}\Z")
 MAIN_TAG = "main"
 

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -7,10 +7,13 @@ else removes them.
 
 Two modes:
 
-* ``--pr N`` deletes the tags for one pull request, run when it closes.
-* no ``--pr`` sweeps every ``pr-*`` tag whose pull request is closed, run weekly
-  to catch anything the close event missed - a failed run, or a pull request that
-  closed before this existed.
+* ``--pr N`` deletes the tags for one pull request, run when it closes without
+  being merged.
+* no ``--pr`` sweeps every ``pr-*`` tag whose pull request is closed, run weekly.
+  This is what collects merged pull requests, which the close event deliberately
+  leaves alone so the trunk run started by the merge can still reuse them, and
+  anything the close event missed - a failed run, or a pull request that closed
+  before this existed.
 
 GHCR deletes *versions* - manifests - not individual tags, and one manifest
 carries both its ``src-<hash>`` tag and the ``pr-<N>`` alias for the pull request

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -42,7 +42,11 @@ API = "https://api.github.com"
 # per build and never moves, so every manifest a pull request used stays
 # attributable to it after the branch is gone.
 PR_TAG = re.compile(r"\Apr-(\d+)(?:-[0-9a-f]{6,})?\Z")
-SRC_TAG = re.compile(r"\Asrc-[0-9a-f]{6,}\Z")
+# src-<hash> plus the -complete marker build-images writes on base once the
+# whole set has merged. The marker is another tag on the src-<hash> manifest,
+# so without it here every base manifest counts as carrying a tag outside the
+# CI families and is protected from cleanup for ever.
+SRC_TAG = re.compile(r"\Asrc-[0-9a-f]{6,}(?:-complete)?\Z")
 MAIN_TAG = "main"
 
 # Kept in step with CI_IMAGES in the Makefile.

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -35,6 +35,7 @@ import sys
 import urllib.error
 import urllib.parse
 import urllib.request
+from datetime import datetime, timedelta, timezone
 
 API = "https://api.github.com"
 PR_TAG = re.compile(r"\Apr-(\d+)\Z")
@@ -145,6 +146,45 @@ def prune_superseded(owner, image, token, dry_run=False):
     return removed, problems
 
 
+def prune_orphans(owner, image, token, older_than_days, dry_run=False):
+    """Remove src-* manifests that no pull request and no branch still points at.
+
+    A pull request retags pr-<N> onto each new build, and a tag names one
+    manifest, so a pull request with several image-affecting commits leaves its
+    earlier manifests carrying only src-*. Nothing else refers to them: the
+    closed-pull-request sweep needs a pr-* tag it does not have, and the
+    superseded sweep only compares against :main.
+
+    An unaliased src-* is provably unused, because every manifest an open pull
+    request depends on is aliased - including one it merely reused. The age guard
+    only covers the minutes between a push and its alias landing.
+    """
+    cutoff = (datetime.now(timezone.utc) - timedelta(days=older_than_days)).isoformat()
+    removed, problems = 0, []
+    for version in versions(owner, image, token):
+        tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+        if not tags or any(not SRC_TAG.match(t) for t in tags):
+            continue
+        created = version.get("created_at") or ""
+        if not created or created >= cutoff:
+            continue
+        if dry_run:
+            print(f"- would delete `{image}:{','.join(sorted(tags))}` ({created[:10]})")
+            removed += 1
+            continue
+        try:
+            _request(
+                f"{API}/orgs/{owner}/packages/container/"
+                f"{urllib.parse.quote(image, safe='')}/versions/{version['id']}",
+                token,
+                method="DELETE",
+            )
+            removed += 1
+        except urllib.error.HTTPError as error:
+            problems.append(f"{image}:{','.join(sorted(tags))} ({error.code})")
+    return removed, problems
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Delete pr-* image tags from GHCR.")
     parser.add_argument("--owner", required=True)
@@ -155,6 +195,13 @@ def main(argv=None):
         "--no-pr-sweep",
         action="store_true",
         help="Skip the closed-pull-request sweep. Used on trunk, where only --prune-superseded applies.",
+    )
+    parser.add_argument(
+        "--prune-orphans",
+        type=int,
+        metavar="DAYS",
+        default=None,
+        help="Also remove src-* manifests with no pr-* alias older than DAYS.",
     )
     parser.add_argument(
         "--prune-superseded",
@@ -243,6 +290,18 @@ def main(argv=None):
             except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
                 failed.append(f"{image} ({error})")
         print(f"- Superseded manifests deleted: **{pruned}**")
+
+    if args.prune_orphans is not None:
+        print(f"\n### Orphaned images older than {args.prune_orphans} days\n")
+        orphans = 0
+        for image in IMAGES:
+            try:
+                removed, problems = prune_orphans(args.owner, image, token, args.prune_orphans, args.dry_run)
+                orphans += removed
+                failed.extend(problems)
+            except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
+                failed.append(f"{image} ({error})")
+        print(f"- Orphaned manifests deleted: **{orphans}**")
 
     scope = "none" if args.no_pr_sweep else (f"PR #{args.pr}" if args.pr is not None else "all closed pull requests")
     print(f"Scope: {scope}\n")

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -25,9 +25,14 @@ these holds:
 * it carries a ``pr-<N>`` tag whose pull request is closed
 * it carries no ``pr-<M>`` tag for a pull request that is still open, since two
   pull requests with identical image content share one manifest
-* it is not the manifest ``main`` points at, which is the release promotion source
-* every tag on it is ``pr-*`` or ``src-*``, so a release tag, ``latest`` or
-  ``nightly`` can never be caught by this even if the API returns one
+* it is not the manifest ``main`` points at
+* every tag on it is one of ours, so a release tag, ``latest`` or ``nightly`` can
+  never be caught by this even if the API returns one
+
+Each removal takes the whole hash family: the index and the per-architecture
+manifests it points at. Those children carry only ``src-<hash>-<arch>`` tags, so
+no sweep judges them on their own - and they cannot be, since deleting a child
+would break an index that may still be in use.
 """
 
 import argparse
@@ -44,12 +49,17 @@ API = "https://api.github.com"
 # pr-<N> moves to a pull request's newest build; pr-<N>-<hash> is written once
 # per build and never moves, so every manifest a pull request used stays
 # attributable to it after the branch is gone.
-PR_TAG = re.compile(r"\Apr-(\d+)(?:-[0-9a-f]{6,})?\Z")
+PR_TAG = re.compile(r"\Apr-(\d+)(?:-([0-9a-f]{6,}))?\Z")
 # src-<hash> plus the -complete marker build-images writes on base once the
 # whole set has merged. The marker is another tag on the src-<hash> manifest,
 # so without it here every base manifest counts as carrying a tag outside the
 # CI families and is protected from cleanup for ever.
-SRC_TAG = re.compile(r"\Asrc-[0-9a-f]{6,}(?:-complete)?\Z")
+SRC_TAG = re.compile(r"\Asrc-([0-9a-f]{6,})(?:-complete)?\Z")
+# The per-architecture manifests the native build jobs push, which merge_ci_images
+# then indexes. They are the children of src-<hash>, not copies of it: deleting one
+# on its own breaks an index that may still be in use, so they are never judged
+# separately - only deleted alongside the index that references them.
+ARCH_TAG = re.compile(r"\Asrc-([0-9a-f]{6,})-(?:amd64|arm64)\Z")
 MAIN_TAG = "main"
 
 # Kept in step with CI_IMAGES in the Makefile.
@@ -61,6 +71,41 @@ IMAGES = [
     "standalone-edge", "standalone-firefox", "standalone-all-browsers",
     "standalone-docker", "standalone-kubernetes", "video", "keda-external-scaler",
 ]
+
+
+def tag_hash(tag):
+    """The content hash a CI tag belongs to, or None if it is not one of ours."""
+    for pattern in (SRC_TAG, ARCH_TAG):
+        match = pattern.match(tag)
+        if match:
+            return match.group(1)
+    match = PR_TAG.match(tag)
+    return match.group(2) if match else None
+
+
+def is_ci_tag(tag):
+    return bool(PR_TAG.match(tag) or SRC_TAG.match(tag) or ARCH_TAG.match(tag))
+
+
+def tags_of(version):
+    return version.get("metadata", {}).get("container", {}).get("tags", []) or []
+
+
+def is_arch_child(version):
+    """A version carrying nothing but per-architecture tags."""
+    tags = tags_of(version)
+    return bool(tags) and all(ARCH_TAG.match(tag) for tag in tags)
+
+
+def arch_children(all_versions):
+    """hash -> the per-architecture manifests the index for that hash points at."""
+    children = {}
+    for version in all_versions:
+        if not is_arch_child(version):
+            continue
+        for digest in {ARCH_TAG.match(tag).group(1) for tag in tags_of(version)}:
+            children.setdefault(digest, []).append(version)
+    return children
 
 
 def _request(url, token, method="GET"):
@@ -76,6 +121,45 @@ def _request(url, token, method="GET"):
     with urllib.request.urlopen(request, timeout=60) as response:
         body = response.read().decode()
     return json.loads(body) if body else None
+
+
+def delete_family(owner, image, version, children, token, dry_run=False):
+    """Delete an index manifest together with the per-architecture children it indexes.
+
+    The children carry only src-<hash>-<arch> tags, so no sweep judges them: on
+    their own they are invisible, and half of every image's CI tags were piling
+    up unreachable. They are also not independent - the index points at them by
+    digest - so the only safe time to remove one is when its index goes too.
+
+    The index is deleted first. If the run dies between the two, what is left is
+    an unreferenced child a later sweep can still collect, rather than an index
+    pointing at a manifest that no longer exists.
+    """
+    targets, seen = [version], {version["id"]}
+    for digest in {tag_hash(tag) for tag in tags_of(version)} - {None}:
+        for child in children.get(digest, []):
+            if child["id"] not in seen:
+                seen.add(child["id"])
+                targets.append(child)
+
+    removed, problems = 0, []
+    for target in targets:
+        label = f"{image}:{','.join(sorted(tags_of(target)))}"
+        if dry_run:
+            print(f"- would delete `{label}`")
+            removed += 1
+            continue
+        try:
+            _request(
+                f"{API}/orgs/{owner}/packages/container/"
+                f"{urllib.parse.quote(image, safe='')}/versions/{target['id']}",
+                token,
+                method="DELETE",
+            )
+            removed += 1
+        except urllib.error.HTTPError as error:
+            problems.append(f"{label} ({error.code})")
+    return removed, problems
 
 
 def versions(owner, image, token):
@@ -120,8 +204,9 @@ def prune_superseded(owner, image, token, dry_run=False):
     current main might be mid-promotion in another run, and is left alone.
     """
     all_versions = versions(owner, image, token)
+    children = arch_children(all_versions)
     main_version = next(
-        (v for v in all_versions if MAIN_TAG in (v.get("metadata", {}).get("container", {}).get("tags", []) or [])),
+        (v for v in all_versions if MAIN_TAG in tags_of(v)),
         None,
     )
     if main_version is None:
@@ -130,29 +215,20 @@ def prune_superseded(owner, image, token, dry_run=False):
     main_created = main_version.get("created_at", "")
     removed, problems = 0, []
     for version in all_versions:
-        tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+        tags = tags_of(version)
         if version["id"] == main_version["id"] or not tags:
             continue
         # Only ever untagged-by-us src-* manifests: a pr-* alias means the
-        # pull-request sweep owns it, and anything else is a release tag.
+        # pull-request sweep owns it, and anything else is a release tag. The
+        # per-architecture children are not judged here either - they go with
+        # whichever index references them.
         if any(not SRC_TAG.match(t) for t in tags):
             continue
         if not version.get("created_at") or version["created_at"] >= main_created:
             continue
-        if dry_run:
-            print(f"- would delete `{image}:{','.join(sorted(tags))}`")
-            removed += 1
-            continue
-        try:
-            _request(
-                f"{API}/orgs/{owner}/packages/container/"
-                f"{urllib.parse.quote(image, safe='')}/versions/{version['id']}",
-                token,
-                method="DELETE",
-            )
-            removed += 1
-        except urllib.error.HTTPError as error:
-            problems.append(f"{image}:{','.join(sorted(tags))} ({error.code})")
+        count, trouble = delete_family(owner, image, version, children, token, dry_run)
+        removed += count
+        problems.extend(trouble)
     return removed, problems
 
 
@@ -170,28 +246,19 @@ def prune_orphans(owner, image, token, older_than_days, dry_run=False):
     only covers the minutes between a push and its alias landing.
     """
     cutoff = (datetime.now(timezone.utc) - timedelta(days=older_than_days)).isoformat()
+    all_versions = versions(owner, image, token)
+    children = arch_children(all_versions)
     removed, problems = 0, []
-    for version in versions(owner, image, token):
-        tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+    for version in all_versions:
+        tags = tags_of(version)
         if not tags or any(not SRC_TAG.match(t) for t in tags):
             continue
         created = version.get("created_at") or ""
         if not created or created >= cutoff:
             continue
-        if dry_run:
-            print(f"- would delete `{image}:{','.join(sorted(tags))}` ({created[:10]})")
-            removed += 1
-            continue
-        try:
-            _request(
-                f"{API}/orgs/{owner}/packages/container/"
-                f"{urllib.parse.quote(image, safe='')}/versions/{version['id']}",
-                token,
-                method="DELETE",
-            )
-            removed += 1
-        except urllib.error.HTTPError as error:
-            problems.append(f"{image}:{','.join(sorted(tags))} ({error.code})")
+        count, trouble = delete_family(owner, image, version, children, token, dry_run)
+        removed += count
+        problems.extend(trouble)
     return removed, problems
 
 
@@ -233,16 +300,13 @@ def main(argv=None):
     for image in [] if args.no_pr_sweep else IMAGES:
         try:
             all_versions = versions(args.owner, image, token)
+            children = arch_children(all_versions)
             # Whatever main points at is the promotion source for a release and is
             # never removed, however old the pull request that first built it.
-            main_ids = {
-                v["id"]
-                for v in all_versions
-                if MAIN_TAG in (v.get("metadata", {}).get("container", {}).get("tags", []) or [])
-            }
+            main_ids = {v["id"] for v in all_versions if MAIN_TAG in tags_of(v)}
 
             for version in all_versions:
-                tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+                tags = tags_of(version)
                 pr_tags = [t for t in tags if PR_TAG.match(t)]
                 if not pr_tags:
                     continue
@@ -251,8 +315,8 @@ def main(argv=None):
                 if args.pr is not None and args.pr not in numbers:
                     continue
 
-                # Never touch anything carrying a tag outside the two CI families.
-                if any(not (PR_TAG.match(t) or SRC_TAG.match(t)) for t in tags):
+                # Never touch anything carrying a tag outside the CI families.
+                if any(not is_ci_tag(t) for t in tags):
                     protected += 1
                     continue
 
@@ -272,20 +336,11 @@ def main(argv=None):
                     kept += 1
                     continue
 
-                if args.dry_run:
-                    print(f"- would delete `{image}:{','.join(sorted(tags))}`")
-                    deleted += 1
-                    continue
-                try:
-                    _request(
-                        f"{API}/orgs/{args.owner}/packages/container/"
-                        f"{urllib.parse.quote(image, safe='')}/versions/{version['id']}",
-                        token,
-                        method="DELETE",
-                    )
-                    deleted += 1
-                except urllib.error.HTTPError as error:
-                    failed.append(f"{image}:{','.join(sorted(tags))} ({error.code})")
+                count, trouble = delete_family(
+                    args.owner, image, version, children, token, args.dry_run
+                )
+                deleted += count
+                failed.extend(trouble)
         except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
             failed.append(f"{image} ({error})")
 

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -138,6 +138,12 @@ def delete_family(owner, image, version, children, token, dry_run=False):
     targets, seen = [version], {version["id"]}
     for digest in {tag_hash(tag) for tag in tags_of(version)} - {None}:
         for child in children.get(digest, []):
+            # Two hashes that build byte-identical images share one manifest, so
+            # this child can also be src-<other>-amd64 - and that other index is
+            # not ours to break. Only take a child that belongs to this hash
+            # alone.
+            if {tag_hash(tag) for tag in tags_of(child)} != {digest}:
+                continue
             if child["id"] not in seen:
                 seen.add(child["id"])
                 targets.append(child)

--- a/scripts/ci/cleanup_pr_images.py
+++ b/scripts/ci/cleanup_pr_images.py
@@ -96,12 +96,71 @@ def pr_is_open(owner, repo, number, token):
         raise
 
 
+def prune_superseded(owner, image, token, dry_run=False):
+    """Remove trunk-built src-* manifests that :main has superseded.
+
+    A trunk build publishes src-<hash> and, once its tests pass, :main is retagged
+    onto it. The previous trunk manifests keep their src-* tag for ever: they carry
+    no pr-* alias, because only a pull request build creates one, so the
+    closed-pull-request sweep can never reach them.
+
+    Superseded means created before whatever :main points at now. That is used
+    rather than an age in days because it cannot race: a manifest newer than the
+    current main might be mid-promotion in another run, and is left alone.
+    """
+    all_versions = versions(owner, image, token)
+    main_version = next(
+        (v for v in all_versions if MAIN_TAG in (v.get("metadata", {}).get("container", {}).get("tags", []) or [])),
+        None,
+    )
+    if main_version is None:
+        return 0, ["no :main tag, so nothing can be judged superseded"]
+
+    main_created = main_version.get("created_at", "")
+    removed, problems = 0, []
+    for version in all_versions:
+        tags = version.get("metadata", {}).get("container", {}).get("tags", []) or []
+        if version["id"] == main_version["id"] or not tags:
+            continue
+        # Only ever untagged-by-us src-* manifests: a pr-* alias means the
+        # pull-request sweep owns it, and anything else is a release tag.
+        if any(not SRC_TAG.match(t) for t in tags):
+            continue
+        if not version.get("created_at") or version["created_at"] >= main_created:
+            continue
+        if dry_run:
+            print(f"- would delete `{image}:{','.join(sorted(tags))}`")
+            removed += 1
+            continue
+        try:
+            _request(
+                f"{API}/orgs/{owner}/packages/container/"
+                f"{urllib.parse.quote(image, safe='')}/versions/{version['id']}",
+                token,
+                method="DELETE",
+            )
+            removed += 1
+        except urllib.error.HTTPError as error:
+            problems.append(f"{image}:{','.join(sorted(tags))} ({error.code})")
+    return removed, problems
+
+
 def main(argv=None):
     parser = argparse.ArgumentParser(description="Delete pr-* image tags from GHCR.")
     parser.add_argument("--owner", required=True)
     parser.add_argument("--repo", default=os.environ.get("GITHUB_REPOSITORY", "").split("/")[-1] or "docker-selenium")
     parser.add_argument("--pr", type=int, default=None, help="Only this pull request.")
     parser.add_argument("--dry-run", action="store_true")
+    parser.add_argument(
+        "--no-pr-sweep",
+        action="store_true",
+        help="Skip the closed-pull-request sweep. Used on trunk, where only --prune-superseded applies.",
+    )
+    parser.add_argument(
+        "--prune-superseded",
+        action="store_true",
+        help="Also remove trunk-built src-* manifests older than what :main points at.",
+    )
     args = parser.parse_args(argv)
 
     token = os.environ.get("GH_TOKEN") or os.environ.get("GITHUB_TOKEN")
@@ -114,7 +173,7 @@ def main(argv=None):
     protected = 0
 
     print("## Pull request image cleanup\n")
-    for image in IMAGES:
+    for image in [] if args.no_pr_sweep else IMAGES:
         try:
             all_versions = versions(args.owner, image, token)
             # Whatever main points at is the promotion source for a release and is
@@ -173,7 +232,19 @@ def main(argv=None):
         except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
             failed.append(f"{image} ({error})")
 
-    scope = f"PR #{args.pr}" if args.pr is not None else "all closed pull requests"
+    if args.prune_superseded:
+        print("\n### Superseded trunk images\n")
+        pruned = 0
+        for image in IMAGES:
+            try:
+                removed, problems = prune_superseded(args.owner, image, token, args.dry_run)
+                pruned += removed
+                failed.extend(problems)
+            except Exception as error:  # noqa: BLE001 - one bad package must not stop the sweep
+                failed.append(f"{image} ({error})")
+        print(f"- Superseded manifests deleted: **{pruned}**")
+
+    scope = "none" if args.no_pr_sweep else (f"PR #{args.pr}" if args.pr is not None else "all closed pull requests")
     print(f"Scope: {scope}\n")
     print(f"- Deleted: **{deleted}**")
     if kept:

--- a/tests/charts/make/chart_test.sh
+++ b/tests/charts/make/chart_test.sh
@@ -42,7 +42,20 @@ BASIC_AUTH_PASSWORD=${BASIC_AUTH_PASSWORD:-"myStrongPassword"}
 LOG_LEVEL=${LOG_LEVEL:-"INFO"}
 INGRESS_DISABLE_USE_HTTP2=${INGRESS_DISABLE_USE_HTTP2:-false}
 TEST_EXISTING_KEDA=${TEST_EXISTING_KEDA:-"false"}
-TEST_EXTERNAL_SCALER=${TEST_EXTERNAL_SCALER:-"false"}
+# The chart ships the external scaler as its default (#3169), so that is what
+# users run. KEDA's built-in selenium-grid scaler still miscounts ongoing
+# sessions upstream, which shows up here as "Unable to find a free slot for
+# request" while the nodes sit ready at 1/1.
+#
+# A test pointed at an existing KEDA install therefore gets the external scaler
+# too. Setting TEST_EXTERNAL_SCALER=false in a target still forces the built-in
+# one, which is how to keep a canary on upstream behaviour if that is wanted -
+# no target does so today.
+if [ "${TEST_EXISTING_KEDA}" = "true" ]; then
+  TEST_EXTERNAL_SCALER=${TEST_EXTERNAL_SCALER:-"true"}
+else
+  TEST_EXTERNAL_SCALER=${TEST_EXTERNAL_SCALER:-"false"}
+fi
 TEST_UPGRADE_CHART=${TEST_UPGRADE_CHART:-"false"}
 RENDER_HELM_TEMPLATE_ONLY=${RENDER_HELM_TEMPLATE_ONLY:-"false"}
 TEST_PV_CLAIM_NAME=${TEST_PV_CLAIM_NAME:-"selenium-grid-pvc-local"}
@@ -233,8 +246,8 @@ elif [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ] && [ "${TEST_EXISTING_KEDA}" = 
   "
 fi
 
-# Deterministically pin the scaler mode per test (the chart default is external);
-# built-in strategies keep TEST_EXTERNAL_SCALER=false so they still cover selenium-grid.
+# Pin the scaler mode per test. Defaulted above: external whenever an existing
+# KEDA install is used, matching the chart default, and built-in otherwise.
 if [ "${SELENIUM_GRID_AUTOSCALING}" = "true" ]; then
   HELM_COMMAND_SET_IMAGES="${HELM_COMMAND_SET_IMAGES} \
   --set autoscaling.externalScaler.enabled=${TEST_EXTERNAL_SCALER} \

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -76,3 +76,80 @@ class DeletionRuleTest(unittest.TestCase):
     def test_main_protection_applies_per_image_not_globally(self):
         vs = [version(1, ["src-aaaaaa", "pr-100", "main"]), version(2, ["src-bbbbbb", "pr-100"])]
         self.assertEqual(decide(vs, closed={100}), [2])
+
+
+def tv(vid, tags, created):
+    return {"id": vid, "created_at": created, "metadata": {"container": {"tags": tags}}}
+
+
+def supersede(versions):
+    """Mirror of prune_superseded's rule, exercised without HTTP."""
+    main_v = next((v for v in versions if cp.MAIN_TAG in v["metadata"]["container"]["tags"]), None)
+    if main_v is None:
+        return []
+    out = []
+    for v in versions:
+        tags = v["metadata"]["container"]["tags"]
+        if v["id"] == main_v["id"] or not tags:
+            continue
+        if any(not cp.SRC_TAG.match(t) for t in tags):
+            continue
+        if not v.get("created_at") or v["created_at"] >= main_v["created_at"]:
+            continue
+        out.append(v["id"])
+    return out
+
+
+class PruneSupersededTest(unittest.TestCase):
+    def test_removes_a_trunk_manifest_older_than_main(self):
+        vs = [tv(1, ["src-0d1111"], "2026-09-01"), tv(2, ["src-e42222", "main"], "2026-09-05")]
+        self.assertEqual(supersede(vs), [1])
+
+    def test_never_removes_what_main_points_at(self):
+        vs = [tv(2, ["src-e42222", "main"], "2026-09-05")]
+        self.assertEqual(supersede(vs), [])
+
+    def test_leaves_a_manifest_newer_than_main_alone(self):
+        # could be mid-promotion in a concurrent run
+        vs = [tv(1, ["src-e4e111"], "2026-09-06"), tv(2, ["src-a11122", "main"], "2026-09-05")]
+        self.assertEqual(supersede(vs), [])
+
+    def test_leaves_pull_request_manifests_to_the_other_sweep(self):
+        vs = [tv(1, ["src-0d1111", "pr-100"], "2026-09-01"), tv(2, ["src-e42222", "main"], "2026-09-05")]
+        self.assertEqual(supersede(vs), [])
+
+    def test_never_removes_a_release_or_floating_tag(self):
+        for tag in ["4.48.0-20260909", "latest", "nightly"]:
+            vs = [tv(1, ["src-0d1111", tag], "2026-09-01"), tv(2, ["src-e42222", "main"], "2026-09-05")]
+            self.assertEqual(supersede(vs), [], tag)
+
+    def test_does_nothing_when_there_is_no_main(self):
+        vs = [tv(1, ["src-0d1111"], "2026-09-01")]
+        self.assertEqual(supersede(vs), [])
+
+    def test_removes_several_superseded_manifests(self):
+        vs = [
+            tv(1, ["src-a11111"], "2026-09-01"),
+            tv(2, ["src-b22222"], "2026-09-02"),
+            tv(3, ["src-c33333", "main"], "2026-09-05"),
+        ]
+        self.assertEqual(sorted(supersede(vs)), [1, 2])
+
+    def test_skips_an_untagged_manifest(self):
+        vs = [tv(1, [], "2026-09-01"), tv(2, ["src-e42222", "main"], "2026-09-05")]
+        self.assertEqual(supersede(vs), [])
+
+
+class SrcTagStrictnessTest(unittest.TestCase):
+    def test_matches_a_real_source_hash(self):
+        self.assertTrue(cp.SRC_TAG.match("src-331808bba75d"))
+
+    def test_rejects_anything_that_is_not_a_hex_hash(self):
+        # a tag merely starting with src- must not be mistaken for one of ours
+        for tag in ["src-latest", "src-", "src-release", "srcs-aaaaaa", "src-aaa"]:
+            self.assertIsNone(cp.SRC_TAG.match(tag), tag)
+
+    def test_rejects_release_and_floating_tags(self):
+        for tag in ["main", "latest", "nightly", "4.48.0-20260909", "ffmpeg-8.1-20260905"]:
+            self.assertIsNone(cp.SRC_TAG.match(tag), tag)
+            self.assertIsNone(cp.PR_TAG.match(tag), tag)

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -1,15 +1,14 @@
 import importlib.util
+import io
 import pathlib
 import unittest
+import urllib.error
+from datetime import datetime, timedelta, timezone
 
 MODULE_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "ci" / "cleanup_pr_images.py"
 spec = importlib.util.spec_from_file_location("cleanup_pr_images", MODULE_PATH)
 cp = importlib.util.module_from_spec(spec)
 spec.loader.exec_module(cp)
-
-
-def version(vid, tags):
-    return {"id": vid, "metadata": {"container": {"tags": tags}}}
 
 
 def decide(versions, closed, target_pr=None):
@@ -24,7 +23,7 @@ def decide(versions, closed, target_pr=None):
         numbers = sorted(int(cp.PR_TAG.match(t).group(1)) for t in pr_tags)
         if target_pr is not None and target_pr not in numbers:
             continue
-        if any(not (cp.PR_TAG.match(t) or cp.SRC_TAG.match(t)) for t in tags):
+        if any(not cp.is_ci_tag(t) for t in tags):
             continue
         if v["id"] in main_ids:
             continue
@@ -162,12 +161,15 @@ class SrcTagStrictnessTest(unittest.TestCase):
         self.assertTrue(cp.SRC_TAG.match("src-331808bba75d-complete"))
 
     def test_still_rejects_the_per_architecture_tags(self):
-        # Deliberate. src-<hash>-amd64 is the child manifest the merged index
-        # points at, not a copy of it: deleting the child breaks an index that
-        # may still be in use. They are left for a fix that deletes an index and
-        # its children together.
+        # Deliberate, and load-bearing. SRC_TAG identifies an index, and every
+        # sweep judges indexes only: src-<hash>-amd64 is the child manifest the
+        # index points at, not a copy of it, so deleting one on its own breaks an
+        # index that may still be in use. ARCH_TAG matches those instead, and
+        # delete_family removes them with their index.
         for tag in ["src-331808bba75d-amd64", "src-331808bba75d-arm64"]:
             self.assertIsNone(cp.SRC_TAG.match(tag), tag)
+            self.assertTrue(cp.ARCH_TAG.match(tag), tag)
+            self.assertTrue(cp.is_ci_tag(tag), tag)
 
 
 def orphan(versions, cutoff):
@@ -261,3 +263,126 @@ class DurableMarkerTest(unittest.TestCase):
             version(2, ["src-b22222", "pr-101-b22222"]),
         ]
         self.assertEqual(decide(vs, closed={100, 101}, target_pr=100), [1])
+
+
+def version(vid, tags, created="2020-01-01T00:00:00Z"):
+    return {"id": vid, "created_at": created, "metadata": {"container": {"tags": list(tags)}}}
+
+
+class RecordingApi:
+    """Stands in for the GitHub API: serves one package, records the deletes.
+
+    These tests drive the real functions rather than a restatement of their
+    rules, which is the only way a defect in delete_family can show up here.
+    """
+
+    def __init__(self, versions, fails=()):
+        self.versions = versions
+        self.fails = set(fails)
+        self.deleted = []
+
+    def request(self, url, token, method="GET"):
+        if method != "DELETE":
+            raise AssertionError(f"unexpected {method} {url}")
+        vid = int(url.rsplit("/", 1)[-1])
+        if vid in self.fails:
+            raise urllib.error.HTTPError(url, 403, "Forbidden", {}, None)
+        self.deleted.append(vid)
+
+    def install(self, testcase):
+        testcase.addCleanup(setattr, cp, "_request", cp._request)
+        testcase.addCleanup(setattr, cp, "versions", cp.versions)
+        cp._request = self.request
+        cp.versions = lambda owner, image, token: self.versions
+
+
+class ArchChildrenTest(unittest.TestCase):
+    def test_groups_children_under_the_hash_of_their_index(self):
+        found = cp.arch_children(
+            [
+                version(1, ["src-aaaaaaaaaaaa", "src-aaaaaaaaaaaa-complete"]),
+                version(2, ["src-aaaaaaaaaaaa-amd64"]),
+                version(3, ["src-aaaaaaaaaaaa-arm64"]),
+                version(4, ["src-bbbbbbbbbbbb-amd64"]),
+            ]
+        )
+        self.assertEqual(sorted(v["id"] for v in found["aaaaaaaaaaaa"]), [2, 3])
+        self.assertEqual([v["id"] for v in found["bbbbbbbbbbbb"]], [4])
+
+    def test_the_index_itself_is_not_a_child(self):
+        self.assertEqual(cp.arch_children([version(1, ["src-aaaaaaaaaaaa"])]), {})
+
+    def test_a_pr_alias_reveals_the_hash_it_belongs_to(self):
+        self.assertEqual(cp.tag_hash("pr-3229-aaaaaaaaaaaa"), "aaaaaaaaaaaa")
+        self.assertEqual(cp.tag_hash("src-aaaaaaaaaaaa-amd64"), "aaaaaaaaaaaa")
+        self.assertIsNone(cp.tag_hash("pr-3229"))
+        self.assertIsNone(cp.tag_hash("latest"))
+
+
+class DeleteFamilyTest(unittest.TestCase):
+    def test_an_index_takes_its_architecture_children_with_it(self):
+        api = RecordingApi([])
+        api.install(self)
+        index = version(1, ["src-aaaaaaaaaaaa", "src-aaaaaaaaaaaa-complete"])
+        children = cp.arch_children([version(2, ["src-aaaaaaaaaaaa-amd64"]), version(3, ["src-aaaaaaaaaaaa-arm64"])])
+        removed, problems = cp.delete_family("seleniumhq", "base", index, children, "t")
+        self.assertEqual(removed, 3)
+        self.assertEqual(problems, [])
+        self.assertEqual(api.deleted, [1, 2, 3], "the index must be deleted before its children")
+
+    def test_children_of_another_hash_are_left_alone(self):
+        api = RecordingApi([])
+        api.install(self)
+        children = cp.arch_children([version(9, ["src-bbbbbbbbbbbb-amd64"])])
+        cp.delete_family("seleniumhq", "base", version(1, ["src-aaaaaaaaaaaa"]), children, "t")
+        self.assertEqual(api.deleted, [1])
+
+    def test_a_refused_delete_is_reported_rather_than_raised(self):
+        api = RecordingApi([], fails={2})
+        api.install(self)
+        children = cp.arch_children([version(2, ["src-aaaaaaaaaaaa-amd64"])])
+        removed, problems = cp.delete_family("seleniumhq", "base", version(1, ["src-aaaaaaaaaaaa"]), children, "t")
+        self.assertEqual(removed, 1)
+        self.assertEqual(len(problems), 1)
+        self.assertIn("403", problems[0])
+
+
+class OrphanSweepReachesChildrenTest(unittest.TestCase):
+    def test_the_children_no_sweep_could_previously_see_are_collected(self):
+        api = RecordingApi(
+            [
+                version(1, ["src-aaaaaaaaaaaa", "src-aaaaaaaaaaaa-complete"]),
+                version(2, ["src-aaaaaaaaaaaa-amd64"]),
+                version(3, ["src-aaaaaaaaaaaa-arm64"]),
+            ]
+        )
+        api.install(self)
+        removed, problems = cp.prune_orphans("seleniumhq", "base", "t", older_than_days=7)
+        self.assertEqual(removed, 3)
+        self.assertEqual(sorted(api.deleted), [1, 2, 3])
+        self.assertEqual(problems, [])
+
+    def test_a_child_is_never_deleted_while_its_index_is_too_new(self):
+        recent = (datetime.now(timezone.utc) + timedelta(days=1)).isoformat()
+        api = RecordingApi(
+            [
+                version(1, ["src-aaaaaaaaaaaa"], created=recent),
+                version(2, ["src-aaaaaaaaaaaa-amd64"]),
+            ]
+        )
+        api.install(self)
+        removed, _ = cp.prune_orphans("seleniumhq", "base", "t", older_than_days=7)
+        self.assertEqual(removed, 0, "deleting a child of a live index breaks that index")
+        self.assertEqual(api.deleted, [])
+
+    def test_a_release_tag_still_protects_the_whole_family(self):
+        api = RecordingApi(
+            [
+                version(1, ["src-aaaaaaaaaaaa", "4.48.0"]),
+                version(2, ["src-aaaaaaaaaaaa-amd64"]),
+            ]
+        )
+        api.install(self)
+        removed, _ = cp.prune_orphans("seleniumhq", "base", "t", older_than_days=7)
+        self.assertEqual(removed, 0)
+        self.assertEqual(api.deleted, [])

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -1,0 +1,78 @@
+import importlib.util
+import pathlib
+import unittest
+
+MODULE_PATH = pathlib.Path(__file__).parents[2] / "scripts" / "ci" / "cleanup_pr_images.py"
+spec = importlib.util.spec_from_file_location("cleanup_pr_images", MODULE_PATH)
+cp = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(cp)
+
+
+def version(vid, tags):
+    return {"id": vid, "metadata": {"container": {"tags": tags}}}
+
+
+def decide(versions, closed, target_pr=None):
+    """Mirror of the deletion rule in main(), so it can be exercised without HTTP."""
+    main_ids = {v["id"] for v in versions if cp.MAIN_TAG in v["metadata"]["container"]["tags"]}
+    out = []
+    for v in versions:
+        tags = v["metadata"]["container"]["tags"]
+        pr_tags = [t for t in tags if cp.PR_TAG.match(t)]
+        if not pr_tags:
+            continue
+        numbers = sorted(int(cp.PR_TAG.match(t).group(1)) for t in pr_tags)
+        if target_pr is not None and target_pr not in numbers:
+            continue
+        if any(not (cp.PR_TAG.match(t) or cp.SRC_TAG.match(t)) for t in tags):
+            continue
+        if v["id"] in main_ids:
+            continue
+        if any(n not in closed for n in numbers):
+            continue
+        out.append(v["id"])
+    return out
+
+
+class DeletionRuleTest(unittest.TestCase):
+    def test_deletes_a_closed_pull_requests_images(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100"])]
+        self.assertEqual(decide(vs, closed={100}), [1])
+
+    def test_keeps_an_open_pull_requests_images(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100"])]
+        self.assertEqual(decide(vs, closed=set()), [])
+
+    def test_keeps_a_manifest_two_pull_requests_share_when_one_is_open(self):
+        # identical image content is one manifest, tagged for both
+        vs = [version(1, ["src-aaaaaa", "pr-100", "pr-101"])]
+        self.assertEqual(decide(vs, closed={100}), [])
+
+    def test_deletes_a_shared_manifest_once_every_sharer_is_closed(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100", "pr-101"])]
+        self.assertEqual(decide(vs, closed={100, 101}), [1])
+
+    def test_never_deletes_what_main_points_at(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100", "main"])]
+        self.assertEqual(decide(vs, closed={100}), [])
+
+    def test_never_deletes_a_release_tag_even_beside_a_pr_tag(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100", "4.48.0-20260909"])]
+        self.assertEqual(decide(vs, closed={100}), [])
+
+    def test_never_deletes_latest_or_nightly(self):
+        for tag in ["latest", "nightly"]:
+            vs = [version(1, ["src-aaaaaa", "pr-100", tag])]
+            self.assertEqual(decide(vs, closed={100}), [], tag)
+
+    def test_ignores_versions_with_no_pr_tag(self):
+        vs = [version(1, ["src-aaaaaa"]), version(2, ["main"])]
+        self.assertEqual(decide(vs, closed={100}), [])
+
+    def test_targeting_one_pull_request_leaves_the_others(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100"]), version(2, ["src-bbbbbb", "pr-101"])]
+        self.assertEqual(decide(vs, closed={100, 101}, target_pr=100), [1])
+
+    def test_main_protection_applies_per_image_not_globally(self):
+        vs = [version(1, ["src-aaaaaa", "pr-100", "main"]), version(2, ["src-bbbbbb", "pr-100"])]
+        self.assertEqual(decide(vs, closed={100}), [2])

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -154,6 +154,21 @@ class SrcTagStrictnessTest(unittest.TestCase):
             self.assertIsNone(cp.SRC_TAG.match(tag), tag)
             self.assertIsNone(cp.PR_TAG.match(tag), tag)
 
+    def test_accepts_the_completeness_marker(self):
+        # build-images tags base:src-<hash>-complete once the whole set has
+        # merged, on the same manifest as src-<hash>. Unrecognised, it would read
+        # as a tag outside the CI families and protect every base manifest from
+        # cleanup for ever.
+        self.assertTrue(cp.SRC_TAG.match("src-331808bba75d-complete"))
+
+    def test_still_rejects_the_per_architecture_tags(self):
+        # Deliberate. src-<hash>-amd64 is the child manifest the merged index
+        # points at, not a copy of it: deleting the child breaks an index that
+        # may still be in use. They are left for a fix that deletes an index and
+        # its children together.
+        for tag in ["src-331808bba75d-amd64", "src-331808bba75d-arm64"]:
+            self.assertIsNone(cp.SRC_TAG.match(tag), tag)
+
 
 def orphan(versions, cutoff):
     """Mirror of prune_orphans' rule, exercised without HTTP."""

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -386,3 +386,16 @@ class OrphanSweepReachesChildrenTest(unittest.TestCase):
         removed, _ = cp.prune_orphans("seleniumhq", "base", "t", older_than_days=7)
         self.assertEqual(removed, 0)
         self.assertEqual(api.deleted, [])
+
+    def test_a_child_shared_with_another_index_is_left_alone(self):
+        # Two hashes whose images come out byte-identical share one manifest, and
+        # that manifest then carries an arch tag for each. Taking it with one
+        # index would break the other.
+        api = RecordingApi([])
+        api.install(self)
+        shared = version(2, ["src-aaaaaaaaaaaa-amd64", "src-bbbbbbbbbbbb-amd64"])
+        children = cp.arch_children([shared, version(3, ["src-aaaaaaaaaaaa-arm64"])])
+        removed, _ = cp.delete_family("seleniumhq", "base", version(1, ["src-aaaaaaaaaaaa"]), children, "t")
+        self.assertEqual(removed, 2)
+        self.assertEqual(api.deleted, [1, 3])
+        self.assertNotIn(2, api.deleted)

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -204,3 +204,45 @@ class PruneOrphansTest(unittest.TestCase):
     def test_an_untagged_manifest_is_left_alone(self):
         vs = [tv(1, [], "2026-09-01")]
         self.assertEqual(orphan(vs, cutoff="2026-09-05"), [])
+
+
+class DurableMarkerTest(unittest.TestCase):
+    """pr-<N> moves; pr-<N>-<hash> does not, so a closed PR's whole set is findable."""
+
+    def test_both_marker_forms_yield_the_pull_request_number(self):
+        self.assertEqual(cp.PR_TAG.match("pr-3229").group(1), "3229")
+        self.assertEqual(cp.PR_TAG.match("pr-3229-331808bba75d").group(1), "3229")
+
+    def test_a_marker_suffix_must_be_a_hex_hash(self):
+        for tag in ["pr-3229-notahash", "pr-3229-", "pr-3229-abc", "pr-"]:
+            self.assertIsNone(cp.PR_TAG.match(tag), tag)
+
+    def test_closing_a_pull_request_now_reaches_every_build_it_made(self):
+        # three commits, three manifests; pr-100 moved to the newest, but each
+        # build kept its own durable marker
+        vs = [
+            version(1, ["src-a11111", "pr-100-a11111"]),
+            version(2, ["src-b22222", "pr-100-b22222"]),
+            version(3, ["src-c33333", "pr-100-c33333", "pr-100"]),
+        ]
+        self.assertEqual(sorted(decide(vs, closed={100})), [1, 2, 3])
+
+    def test_an_open_pull_request_keeps_all_of_its_builds(self):
+        vs = [
+            version(1, ["src-a11111", "pr-100-a11111"]),
+            version(2, ["src-b22222", "pr-100-b22222", "pr-100"]),
+        ]
+        self.assertEqual(decide(vs, closed=set()), [])
+
+    def test_a_manifest_two_pull_requests_used_survives_while_either_is_open(self):
+        # PR 101 reused what PR 100 built, so both markers sit on one manifest
+        vs = [version(1, ["src-a11111", "pr-100-a11111", "pr-101-a11111"])]
+        self.assertEqual(decide(vs, closed={100}), [])
+        self.assertEqual(decide(vs, closed={100, 101}), [1])
+
+    def test_targeting_one_pull_request_still_reaches_its_older_builds(self):
+        vs = [
+            version(1, ["src-a11111", "pr-100-a11111"]),
+            version(2, ["src-b22222", "pr-101-b22222"]),
+        ]
+        self.assertEqual(decide(vs, closed={100, 101}, target_pr=100), [1])

--- a/tests/ci/test_cleanup_pr_images.py
+++ b/tests/ci/test_cleanup_pr_images.py
@@ -153,3 +153,54 @@ class SrcTagStrictnessTest(unittest.TestCase):
         for tag in ["main", "latest", "nightly", "4.48.0-20260909", "ffmpeg-8.1-20260905"]:
             self.assertIsNone(cp.SRC_TAG.match(tag), tag)
             self.assertIsNone(cp.PR_TAG.match(tag), tag)
+
+
+def orphan(versions, cutoff):
+    """Mirror of prune_orphans' rule, exercised without HTTP."""
+    out = []
+    for v in versions:
+        tags = v["metadata"]["container"]["tags"]
+        if not tags or any(not cp.SRC_TAG.match(t) for t in tags):
+            continue
+        created = v.get("created_at") or ""
+        if not created or created >= cutoff:
+            continue
+        out.append(v["id"])
+    return out
+
+
+class PruneOrphansTest(unittest.TestCase):
+    """The case a PR with several image-affecting commits leaves behind.
+
+    pr-<N> is retagged onto each new build, so earlier manifests keep only src-*.
+    """
+
+    def test_removes_earlier_builds_of_the_same_pull_request(self):
+        vs = [
+            tv(1, ["src-a11111"], "2026-09-01"),  # commit 1, alias moved away
+            tv(2, ["src-b22222"], "2026-09-02"),  # commit 2, alias moved away
+            tv(3, ["src-c33333", "pr-100"], "2026-09-03"),  # current build, aliased
+        ]
+        self.assertEqual(sorted(orphan(vs, cutoff="2026-09-03")), [1, 2])
+
+    def test_never_removes_the_currently_aliased_build(self):
+        vs = [tv(3, ["src-c33333", "pr-100"], "2026-09-01")]
+        self.assertEqual(orphan(vs, cutoff="2026-09-05"), [])
+
+    def test_never_removes_main_or_a_release_tag(self):
+        for tag in ["main", "latest", "nightly", "4.48.0-20260909"]:
+            vs = [tv(1, ["src-a11111", tag], "2026-09-01")]
+            self.assertEqual(orphan(vs, cutoff="2026-09-05"), [], tag)
+
+    def test_respects_the_age_guard(self):
+        # covers the minutes between a manifest being pushed and its alias landing
+        vs = [tv(1, ["src-a11111"], "2026-09-05")]
+        self.assertEqual(orphan(vs, cutoff="2026-09-01"), [])
+
+    def test_skips_a_manifest_with_no_creation_date(self):
+        vs = [{"id": 1, "created_at": None, "metadata": {"container": {"tags": ["src-a11111"]}}}]
+        self.assertEqual(orphan(vs, cutoff="2026-09-05"), [])
+
+    def test_an_untagged_manifest_is_left_alone(self):
+        vs = [tv(1, [], "2026-09-01")]
+        self.assertEqual(orphan(vs, cutoff="2026-09-05"), [])


### PR DESCRIPTION
## The problem, measured

Every job in the PR suite builds the images it needs, from scratch.

| Workflow | Matrix jobs |
| --- | --- |
| `docker-test.yml` | 18 |
| `k8s-scaling-test.yml` | 9 |
| `helm-chart-test.yml` | 8 |
| `k8s-dynamic-grid-test.yml` | 2 |
| **Total** | **37** |

It is not only the four entries with `build-all: true`. Every test target names image targets as Make **prerequisites** — `test_video: video hub chrome firefox edge chromium` — so all 37 build something. Recent PR runs took **75–88 minutes**.

`deploy.yml` then built them a 38th time, so the artefact released was a *rebuild of the tested source* rather than the tested artefact.

## The design

Build once, publish to GHCR, have everything else pull.

| Tag | Meaning |
| --- | --- |
| `ghcr.io/<owner>/<image>:pr-<N>` | One set per pull request |
| `ghcr.io/<owner>/<image>:trunk-<sha>` | One set per trunk run |
| `ghcr.io/<owner>/<image>:main` | The last trunk set **whose tests passed** |

`build-images.yml` decides what each run actually needs:

| Mode | When | Result |
| --- | --- | --- |
| `reuse-main` | Nothing image-affecting changed | **Nothing is built at all** |
| `build-and-push` | Image content changed | Built once, multi-arch; 37 jobs pull |
| `build-in-job` | Fork PR | Exactly today's behaviour |

**Image-affecting** means the 21 directories holding a `Dockerfile`, or the `Makefile` (build args and pinned versions). That rule is deliberately coarse — an unnecessary build costs minutes, a missed one ships an untested image. Measured against the last 18 merges: **12 would rebuild, 6 would reuse `:main`.**

## Fork safety

Forks are detected by comparing head repository to this one, and **never receive credentials**. `pull_request_target` is deliberately not used — it would hand a registry write token to untrusted code. 3 of the last 60 PRs came from forks; they keep building in-job, unchanged.

## How tests consume the images

Test jobs pull and retag to the local names the compose files already expect, then set `SKIP_BUILD=true`. That turns every image-build target into a no-op via **one guarded block** at the end of the Makefile.

The 48 build recipes and 59 test targets are **untouched**. The block sits last because GNU Make lets the last definition of a target win — I had it at the top first and `SKIP_BUILD` silently did nothing, which is exactly the sort of thing that would have looked green and scanned nothing.

`gen_certs`, `prepare_resources` and `update_go` are deliberately **not** skipped: they produce working-tree files the tests read, not images.

```
make -n test_video                    -> 8 docker buildx build lines, 0 warnings
make -n test_video SKIP_BUILD=true    -> 0 docker buildx build lines
make -n build                         -> 30 build lines, unchanged
```

## Promotion, not rebuilding

`:main` is moved **only after the full suite passes**, by retagging the run-scoped `trunk-<sha>` manifest — so `:main` always denotes a tested tree and the digest never changes.

`deploy.yml` pulls `:main` and promotes it, falling back to building when `:main` does not exist — which it will not, on the first release after this lands.

## Cleanup

`pr-*` tags are deleted when the PR closes, plus a weekly sweep. The script only removes tags matching `pr-<digits>`, and only when **every** tag on that manifest matches, so a shared or release tag cannot be caught by it. Its image list is asserted to match the Makefile's `CI_IMAGES`.

## What is verified, and what is not

Verified locally:

- `SKIP_BUILD` contract, all three cases above.
- All five decision branches of the `decide` job, run as shell against real commits: fork, trunk push, forced, docs-only commit (`reuse-main`), `NodeChrome/` commit (`build-and-push`).
- All 27 workflow files parse; `mbake validate` passes; the two image lists match exactly.
- Build and pull steps are mutually exclusive in all four test workflows.

**Not verified, and it needs a real run:** none of this has executed in Actions. The first PR after merge is the real test. Two things I would watch specifically:

1. **The first run cannot use `:main`** — it does not exist yet, so the `decide` job will choose `build-and-push`. That is handled, but it means the speedup only shows from the second PR onward.
2. **GHCR package visibility.** The packages must allow the repository's `GITHUB_TOKEN` to pull. If `:pr-N` pushes succeed but test jobs fail to pull, that is the cause, and it is a package settings change rather than a workflow one.

I would merge this when you can watch a PR run through it, rather than at the end of a day.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGLHB3pjY3mGZBu4TyUsrm
