### PR TITLE
[ci] Release the tested images instead of rebuilding their source

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -23,6 +23,18 @@ on:
         required: false
         default: false
         type: boolean
+    outputs:
+      # What a caller needs to publish the artefact this run actually tested,
+      # rather than rebuild its source. deploy.yml promotes from this tag.
+      ci-tag:
+        description: 'Registry tag holding the images these tests ran against'
+        value: ${{ jobs.build-images.outputs.ci-tag }}
+      ci-registry:
+        description: 'Registry holding that tag'
+        value: ${{ jobs.build-images.outputs.registry }}
+      ci-mode:
+        description: 'reuse, build-and-push, or build-in-job'
+        value: ${{ jobs.build-images.outputs.mode }}
   workflow_dispatch:
     inputs:
       rerunFailedOnly:

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -138,14 +138,28 @@ jobs:
         run: |
           make chart_render_template
           echo "PUBLISH_YAML_MANIFESTS=$(find ./tests/tests -name "k8s_*.yaml" | tr '\n' ',')" >> $GITHUB_ENV
-      - name: Build images
-        if: github.event.inputs.skip-build-push-image != 'true'
-        uses: nick-invision/retry@master
-        with:
-          timeout_minutes: 180
-          max_attempts: 3
-          retry_wait_seconds: 60
-          command: PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make build
+      # The suite that just ran published its images to GHCR. Publishing THAT
+      # manifest, rather than a fresh build of the same source, is what makes the
+      # released artefact the tested one - and it skips a full multi-arch build.
+      #
+      # Only when the suite actually ran and produced a tag. Skipped tests, a
+      # fork run, or any doubt falls back to building everything, exactly as
+      # before.
+      - name: Decide how to publish
+        id: publish
+        env:
+          CI_TAG: ${{ needs.build-test.outputs.ci-tag }}
+          CI_MODE: ${{ needs.build-test.outputs.ci-mode }}
+          TEST_RESULT: ${{ needs.build-test.result }}
+        run: |
+          set -euo pipefail
+          if [ "${TEST_RESULT}" = "success" ] && [ -n "${CI_TAG}" ] && [ "${CI_MODE}" != "build-in-job" ]; then
+            echo "Promoting the tested images (${CI_TAG})."
+            echo "promote=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No tested image set to promote (result=${TEST_RESULT}, tag=${CI_TAG:-none}, mode=${CI_MODE:-none}); building."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Login Docker Hub
         run: docker login -u="$DOCKER_USERNAME" -p="$DOCKER_PASSWORD"
         env:
@@ -154,8 +168,70 @@ jobs:
       - name: Login GitHub Container Registry
         if: github.event.inputs.skip-build-push-image != 'true'
         run: echo "${{ secrets.SELENIUM_CI_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME }}" --password-stdin
+
+      # --- promoting the tested images ---------------------------------------
+      - name: Promote the tested images to the release tags
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 30
+          max_attempts: 5
+          retry_wait_seconds: 300
+          command: |
+            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              CI_REGISTRY="${{ needs.build-test.outputs.ci-registry }}" \
+              CI_TAG="${{ needs.build-test.outputs.ci-tag }}" \
+              make promote_release_images
+      # NodeDocker/config.toml and NodeKubernetes/config.toml name the standalone
+      # tags of this very release, and the rewrite above has just put them there,
+      # so these four cannot have been built before now. They build FROM the base
+      # image promoted in the step above - SKIP_BUILD_TARGETS=base is what stops
+      # make rebuilding a second, different base underneath them.
+      - name: Build the four images the release tag is baked into
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 60
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: |
+            SKIP_BUILD=true SKIP_BUILD_TARGETS=base \
+              PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              make standalone_docker standalone_kubernetes
+      - name: Deploy those four
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 20
+          max_attempts: 5
+          retry_wait_seconds: 300
+          command: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make release_built_images
+      - name: Mirror the promoted release to GHCR
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 30
+          max_attempts: 5
+          retry_wait_seconds: 300
+          command: |
+            GHCR_NAMESPACE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              CI_REGISTRY="${{ needs.build-test.outputs.ci-registry }}" \
+              CI_TAG="${{ needs.build-test.outputs.ci-tag }}" \
+              PROMOTE_NAMESPACE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              make promote_release_images release_built_images_ghcr
+
+      # --- building everything, as before ------------------------------------
+      - name: Build images
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 180
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: PLATFORMS="${PLATFORMS}" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make build
       - name: Deploy new images
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 20
@@ -163,18 +239,46 @@ jobs:
           retry_wait_seconds: 300
           command: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make release
       - name: Mirror versioned images to GHCR
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 30
           max_attempts: 5
           retry_wait_seconds: 300
           command: GHCR_NAMESPACE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make release_ghcr
