### PR TITLE
K8s: Hash only the config data in checksum/* pod annotations

### DIFF
--- a/charts/selenium-grid/templates/_helpers.tpl
+++ b/charts/selenium-grid/templates/_helpers.tpl
@@ -381,10 +381,10 @@ template:
         {{- toYaml . | nindent 6 }}
       {{- end }}
     annotations:
-      checksum/event-bus-configmap: {{ include (print $.Template.BasePath "/event-bus-configmap.yaml") . | sha256sum }}
-      checksum/node-configmap: {{ include (print $.Template.BasePath "/node-configmap.yaml") . | sha256sum }}
-      checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-      checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
+      checksum/event-bus-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/event-bus-configmap.yaml") }}
+      checksum/node-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/node-configmap.yaml") }}
+      checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+      checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
       {{- with .node.annotations }}
         {{- toYaml . | nindent 6 }}
       {{- end }}
@@ -1108,4 +1108,13 @@ Usage: {{- $thisArray = include "utils.appendDefaultIfNotExist" (dict "currentAr
     {{- end -}}
   {{- end -}}
   {{- $currentArray | toYaml -}}
+{{- end -}}
+
+{{/*
+Compute a ConfigMap or Secret checksum from its data only, for checksum/* pod annotations.
+Hashing the whole manifest would include the chart labels, which change on every chart version
+bump and would restart the pods when no configuration changed.
+*/}}
+{{- define "seleniumGrid.configMapOrSecretContentHash" -}}
+{{ pick (include (print .ctx.Template.BasePath .name) .ctx | fromYaml) "data" "stringData" | toYaml | sha256sum }}
 {{- end -}}

--- a/charts/selenium-grid/templates/distributor-deployment.yaml
+++ b/charts/selenium-grid/templates/distributor-deployment.yaml
@@ -21,12 +21,12 @@ spec:
     metadata:
       labels: *distributor_labels
       annotations:
-        checksum/event-bus-configmap: {{ include (print $.Template.BasePath "/event-bus-configmap.yaml") . | sha256sum }}
-        checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-        checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
-        checksum/distributor-configmap: {{ include (print $.Template.BasePath "/distributor-configmap.yaml") . | sha256sum }}
-        checksum/router-configmap: {{ include (print $.Template.BasePath "/router-configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/event-bus-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/event-bus-configmap.yaml") }}
+        checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+        checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
+        checksum/distributor-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/distributor-configmap.yaml") }}
+        checksum/router-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/router-configmap.yaml") }}
+        checksum/secrets: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets.yaml") }}
     {{- with .Values.components.distributor.annotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/event-bus-deployment.yaml
+++ b/charts/selenium-grid/templates/event-bus-deployment.yaml
@@ -21,9 +21,9 @@ spec:
     metadata:
       labels: *event_bus_labels
       annotations:
-        checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-        checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+        checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
+        checksum/secrets: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets.yaml") }}
     {{- with .Values.components.eventBus.annotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/hub-deployment.yaml
+++ b/charts/selenium-grid/templates/hub-deployment.yaml
@@ -24,12 +24,12 @@ spec:
     metadata:
       labels: *hub_labels
       annotations:
-        checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-        checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
-        checksum/distributor-configmap: {{ include (print $.Template.BasePath "/distributor-configmap.yaml") . | sha256sum }}
-        checksum/router-configmap: {{ include (print $.Template.BasePath "/router-configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
-        checksum/tls-cert-secret: {{ include (print $.Template.BasePath "/tls-cert-secret.yaml") . | sha256sum }}
+        checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+        checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
+        checksum/distributor-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/distributor-configmap.yaml") }}
+        checksum/router-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/router-configmap.yaml") }}
+        checksum/secrets: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets.yaml") }}
+        checksum/tls-cert-secret: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/tls-cert-secret.yaml") }}
     {{- with .Values.hub.annotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/router-deployment.yaml
+++ b/charts/selenium-grid/templates/router-deployment.yaml
@@ -21,10 +21,10 @@ spec:
     metadata:
       labels: *router_labels
       annotations:
-        checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-        checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
-        checksum/router-configmap: {{ include (print $.Template.BasePath "/router-configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+        checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
+        checksum/router-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/router-configmap.yaml") }}
+        checksum/secrets: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets.yaml") }}
     {{- with .Values.components.router.annotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/session-map-deployment.yaml
+++ b/charts/selenium-grid/templates/session-map-deployment.yaml
@@ -21,10 +21,10 @@ spec:
     metadata:
       labels: *session_map_labels
       annotations:
-        checksum/event-bus-configmap: {{ include (print $.Template.BasePath "/event-bus-configmap.yaml") . | sha256sum }}
-        checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-        checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/event-bus-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/event-bus-configmap.yaml") }}
+        checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+        checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
+        checksum/secrets: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets.yaml") }}
     {{- with .Values.components.sessionMap.annotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}

--- a/charts/selenium-grid/templates/session-queue-deployment.yaml
+++ b/charts/selenium-grid/templates/session-queue-deployment.yaml
@@ -21,9 +21,9 @@ spec:
     metadata:
       labels: *session_queue_labels
       annotations:
-        checksum/logging-configmap: {{ include (print $.Template.BasePath "/logging-configmap.yaml") . | sha256sum }}
-        checksum/server-configmap: {{ include (print $.Template.BasePath "/server-configmap.yaml") . | sha256sum }}
-        checksum/secrets: {{ include (print $.Template.BasePath "/secrets.yaml") . | sha256sum }}
+        checksum/logging-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/logging-configmap.yaml") }}
+        checksum/server-configmap: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/server-configmap.yaml") }}
+        checksum/secrets: {{ include "seleniumGrid.configMapOrSecretContentHash" (dict "ctx" . "name" "/secrets.yaml") }}
     {{- with .Values.components.sessionQueue.annotations }}
         {{- toYaml . | nindent 8 }}
     {{- end }}


### PR DESCRIPTION
### Description

Adds a `seleniumGrid.configMapOrSecretContentHash` helper that hashes only the `data`/`stringData` of a rendered ConfigMap or Secret, and switches all 31 `checksum/*` pod annotations to it — hub, router, distributor, session-map, session-queue, event-bus and the node pod template.

### Motivation and Context

The annotations hashed the whole rendered manifest, and `metadata.labels` carry the chart labels, which change on every chart version bump. Every component pod therefore restarted on `helm upgrade` even when no configuration had changed — for the nodes that means dropping live sessions for nothing.

After this change a chart-version-only upgrade leaves the checksums untouched, while a real config change (for example `global.seleniumGrid.logLevel`) still changes them and restarts the pods. Upgrading to the release containing this change restarts the pods once, as the annotation values change.

The same fix was recently made in the argo-cd chart (argoproj/argo-helm#4044), and the loki chart uses the same data-only hashing.

### Types of changes

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

### Checklist

- [x] I have read the [contributing](https://selenium.dev/documentation/en/contributing/) document.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.