### PR TITLE
[ci] Publish the tested images as :nightly

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -84,7 +84,26 @@ jobs:
           tag_name: ${{ env.BASE_RELEASE }}
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      # The suite that just ran published its images to GHCR. Publishing THAT
+      # manifest is what makes :nightly the thing that passed - it was a fresh
+      # build of the same source before, tested by nothing.
+      - name: Decide how to publish
+        id: publish
+        env:
+          CI_TAG: ${{ needs.build-test.outputs.ci-tag }}
+          CI_MODE: ${{ needs.build-test.outputs.ci-mode }}
+          TEST_RESULT: ${{ needs.build-test.result }}
+        run: |
+          set -euo pipefail
+          if [ "${TEST_RESULT}" = "success" ] && [ -n "${CI_TAG}" ] && [ "${CI_MODE}" != "build-in-job" ]; then
+            echo "Promoting the tested images (${CI_TAG})."
+            echo "promote=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "No tested image set to promote (result=${TEST_RESULT}, tag=${CI_TAG:-none}, mode=${CI_MODE:-none}); building."
+            echo "promote=false" >> "$GITHUB_OUTPUT"
+          fi
       - name: Build images
+        if: steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 180
@@ -100,9 +119,27 @@ jobs:
           DOCKER_PASSWORD: ${{secrets.DOCKER_PASSWORD}}
       - name: Login GitHub Container Registry
         run: echo "${{ secrets.SELENIUM_CI_TOKEN }}" | docker login ghcr.io -u "${{ secrets.SELENIUM_CI_USERNAME }}" --password-stdin
+      # Registry to registry, on the index, so the multi-architecture manifest
+      # list arrives intact. Docker Hub and GHCR in one call - the same 26 images
+      # release_nightly used to push.
+      - name: Promote the tested images to :nightly
+        if: steps.publish.outputs.promote == 'true'
+        uses: nick-invision/retry@master
+        with:
+          timeout_minutes: 30
+          max_attempts: 3
+          retry_wait_seconds: 120
+          command: |
+            VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} \
+              CI_REGISTRY="${{ needs.build-test.outputs.ci-registry }}" \
+              CI_TAG="${{ needs.build-test.outputs.ci-tag }}" \
+              GHCR_NAMESPACE="ghcr.io/$(echo "${{ github.repository_owner }}" | tr '[:upper:]' '[:lower:]')" \
+              make promote_nightly_images
       - name: Tag images as nightly
+        if: steps.publish.outputs.promote != 'true'
         run: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make tag_nightly
       - name: Deploy nightly tag
+        if: steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 20
@@ -110,6 +147,7 @@ jobs:
           retry_wait_seconds: 120
           command: VERSION="${GRID_VERSION}" BUILD_DATE=${BUILD_DATE} make release_nightly
       - name: Mirror nightly images to GHCR
+        if: steps.publish.outputs.promote != 'true'
         uses: nick-invision/retry@master
         with:
           timeout_minutes: 20

--- a/Makefile
+++ b/Makefile
@@ -275,6 +275,19 @@ release_built_images_ghcr_latest:
 			--tag $(GHCR_NAMESPACE)/$$image:latest docker.io/$(NAME)/$$image:latest ; \
 	done
 
+# :nightly, for every image, straight from the tag the nightly suite ran against.
+# Unlike a release, nothing here depends on the tag being created - nightly.yml
+# rewrites the docs after publishing, not before - so all 26 can be promoted,
+# which is exactly the set release_nightly used to push.
+promote_nightly_images:
+	@set -e; for image in $(CI_IMAGES); do \
+		echo "promote $$image -> :nightly" ; \
+		docker buildx imagetools create \
+			--tag $(NAME)/$$image:nightly \
+			--tag $(GHCR_NAMESPACE)/$$image:nightly \
+			$(CI_REGISTRY)/$$image:$(CI_TAG) ; \
+	done
+
 # Point another tag at an already-tested manifest, without rebuilding. Used for
 # the pr-<N> markers the cleanup keys on, and to retag a passing trunk set as
 # :main.


### PR DESCRIPTION
The other half of what [run 34032857205](https://github.com/SeleniumHQ/docker-selenium/actions/runs/34032857205) exposed. #3232 fixes the cause; this fixes what gets published.

`nightly.yml` had the same shape the release had before #3231: the suite tested one set of images, and the `deploy` job then built another — and that second set is what was pushed as `:nightly`. Read straight off the registry for that run:

| | built |
|---|---|
| `base:src-42e052aab8fe` — what the tests ran against | 2026-09-06 **08:05** |
| `base:nightly` — what was published | 2026-09-06 **14:34** |

It now copies the tested manifest to `:nightly`, registry to registry on the index, so the multi-arch manifest list arrives intact — Docker Hub and GHCR in a single `imagetools create`.

**All 26 images can be promoted here**, unlike a release. `nightly.yml` rewrites the docs *after* publishing rather than before, so nothing in an image depends on a tag that does not exist yet. 26 is exactly the set `release_nightly` used to push — verified by diffing the two sets.

Anything short of a clean, tested image set falls back to building everything, exactly as before: skipped tests, a fork run, or no tag.

**Depends on #3232 to be correct.** Without the core's digest in the content hash, the images promoted here could have been built against an older nightly jar — which is precisely the staleness that made this run's tests meaningless.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01EGLHB3pjY3mGZBu4TyUsrm