+
+      # --- :latest, either way -----------------------------------------------
+      - name: Promote latest
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 20
+          max_attempts: 5
+          retry_wait_seconds: 300
+          command: |
+            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              CI_REGISTRY="${{ needs.build-test.outputs.ci-registry }}" \
+              CI_TAG="${{ needs.build-test.outputs.ci-tag }}" \
+              make promote_release_latest release_built_images_latest
+      - name: Mirror latest to GHCR
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 20
+          max_attempts: 5
+          retry_wait_seconds: 300
+          command: |
+            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              CI_REGISTRY="${{ needs.build-test.outputs.ci-registry }}" \
+              CI_TAG="${{ needs.build-test.outputs.ci-tag }}" \
+              GHCR_NAMESPACE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              PROMOTE_NAMESPACE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              make promote_release_latest release_built_images_ghcr_latest
       - name: Tag images as latest
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
         run: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make tag_latest
       - name: Deploy latest tag
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 20
@@ -182,7 +286,7 @@ jobs:
           retry_wait_seconds: 300
           command: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make release_latest
       - name: Mirror latest images to GHCR
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 20
@@ -202,9 +306,20 @@ jobs:
           timeout_minutes: 20
           max_attempts: 5
           retry_wait_seconds: 300
-          command: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} PUSH_IMAGE=true make tag_and_push_browser_images
+          # PROMOTE_TAGS makes the script alias the published manifest registry
+          # side. Without it the browser tags would be `docker tag` of an image
+          # `docker run` had pulled - i.e. the runner's architecture only, while
+          # the release tag they alias is multi-architecture.
+          command: |
+            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} PUSH_IMAGE=true \
+              PROMOTE_TAGS="${{ steps.publish.outputs.promote }}" \
+              PROMOTE_GHCR_NAMESPACE="$([ "${{ steps.publish.outputs.promote }}" = "true" ] && echo "ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')")" \
+              make tag_and_push_browser_images
+      # Only on the build path. tag_and_push_browser_images_ghcr discovers what to
+      # mirror with `docker images`, and on the promote path the local store holds
+      # none of it - the script mirrors as it tags instead.
       - name: Mirror browser images to GHCR
-        if: github.event.inputs.skip-build-push-image != 'true'
+        if: github.event.inputs.skip-build-push-image != 'true' && steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 30

--- a/Makefile
+++ b/Makefile
@@ -77,14 +77,18 @@ CI_IMAGES := base hub distributor router sessions session-queue event-bus \
 # of which matter only to a build. Leaving it in cost minutes per job, added a
 # live-network flake to each one, and mutated hashed sources after the tag had
 # already been decided.
-SKIP_BUILD_TARGETS := base hub distributor router sessions sessionqueue event_bus \
+# Overridable from the environment, not just as a make argument: the release
+# needs `SKIP_BUILD=true SKIP_BUILD_TARGETS=base` to build the four tag-dependent
+# images on top of the base it just published, and a plain `:=` here would
+# silently ignore that and no-op the four as well.
+SKIP_BUILD_TARGETS := $(or $(SKIP_BUILD_TARGETS),base hub distributor router sessions sessionqueue event_bus \
 	node_base chrome chrome_only chrome-for-testing chrome-for-testing_only chromium \
 	edge edge_only firefox firefox_only all_browsers docker kubernetes \
 	standalone_chrome standalone_chrome_only standalone_chrome-for-testing \
 	standalone_chrome-for-testing_only standalone_chromium standalone_edge \
 	standalone_edge_only standalone_firefox standalone_firefox_only \
 	standalone_all_browsers standalone_docker standalone_kubernetes \
-	video ffmpeg keda_external_scaler update_go
+	video ffmpeg keda_external_scaler update_go)
 
 # Push what was just built, so the rest of the run can reuse it.
 # video does not carry the grid tag: it is built as
