### PR TITLE
[ci] Key the image hash on the core's digest, not its version string

### DIFF
--- a/.github/actions/get-latest-upstream/action.yml
+++ b/.github/actions/get-latest-upstream/action.yml
@@ -50,10 +50,24 @@ runs:
             RELEASE=$(echo "${RELEASES}" | jq -r '[.[]? | select(.prerelease == false)] | .[0].tag_name')
           fi
         fi
-        jar_file=$(curl -s -H "$AUTH_HEADER" https://api.github.com/repos/${AUTHORS}/selenium/releases/tags/${RELEASE} | jq -r '.assets[] | select(.name | endswith(".jar")) | .name' | tail -n 1)
+        ASSET=$(curl -s -H "$AUTH_HEADER" https://api.github.com/repos/${AUTHORS}/selenium/releases/tags/${RELEASE} | jq -r '[.assets[] | select(.name | endswith(".jar"))] | last')
+        jar_file=$(echo "${ASSET}" | jq -r '.name')
         echo "Server package: ${jar_file}"
         VERSION=$(echo $jar_file | sed 's/selenium-server-//;s/\.jar//')
+        # What that jar actually IS, not just what it is called. The nightly jar
+        # keeps one name - selenium-server-4.49.0-SNAPSHOT.jar - for a whole
+        # snapshot cycle while its contents are replaced every night, so the
+        # version alone cannot tell two nightly cores apart. Anything keyed on the
+        # core needs this, or it will treat last week's nightly as today's.
+        ASSET_DIGEST=$(echo "${ASSET}" | jq -r '.digest // empty')
+        if [ -z "${ASSET_DIGEST}" ] || [ "${ASSET_DIGEST}" = "null" ]; then
+          # Older assets predate the digest field; identity then comes from the
+          # asset id and the time it was last uploaded, which move together.
+          ASSET_DIGEST=$(echo "${ASSET}" | jq -r '"\(.id)-\(.updated_at)"')
+        fi
         echo "BASE_RELEASE=${RELEASE} | BASE_VERSION=${VERSION} | VERSION=${VERSION}"
+        echo "Server package digest: ${ASSET_DIGEST}"
         echo "BASE_RELEASE=${RELEASE}" >> $GITHUB_ENV
         echo "BASE_VERSION=${VERSION}" >> $GITHUB_ENV
+        echo "BASE_ASSET_DIGEST=${ASSET_DIGEST}" >> $GITHUB_ENV
         echo "VERSION=${VERSION}" >> $GITHUB_ENV

--- a/.github/workflows/build-images.yml
+++ b/.github/workflows/build-images.yml
@@ -136,16 +136,27 @@ jobs:
                  NodeChrome NodeChromium NodeEdge NodeFirefox NodeDocker NodeKubernetes
                  NodeAllBrowsers Standalone StandaloneDocker StandaloneKubernetes Video
                  .ffmpeg .keda-external-scaler Makefile"
-          # BASE_VERSION is part of the digest on purpose. Identical source built
+          # The core is part of the digest on purpose. Identical source built
           # against a nightly core and against the stable core are different
           # images; keying only on the files would let a pull request's
           # nightly-core build be promoted to :main and released.
+          #
+          # It has to be the jar's digest and not its version. The nightly jar
+          # keeps the name selenium-server-4.49.0-SNAPSHOT.jar for a whole
+          # snapshot cycle while its contents change every night, so on
+          # BASE_VERSION alone every nightly hashes the same. Run 34032857205 is
+          # what that costs: the suite reused images built against an earlier
+          # nightly core and reported success, while the jar it was supposed to be
+          # testing had moved on. The digest changes when the jar does, so a new
+          # core rebuilds - and a stable release, whose jar never moves, keeps
+          # reusing exactly as before.
           SRC_HASH=$(
-            { git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort; echo "core=${BASE_VERSION}"; } \
+            { git ls-tree -r HEAD -- $PATHS | awk '{print $3, $4}' | sort; \
+              echo "core=${BASE_VERSION}@${BASE_ASSET_DIGEST}"; } \
               | sha256sum | cut -c1-12
           )
           TAG="${INPUT_TAG:-src-${SRC_HASH}}"
-          echo "Selenium core: ${BASE_RELEASE} (${BASE_VERSION})"
+          echo "Selenium core: ${BASE_RELEASE} (${BASE_VERSION}) ${BASE_ASSET_DIGEST}"
           echo "Source hash: ${SRC_HASH}"
           echo "ci-tag=${TAG}" >> "$GITHUB_OUTPUT"
           echo "src-hash=${SRC_HASH}" >> "$GITHUB_OUTPUT"


### PR DESCRIPTION
Found while checking [run 34032857205](https://github.com/SeleniumHQ/docker-selenium/actions/runs/34032857205), where the nightly suite reported `reuse` and the nightly images were built fresh anyway.

## The bug

The nightly jar keeps **one name for a whole snapshot cycle**:

```
selenium-server-4.49.0-SNAPSHOT.jar
```

Its contents are replaced every night. `get-latest-upstream` parses `BASE_VERSION` out of that name, and `decide` folded `BASE_VERSION` into the content hash — so **every nightly hashes the same**. With the repo source unchanged, `decide` chose `reuse` for ever and the suite kept testing images built against an older core, reporting success each time.

That run is the example, from the registry:

| | built |
|---|---|
| `base:src-42e052aab8fe` — what the tests ran against | 2026-09-06 **08:05** |
| `base:nightly` — what was published | 2026-09-06 **14:34** |

The suite reused the 08:05 images; the `deploy` job then built new ones and pushed them as `:nightly`. What shipped was never what passed.

## The fix

The release asset carries a sha256 that moves with the jar, on nightly and stable alike:

```
selenium-server-4.49.0-SNAPSHOT.jar  sha256:a629ca57909a…  updated 2026-09-06T00:24:12Z
selenium-server-4.48.0.jar           sha256:c3119218bcd0…  updated 2026-08-27T20:12:59Z
```

`get-latest-upstream` now reports it as `BASE_ASSET_DIGEST`, and the hash keys on `core=${BASE_VERSION}@${BASE_ASSET_DIGEST}`.

| | before | after |
|---|---|---|
| two different nightly jars, same source | same hash → **reuse** | different hash → rebuild |
| the same stable jar twice | same hash → reuse | same hash → reuse |

Assets predating the `digest` field fall back to the asset id plus its upload time, which move together. If the variable is ever empty the hash degrades to today's behaviour rather than breaking.

**Cost:** a PR run rebuilds the first time it sees a new nightly jar — roughly once a day, with reuse across every run after that. That is the honest price of testing against nightly.

Publishing the tested images as `:nightly`, rather than rebuilding them, is the other half and is in #3231.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGLHB3pjY3mGZBu4TyUsrm