@@ -175,6 +179,101 @@ merge_ci_images:
 # storage, and nothing for the cleanup to leak.
 mark_ci_images_complete:
 	docker buildx imagetools create -t $(CI_REGISTRY)/base:$(CI_TAG)-complete $(CI_REGISTRY)/base:$(CI_TAG)
+
+# --- Release by promotion -----------------------------------------------------
+#
+# A release rebuilt every image the trunk suite had just built and tested, so
+# what got published was a rebuild of the tested source rather than the tested
+# artefact. Most images can be retagged instead.
+#
+# Most, not all. NodeDocker/config.toml and NodeKubernetes/config.toml name the
+# exact standalone tags of the release being made -
+#   "selenium/standalone-chrome:4.48.0-20260905"
+# - and update_tag_in_docs_and_files.sh rewrites them as part of tagging. Those
+# two images cannot exist before the tag does, nor can the two standalones built
+# FROM them, so those four are still built at release time.
+RELEASE_PROMOTED_IMAGES := base hub distributor router sessions session-queue event-bus \
+	node-base node-chrome node-chrome-for-testing node-chromium node-edge node-firefox \
+	node-all-browsers standalone-chrome standalone-chrome-for-testing standalone-chromium \
+	standalone-edge standalone-firefox standalone-all-browsers keda-external-scaler
+
+RELEASE_BUILT_IMAGES := node-docker node-kubernetes standalone-docker standalone-kubernetes
+
+# Where a promotion lands. $(NAME) publishes to Docker Hub; pass
+# $(GHCR_NAMESPACE) to mirror the same manifest there.
+PROMOTE_NAMESPACE := $(or $(PROMOTE_NAMESPACE),$(NAME))
+
+# Registry to registry, on the index. Nothing is pulled, so the multi-architecture
+# manifest list arrives intact and the digest released is the digest tested.
+# Pulling per architecture and pushing from the local store is what published
+# single-architecture releases before.
+promote_release_images:
+	@set -e; for image in $(RELEASE_PROMOTED_IMAGES); do \
+		echo "promote $$image -> $(PROMOTE_NAMESPACE)/$$image:$(TAG_VERSION)" ; \
+		docker buildx imagetools create \
+			--tag $(PROMOTE_NAMESPACE)/$$image:$(TAG_VERSION) \
+			--tag $(PROMOTE_NAMESPACE)/$$image:$(MAJOR) \
+			--tag $(PROMOTE_NAMESPACE)/$$image:$(MAJOR).$(MINOR) \
+			--tag $(PROMOTE_NAMESPACE)/$$image:$(MAJOR_MINOR_PATCH) \
+			$(CI_REGISTRY)/$$image:$(CI_TAG) ; \
+	done
+	docker buildx imagetools create \
+		--tag $(PROMOTE_NAMESPACE)/video:$(FFMPEG_TAG_VERSION)-$(BUILD_DATE) \
+		$(CI_REGISTRY)/video:$(CI_TAG)
+
+# Separate from the version tags, exactly as release_latest is separate from
+# release: a prerelease publishes versions without moving :latest.
+promote_release_latest:
+	@set -e; for image in $(RELEASE_PROMOTED_IMAGES); do \
+		echo "promote $$image -> $(PROMOTE_NAMESPACE)/$$image:latest" ; \
+		docker buildx imagetools create --tag $(PROMOTE_NAMESPACE)/$$image:latest \
+			$(CI_REGISTRY)/$$image:$(CI_TAG) ; \
+	done
+	docker buildx imagetools create --tag $(PROMOTE_NAMESPACE)/video:latest \
+		$(CI_REGISTRY)/video:$(CI_TAG)
+
+# The four the promotion cannot cover. Built after the tag rewrite, FROM the base
+# image the promotion has just published, so they sit on the released base rather
+# than on a second local build of it. That is what
+#   SKIP_BUILD=true SKIP_BUILD_TARGETS=base
+# buys: `docker` and `kubernetes` name base as a prerequisite, and without this
+# make would rebuild it here and produce a different digest from the one released.
+release_built_images:
+	@set -e; for image in $(RELEASE_BUILT_IMAGES); do \
+		for tag in $(MAJOR) $(MAJOR).$(MINOR) $(MAJOR_MINOR_PATCH); do \
+			docker tag $(NAME)/$$image:$(TAG_VERSION) $(NAME)/$$image:$$tag ; \
+		done ; \
+		for tag in $(TAG_VERSION) $(MAJOR) $(MAJOR).$(MINOR) $(MAJOR_MINOR_PATCH); do \
+			echo "push $(NAME)/$$image:$$tag" ; \
+			docker push --quiet $(NAME)/$$image:$$tag ; \
+		done ; \
+	done
+
+release_built_images_latest:
+	@set -e; for image in $(RELEASE_BUILT_IMAGES); do \
+		docker tag $(NAME)/$$image:$(TAG_VERSION) $(NAME)/$$image:latest ; \
+		echo "push $(NAME)/$$image:latest" ; \
+		docker push --quiet $(NAME)/$$image:latest ; \
+	done
+
+# Mirror the four to GHCR from what was just pushed to Docker Hub, the way
+# release_ghcr already mirrors everything else.
+release_built_images_ghcr:
+	@set -e; for image in $(RELEASE_BUILT_IMAGES); do \
+		for tag in $(TAG_VERSION) $(MAJOR) $(MAJOR).$(MINOR) $(MAJOR_MINOR_PATCH); do \
+			docker buildx imagetools create \
+			--tag $(GHCR_NAMESPACE)/$$image:$$tag docker.io/$(NAME)/$$image:$$tag ; \
+		done ; \
+	done
+
+# :latest for the four, on GHCR. promote_release_latest covers the other 22, but
+# it copies from the CI tag - these four have no CI tag, because they did not
+# exist until the release built them.
+release_built_images_ghcr_latest:
+	@set -e; for image in $(RELEASE_BUILT_IMAGES); do \
+		docker buildx imagetools create \
+			--tag $(GHCR_NAMESPACE)/$$image:latest docker.io/$(NAME)/$$image:latest ; \
+	done
 
 # Point another tag at an already-tested manifest, without rebuilding. Used for
 # the pr-<N> markers the cleanup keys on, and to retag a passing trunk set as

--- a/tag_and_push_browser_images.sh
+++ b/tag_and_push_browser_images.sh
@@ -7,9 +7,48 @@ PUSH_IMAGE="${4:-false}"
 BROWSER=$5
 RELEASE_OLD_VERSION="${6:-false}"
 PLATFORM="${7:-linux/amd64}"
+# Set by deploy.yml when the release promotes its tested images rather than
+# rebuilding them. See retag() below.
+PROMOTE_TAGS="${PROMOTE_TAGS:-false}"
+PROMOTE_GHCR_NAMESPACE="${PROMOTE_GHCR_NAMESPACE:-}"
 
 TAG_VERSION=${VERSION}-${BUILD_DATE}
 NAMESPACE=${NAME:-selenium}
+
+# Give one already-published image another tag.
+#
+# PROMOTE_TAGS=true means the source lives in a registry and was never built
+# here: a release now publishes the manifest its tests ran against instead of
+# rebuilding it. `docker tag` cannot express that - it needs the image locally,
+# and a `docker pull` brings back only the runner's architecture, so the browser
+# tags would come out single-architecture while the release tags they alias are
+# multi-architecture. imagetools works on the index, registry to registry.
+#
+# PROMOTE_GHCR_NAMESPACE, when set, mirrors in the same call. The Makefile's
+# tag_and_push_browser_images_ghcr cannot do it afterwards, because it discovers
+# what to mirror with `docker images` - and on this path the local store is
+# empty.
+function retag() {
+  local __image=$1
+  local __tag=$2
+  local __source="${NAMESPACE}/${__image}:${TAG_VERSION}"
+
+  if [ "${PROMOTE_TAGS}" = "true" ]; then
+    local __targets=(--tag "${NAMESPACE}/${__image}:${__tag}")
+    if [ -n "${PROMOTE_GHCR_NAMESPACE}" ]; then
+      __targets+=(--tag "${PROMOTE_GHCR_NAMESPACE}/${__image}:${__tag}")
+    fi
+    docker buildx imagetools create "${__targets[@]}" "${__source}"
+    echo "Tagged ${NAMESPACE}/${__image}:${__tag}"
+    return
+  fi
+
+  docker tag "${__source}" "${NAMESPACE}/${__image}:${__tag}"
+  echo "Tagged ${NAMESPACE}/${__image}:${__tag}"
+  if [ "${PUSH_IMAGE}" = true ]; then
+    docker push "${NAMESPACE}/${__image}:${__tag}"
+  fi
+}
 
 function short_version() {
   local __long_version=$1
@@ -60,14 +99,8 @@ chrome)
   fi
 
   for chrome_tag in "${CHROME_TAGS[@]}"; do
-    docker tag ${NAMESPACE}/node-chrome:${TAG_VERSION} ${NAMESPACE}/node-chrome:${chrome_tag}
-    docker tag ${NAMESPACE}/standalone-chrome:${TAG_VERSION} ${NAMESPACE}/standalone-chrome:${chrome_tag}
-    echo "Tagged ${NAMESPACE}/node-chrome:${chrome_tag}"
-    echo "Tagged ${NAMESPACE}/standalone-chrome:${chrome_tag}"
-    if [ "${PUSH_IMAGE}" = true ]; then
-      docker push ${NAMESPACE}/node-chrome:${chrome_tag}
-      docker push ${NAMESPACE}/standalone-chrome:${chrome_tag}
-    fi
+    retag node-chrome "${chrome_tag}"
+    retag standalone-chrome "${chrome_tag}"
   done
 
   ;;
@@ -110,14 +143,8 @@ chromium)
   fi
 
   for chromium_tag in "${CHROMIUM_TAGS[@]}"; do
-    docker tag ${NAMESPACE}/node-chromium:${TAG_VERSION} ${NAMESPACE}/node-chromium:${chromium_tag}
-    docker tag ${NAMESPACE}/standalone-chromium:${TAG_VERSION} ${NAMESPACE}/standalone-chromium:${chromium_tag}
-    echo "Tagged ${NAMESPACE}/node-chromium:${chromium_tag}"
-    echo "Tagged ${NAMESPACE}/standalone-chromium:${chromium_tag}"
-    if [ "${PUSH_IMAGE}" = true ]; then
-      docker push ${NAMESPACE}/node-chromium:${chromium_tag}
-      docker push ${NAMESPACE}/standalone-chromium:${chromium_tag}
-    fi
+    retag node-chromium "${chromium_tag}"
+    retag standalone-chromium "${chromium_tag}"
   done
 
   ;;
@@ -160,14 +187,8 @@ edge)
   fi
 
   for edge_tag in "${EDGE_TAGS[@]}"; do
-    docker tag ${NAMESPACE}/node-edge:${TAG_VERSION} ${NAMESPACE}/node-edge:${edge_tag}
-    docker tag ${NAMESPACE}/standalone-edge:${TAG_VERSION} ${NAMESPACE}/standalone-edge:${edge_tag}
-    echo "Tagged ${NAMESPACE}/node-edge:${edge_tag}"
-    echo "Tagged ${NAMESPACE}/standalone-edge:${edge_tag}"
-    if [ "${PUSH_IMAGE}" = true ]; then
-      docker push ${NAMESPACE}/node-edge:${edge_tag}
-      docker push ${NAMESPACE}/standalone-edge:${edge_tag}
-    fi
+    retag node-edge "${edge_tag}"
+    retag standalone-edge "${edge_tag}"
   done
 
   ;;
@@ -209,14 +230,8 @@ firefox)
   fi
 
   for firefox_tag in "${FIREFOX_TAGS[@]}"; do
-    docker tag ${NAMESPACE}/node-firefox:${TAG_VERSION} ${NAMESPACE}/node-firefox:${firefox_tag}
-    docker tag ${NAMESPACE}/standalone-firefox:${TAG_VERSION} ${NAMESPACE}/standalone-firefox:${firefox_tag}
-    echo "Tagged ${NAMESPACE}/node-firefox:${firefox_tag}"
-    echo "Tagged ${NAMESPACE}/standalone-firefox:${firefox_tag}"
-    if [ "${PUSH_IMAGE}" = true ]; then
-      docker push ${NAMESPACE}/node-firefox:${firefox_tag}
-      docker push ${NAMESPACE}/standalone-firefox:${firefox_tag}
-    fi
+    retag node-firefox "${firefox_tag}"
+    retag standalone-firefox "${firefox_tag}"
   done
 
   ;;
@@ -259,14 +274,8 @@ chrome-for-testing)
   fi
 
   for chrome_tag in "${CHROME_TAGS[@]}"; do
-    docker tag ${NAMESPACE}/node-chrome-for-testing:${TAG_VERSION} ${NAMESPACE}/node-chrome-for-testing:${chrome_tag}
-    docker tag ${NAMESPACE}/standalone-chrome-for-testing:${TAG_VERSION} ${NAMESPACE}/standalone-chrome-for-testing:${chrome_tag}
-    echo "Tagged ${NAMESPACE}/node-chrome-for-testing:${chrome_tag}"
-    echo "Tagged ${NAMESPACE}/standalone-chrome-for-testing:${chrome_tag}"
-    if [ "${PUSH_IMAGE}" = true ]; then
-      docker push ${NAMESPACE}/node-chrome-for-testing:${chrome_tag}
-      docker push ${NAMESPACE}/standalone-chrome-for-testing:${chrome_tag}
-    fi
+    retag node-chrome-for-testing "${chrome_tag}"
+    retag standalone-chrome-for-testing "${chrome_tag}"
   done
 
   ;;


### PR DESCRIPTION
Stacked on #3230 — it retargets to `trunk` once that merges. It depends on #3230 at runtime too: promoting `:main` only makes sense once trunk builds against the **stable** core.

## What changes

`deploy.yml` rebuilt every image the trunk suite had just built and tested, so what reached Docker Hub was a rebuild of the tested source rather than the tested artefact. `build-test.yml` now reports the tag its suite ran against, and the release copies that manifest to the release tags — registry to registry, on the index, so the multi-arch manifest list arrives intact.

Pulling per-architecture and pushing from the local store is what published single-arch releases in an earlier attempt at this; `imagetools create` never touches a local store.

## 22 of 26 images can be promoted. Four cannot

`NodeDocker/config.toml` and `NodeKubernetes/config.toml` name the standalone tags of the release **being made**:

```toml
"selenium/standalone-chrome:4.48.0-20260905", '{"browserName": "chrome", ...}',
```

`update_tag_in_docs_and_files.sh` rewrites them as part of tagging, so those images cannot exist before the tag does — nor can the two standalones built `FROM` them. Those four are still built at release time, on the base the promotion has just published.

`SKIP_BUILD_TARGETS=base` is what stops make building a second, different base underneath them, since `docker: base`. That required making the variable overridable from the environment rather than a plain `:=` — verified both ways.

## The browser tags had the same latent bug

They were `docker tag` of an image `docker run` had pulled — the runner's architecture only. Aliasing a promoted manifest that way would have published single-arch browser tags against multi-arch release tags. The script now aliases registry-side under `PROMOTE_TAGS`, and mirrors to GHCR in the same call, because `tag_and_push_browser_images_ghcr` discovers its work with `docker images` and the local store is empty on this path.

Exercised both modes against a stub docker — the tag names produced are byte-identical, only the mechanism differs.

## Falling back

Anything short of a clean, tested image set builds everything, exactly as before: skipped tests, a fork run, or no tag. Both paths publish the same **26 images** under the same tags — verified by diffing the sets the two paths push.

| | promote path | build path |
|---|---|---|
| Docker Hub version tags | 22 promoted + 4 built | 26 built |
| Docker Hub `:latest` | 22 promoted + 4 built | 26 built |
| GHCR mirror | same | same |
| browser-version tags | registry-side alias | `docker tag` + push |

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGLHB3pjY3mGZBu4TyUsrm